### PR TITLE
Swapping to call setTopic before setException

### DIFF
--- a/nebula-logger/main/logger/classes/Logger.cls
+++ b/nebula-logger/main/logger/classes/Logger.cls
@@ -140,7 +140,7 @@ public without sharing class Logger {
     }
 
     public static LogEntryBuilder error(String message, Exception apexException, List<String> topics) {
-        return error().setMessage(message).setExceptionDetails(apexException).setTopics(topics);
+        return error().setMessage(message).setTopics(topics).setExceptionDetails(apexException);
     }
 
     public static LogEntryBuilder error(String message, SObject record, Exception apexException) {


### PR DESCRIPTION
Seems like if you autosave on exception, you can't setTopics after.
Other methods already follow this pattern, this one just wasn't. D: