### PR TITLE
Added return values for 3 scheduler classes & fixed unit tests

### DIFF
--- a/src/classes/LogglyLogPushScheduler.cls
+++ b/src/classes/LogglyLogPushScheduler.cls
@@ -4,20 +4,23 @@
 *************************************************************************************************/
 public without sharing class LogglyLogPushScheduler implements System.Schedulable {
 
-    public static void scheduleEveryXMinutes(Integer x) {
+    public static List<Id> scheduleEveryXMinutes(Integer x) {
+        List<Id> jobIds = new List<Id>();
         for(Integer i = 0; i < 60; i += x) {
-            scheduleHourly(i);
+            jobIds.add(scheduleHourly(i));
         }
+        return jobIds;
     }
 
-    public static void scheduleHourly(Integer startingMinuteInHour) {
+    public static Id scheduleHourly(Integer startingMinuteInHour) {
         String minuteString = String.valueOf(startingMinuteInHour);
         minuteString = minuteString.leftPad(2, '0');
-        scheduleHourly(startingMinuteInHour, 'Loggly Log Sync: Every Hour at ' + minuteString);
+        return scheduleHourly(startingMinuteInHour, 'Loggly Log Sync: Every Hour at ' + minuteString);
     }
 
-    public static void scheduleHourly(Integer startingMinuteInHour, String jobName) {
-        System.schedule(jobName, '0 ' + startingMinuteInHour + ' * * * ?', new LogglyLogPushScheduler());
+    public static Id scheduleHourly(Integer startingMinuteInHour, String jobName) {
+        Id jobId = System.schedule(jobName, '0 ' + startingMinuteInHour + ' * * * ?', new LogglyLogPushScheduler());
+        return jobId;
     }
 
     public void execute(SchedulableContext sc) {

--- a/src/classes/LogglyLogPushScheduler_Tests.cls
+++ b/src/classes/LogglyLogPushScheduler_Tests.cls
@@ -5,6 +5,13 @@
 @isTest
 private class LogglyLogPushScheduler_Tests {
 
+    @testSetup
+    static void testSetup() {
+        for(CronTrigger ct : [SELECT Id FROM CronTrigger]) {
+            System.abortJob(ct.Id);
+        }
+    }
+
     @isTest
     static void it_should_schedule_the_batch_job() {
         String cronExpression = '0 0 0 15 3 ? 2022';
@@ -12,7 +19,7 @@ private class LogglyLogPushScheduler_Tests {
         System.assertEquals(0, numberOfScheduledJobs);
 
         Test.startTest();
-        String jobId = System.schedule('LogglyLogPushScheduler', cronExpression, new LogglyLogPushScheduler());
+        Id jobId = System.schedule('LogglyLogPushScheduler', cronExpression, new LogglyLogPushScheduler());
         Test.stopTest();
 
         CronTrigger ct = [SELECT Id, CronExpression, TimesTriggered, NextFireTime FROM CronTrigger WHERE Id = :jobId];
@@ -21,22 +28,49 @@ private class LogglyLogPushScheduler_Tests {
 
     @isTest
     static void it_should_schedule_the_batch_job_schedule_every_5_minutes() {
+        List<String> cronExpressionsForEvery5Minutes = new List<String>{
+            '0 0 * * * ?',
+            '0 5 * * * ?',
+            '0 10 * * * ?',
+            '0 15 * * * ?',
+            '0 20 * * * ?',
+            '0 25 * * * ?',
+            '0 30 * * * ?',
+            '0 35 * * * ?',
+            '0 40 * * * ?',
+            '0 45 * * * ?',
+            '0 50 * * * ?',
+            '0 55 * * * ?'
+        };
+
         Integer numberOfScheduledJobs = [SELECT COUNT() FROM CronTrigger];
         System.assertEquals(0, numberOfScheduledJobs);
 
         Test.startTest();
-        LogglyLogPushScheduler.scheduleEveryXMinutes(5);
+        List<Id> jobIds = LogglyLogPushScheduler.scheduleEveryXMinutes(5);
         Test.stopTest();
+
+        List<CronTrigger> cts = [SELECT Id, CronExpression, TimesTriggered, NextFireTime FROM CronTrigger WHERE Id IN :jobIds];
+        System.assertEquals(cronExpressionsForEvery5Minutes.size(), cts.size());
+        for(CronTrigger ct : cts) {
+            System.assert(cronExpressionsForEvery5Minutes.contains(ct.cronExpression), ct.CronExpression);
+        }
     }
 
     @isTest
     static void it_should_schedule_the_batch_job_schedule_hourly() {
+        Integer startingMinuteInHour = 0;
+        String expectedCronExpression = '0 ' + startingMinuteInHour + ' * * * ?';
+
         Integer numberOfScheduledJobs = [SELECT COUNT() FROM CronTrigger];
         System.assertEquals(0, numberOfScheduledJobs);
 
         Test.startTest();
-        LogglyLogPushScheduler.scheduleHourly(0);
+        Id jobId = LogglyLogPushScheduler.scheduleHourly(0);
         Test.stopTest();
+
+        CronTrigger ct = [SELECT Id, CronExpression, TimesTriggered, NextFireTime FROM CronTrigger WHERE Id = :jobId];
+        System.assertEquals(expectedCronExpression, ct.CronExpression);
     }
 
 }

--- a/src/classes/SlackLogPushScheduler.cls
+++ b/src/classes/SlackLogPushScheduler.cls
@@ -4,20 +4,23 @@
 *************************************************************************************************/
 public without sharing class SlackLogPushScheduler implements System.Schedulable {
 
-    public static void scheduleEveryXMinutes(Integer x) {
+    public static List<Id> scheduleEveryXMinutes(Integer x) {
+        List<Id> jobIds = new List<Id>();
         for(Integer i = 0; i < 60; i += x) {
-            scheduleHourly(i);
+            jobIds.add(scheduleHourly(i));
         }
+        return jobIds;
     }
 
-    public static void scheduleHourly(Integer startingMinuteInHour) {
+    public static Id scheduleHourly(Integer startingMinuteInHour) {
         String minuteString = String.valueOf(startingMinuteInHour);
         minuteString = minuteString.leftPad(2, '0');
-        scheduleHourly(startingMinuteInHour, 'Slack Log Sync: Every Hour at ' + minuteString);
+        return scheduleHourly(startingMinuteInHour, 'Slack Log Sync: Every Hour at ' + minuteString);
     }
 
-    public static void scheduleHourly(Integer startingMinuteInHour, String jobName) {
-        System.schedule(jobName, '0 ' + startingMinuteInHour + ' * * * ?', new SlackLogPushScheduler());
+    public static Id scheduleHourly(Integer startingMinuteInHour, String jobName) {
+        Id jobId = System.schedule(jobName, '0 ' + startingMinuteInHour + ' * * * ?', new SlackLogPushScheduler());
+        return jobId;
     }
 
     public void execute(SchedulableContext sc) {

--- a/src/classes/SlackLogPushScheduler_Tests.cls
+++ b/src/classes/SlackLogPushScheduler_Tests.cls
@@ -5,6 +5,13 @@
 @isTest
 private class SlackLogPushScheduler_Tests {
 
+    @testSetup
+    static void testSetup() {
+        for(CronTrigger ct : [SELECT Id FROM CronTrigger]) {
+            System.abortJob(ct.Id);
+        }
+    }
+
     @isTest
     static void it_should_schedule_the_batch_job() {
         String cronExpression = '0 0 0 15 3 ? 2022';
@@ -21,22 +28,49 @@ private class SlackLogPushScheduler_Tests {
 
     @isTest
     static void it_should_schedule_the_batch_job_schedule_every_5_minutes() {
+        List<String> cronExpressionsForEvery5Minutes = new List<String>{
+            '0 0 * * * ?',
+            '0 5 * * * ?',
+            '0 10 * * * ?',
+            '0 15 * * * ?',
+            '0 20 * * * ?',
+            '0 25 * * * ?',
+            '0 30 * * * ?',
+            '0 35 * * * ?',
+            '0 40 * * * ?',
+            '0 45 * * * ?',
+            '0 50 * * * ?',
+            '0 55 * * * ?'
+        };
+
         Integer numberOfScheduledJobs = [SELECT COUNT() FROM CronTrigger];
         System.assertEquals(0, numberOfScheduledJobs);
 
         Test.startTest();
-        SlackLogPushScheduler.scheduleEveryXMinutes(5);
+        List<Id> jobIds = SlackLogPushScheduler.scheduleEveryXMinutes(5);
         Test.stopTest();
+
+        List<CronTrigger> cts = [SELECT Id, CronExpression, TimesTriggered, NextFireTime FROM CronTrigger WHERE Id IN :jobIds];
+        System.assertEquals(cronExpressionsForEvery5Minutes.size(), cts.size());
+        for(CronTrigger ct : cts) {
+            System.assert(cronExpressionsForEvery5Minutes.contains(ct.cronExpression), ct.CronExpression);
+        }
     }
 
     @isTest
     static void it_should_schedule_the_batch_job_schedule_hourly() {
+        Integer startingMinuteInHour = 0;
+        String expectedCronExpression = '0 ' + startingMinuteInHour + ' * * * ?';
+
         Integer numberOfScheduledJobs = [SELECT COUNT() FROM CronTrigger];
         System.assertEquals(0, numberOfScheduledJobs);
 
         Test.startTest();
-        SlackLogPushScheduler.scheduleHourly(0);
+        Id jobId = SlackLogPushScheduler.scheduleHourly(0);
         Test.stopTest();
+
+        CronTrigger ct = [SELECT Id, CronExpression, TimesTriggered, NextFireTime FROM CronTrigger WHERE Id = :jobId];
+        System.assertEquals(expectedCronExpression, ct.CronExpression);
     }
 
 }

--- a/src/classes/TrelloLogPushScheduler.cls
+++ b/src/classes/TrelloLogPushScheduler.cls
@@ -4,20 +4,23 @@
 *************************************************************************************************/
 public without sharing class TrelloLogPushScheduler implements System.Schedulable {
 
-    public static void scheduleEveryXMinutes(Integer x) {
+    public static List<Id> scheduleEveryXMinutes(Integer x) {
+        List<Id> jobIds = new List<Id>();
         for(Integer i = 0; i < 60; i += x) {
-            scheduleHourly(i);
+            jobIds.add(scheduleHourly(i));
         }
+        return jobIds;
     }
 
-    public static void scheduleHourly(Integer startingMinuteInHour) {
+    public static Id scheduleHourly(Integer startingMinuteInHour) {
         String minuteString = String.valueOf(startingMinuteInHour);
         minuteString = minuteString.leftPad(2, '0');
-        scheduleHourly(startingMinuteInHour, 'Trello Log Sync: Every Hour at ' + minuteString);
+        return scheduleHourly(startingMinuteInHour, 'Trello Log Sync: Every Hour at ' + minuteString);
     }
 
-    public static void scheduleHourly(Integer startingMinuteInHour, String jobName) {
-        System.schedule(jobName, '0 ' + startingMinuteInHour + ' * * * ?', new TrelloLogPushScheduler());
+    public static Id scheduleHourly(Integer startingMinuteInHour, String jobName) {
+        Id jobId = System.schedule(jobName, '0 ' + startingMinuteInHour + ' * * * ?', new TrelloLogPushScheduler());
+        return jobId;
     }
 
     public void execute(SchedulableContext sc) {

--- a/src/classes/TrelloLogPushScheduler_Tests.cls
+++ b/src/classes/TrelloLogPushScheduler_Tests.cls
@@ -5,6 +5,13 @@
 @isTest
 private class TrelloLogPushScheduler_Tests {
 
+    @testSetup
+    static void testSetup() {
+        for(CronTrigger ct : [SELECT Id FROM CronTrigger]) {
+            System.abortJob(ct.Id);
+        }
+    }
+
     @isTest
     static void it_should_schedule_the_batch_job() {
         String cronExpression = '0 0 0 15 3 ? 2022';
@@ -19,24 +26,51 @@ private class TrelloLogPushScheduler_Tests {
         System.assertEquals(cronExpression, ct.CronExpression);
     }
 
-    @isTest
+     @isTest
     static void it_should_schedule_the_batch_job_schedule_every_5_minutes() {
+        List<String> cronExpressionsForEvery5Minutes = new List<String>{
+            '0 0 * * * ?',
+            '0 5 * * * ?',
+            '0 10 * * * ?',
+            '0 15 * * * ?',
+            '0 20 * * * ?',
+            '0 25 * * * ?',
+            '0 30 * * * ?',
+            '0 35 * * * ?',
+            '0 40 * * * ?',
+            '0 45 * * * ?',
+            '0 50 * * * ?',
+            '0 55 * * * ?'
+        };
+
         Integer numberOfScheduledJobs = [SELECT COUNT() FROM CronTrigger];
         System.assertEquals(0, numberOfScheduledJobs);
 
         Test.startTest();
-        TrelloLogPushScheduler.scheduleEveryXMinutes(5);
+        List<Id> jobIds = TrelloLogPushScheduler.scheduleEveryXMinutes(5);
         Test.stopTest();
+
+        List<CronTrigger> cts = [SELECT Id, CronExpression, TimesTriggered, NextFireTime FROM CronTrigger WHERE Id IN :jobIds];
+        System.assertEquals(cronExpressionsForEvery5Minutes.size(), cts.size());
+        for(CronTrigger ct : cts) {
+            System.assert(cronExpressionsForEvery5Minutes.contains(ct.cronExpression), ct.CronExpression);
+        }
     }
 
     @isTest
     static void it_should_schedule_the_batch_job_schedule_hourly() {
+        Integer startingMinuteInHour = 0;
+        String expectedCronExpression = '0 ' + startingMinuteInHour + ' * * * ?';
+
         Integer numberOfScheduledJobs = [SELECT COUNT() FROM CronTrigger];
         System.assertEquals(0, numberOfScheduledJobs);
 
         Test.startTest();
-        TrelloLogPushScheduler.scheduleHourly(0);
+        Id jobId = TrelloLogPushScheduler.scheduleHourly(0);
         Test.stopTest();
+
+        CronTrigger ct = [SELECT Id, CronExpression, TimesTriggered, NextFireTime FROM CronTrigger WHERE Id = :jobId];
+        System.assertEquals(expectedCronExpression, ct.CronExpression);
     }
 
 }


### PR DESCRIPTION
Fixes #8 - Tests would previously fail if your org had any scheduled jobs because this data is exposed in unit tests - unit tests now compensate for this