### PR TITLE
Removed namespace reference in quickAction

### DIFF
--- a/nebula-logger/main/logger/quickActions/Log__c.ViewJSON.quickAction-meta.xml
+++ b/nebula-logger/main/logger/quickActions/Log__c.ViewJSON.quickAction-meta.xml
@@ -3,7 +3,7 @@
     <description>Shows the current log &amp; log entires in JSON format</description>
     <height>700</height>
     <label>View JSON</label>
-    <lightningComponent>Nebula__logJSONViewer</lightningComponent>
+    <lightningComponent>logJSONViewer</lightningComponent>
     <optionsCreateFeedItem>false</optionsCreateFeedItem>
     <type>LightningComponent</type>
     <width>-100</width>


### PR DESCRIPTION
The repo's metadata shouldn't have any references to the namespace so that everything can be easily deployed to any org