### PR TITLE
Added ability to store record JSON on LogEntry__c

### DIFF
--- a/nebula-logger/main/logger/classes/LogEntryBuilder.cls
+++ b/nebula-logger/main/logger/classes/LogEntryBuilder.cls
@@ -114,6 +114,11 @@ public without sharing virtual class LogEntryBuilder {
     public LogEntryBuilder setRecordId(SObject record) {
         if(!this.shouldSave) return this;
 
+        if(LoggerSettings__c.getInstance().StoreRelatedRecordJson__c) {
+            String truncatedRecordJson = truncateFieldValue(Schema.LogEntryEvent__e.RelatedRecordJson__c, Json.serializePretty(record));
+            this.logEntryEvent.RelatedRecordJson__c = truncatedRecordJson;
+        }
+
         return this.setRecordId(record.Id);
     }
 

--- a/nebula-logger/main/logger/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/logger/classes/LogEntryEventHandler.cls
@@ -130,6 +130,7 @@ public without sharing class LogEntryEventHandler {
                 OriginType__c                     = logEntryEvent.OriginType__c,
                 OriginLocation__c                 = logEntryEvent.OriginLocation__c,
                 RelatedRecordId__c                = logEntryEvent.RelatedRecordId__c,
+                RelatedRecordJson__c              = logEntryEvent.RelatedRecordJson__c,
                 StackTrace__c                     = logEntryEvent.StackTrace__c,
                 Timestamp__c                      = logEntryEvent.Timestamp__c,
                 Type__c                           = logEntryEvent.Type__c

--- a/nebula-logger/main/logger/classes/Logger.cls
+++ b/nebula-logger/main/logger/classes/Logger.cls
@@ -9,8 +9,7 @@ public without sharing class Logger {
     private static final List<LogEntryBuilder> LOG_ENTRIES = new List<LogEntryBuilder>();
     private static final String TRANSACTION_ID             = new Uuid().getValue();
 
-    private static final LoggerSettings__c SETTINGS      = LoggerSettings__c.getInstance();
-    private static final LoggingLevel USER_LOGGING_LEVEL = getLoggingLevel(SETTINGS.LoggingLevel__c);
+    private static final LoggingLevel USER_LOGGING_LEVEL = getLoggingLevel(LoggerSettings__c.getInstance().LoggingLevel__c);
 
     private static final QueueableSaver ASYNC_SAVER_INSTANCE = new QueueableSaver();
 
@@ -32,7 +31,7 @@ public without sharing class Logger {
     }
 
     public static LoggingLevel getUserLoggingLevel() {
-        return getLoggingLevel(getSettings().LoggingLevel__c);
+        return getLoggingLevel(LoggerSettings__c.getInstance().LoggingLevel__c);
     }
 
     public static Id getQueueableSaveJobId() {
@@ -40,7 +39,7 @@ public without sharing class Logger {
     }
 
     public static Boolean isEnabled() {
-        return SETTINGS.IsEnabled__c;
+        return LoggerSettings__c.getInstance().IsEnabled__c;
     }
 
     public static Boolean isEnabled(LoggingLevel loggingLevel) {
@@ -339,7 +338,7 @@ public without sharing class Logger {
     public static void saveLog(SaveMethod transactionSaveMethod) {
         if(LOG_ENTRIES.isEmpty()) return;
 
-        Boolean systemMessagesEnabled = getSettings().EnableSystemMessages__c;
+        Boolean systemMessagesEnabled = LoggerSettings__c.getInstance().EnableSystemMessages__c;
 
         if(suspendSaving) {
             if(systemMessagesEnabled) {
@@ -435,11 +434,6 @@ public without sharing class Logger {
         String query = String.format('SELECT {0}, (SELECT {1} FROM LogEntries__r) FROM Log__c WHERE Id = :logId', textReplacements);
 
         return (Log__c)Database.query(query);
-    }
-
-    // Private methods
-    private static LoggerSettings__c getSettings() {
-        return LoggerSettings__c.getInstance();
     }
 
     // Private inner class for saving log entries via a queuable job (using a singleton pattern)

--- a/nebula-logger/main/logger/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
+++ b/nebula-logger/main/logger/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
@@ -75,6 +75,19 @@
         <customLabel>true</customLabel>
         <detailHeading>true</detailHeading>
         <editHeading>true</editHeading>
+        <label>Related Record JSON</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>RelatedRecordJson__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <style>OneColumn</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
+        <detailHeading>true</detailHeading>
+        <editHeading>true</editHeading>
         <label>Exception Information</label>
         <layoutColumns>
             <layoutItems>

--- a/nebula-logger/main/logger/objects/LogEntryEvent__e/fields/RelatedRecordJson__c.field-meta.xml
+++ b/nebula-logger/main/logger/objects/LogEntryEvent__e/fields/RelatedRecordJson__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RelatedRecordJson__c</fullName>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Related Record JSON</label>
+    <length>131072</length>
+    <type>LongTextArea</type>
+    <visibleLines>6</visibleLines>
+</CustomField>

--- a/nebula-logger/main/logger/objects/LogEntry__c/fields/RelatedRecordJson__c.field-meta.xml
+++ b/nebula-logger/main/logger/objects/LogEntry__c/fields/RelatedRecordJson__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RelatedRecordJson__c</fullName>
+    <description>JSON of the related SObject record</description>
+    <externalId>false</externalId>
+    <inlineHelpText>JSON of the related SObject record</inlineHelpText>
+    <label>Related Record JSON</label>
+    <length>131072</length>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>6</visibleLines>
+</CustomField>

--- a/nebula-logger/main/logger/objects/LoggerSettings__c/fields/StoreRelatedRecordJson__c.field-meta.xml
+++ b/nebula-logger/main/logger/objects/LoggerSettings__c/fields/StoreRelatedRecordJson__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>StoreRelatedRecordJson__c</fullName>
+    <defaultValue>true</defaultValue>
+    <externalId>false</externalId>
+    <label>Store Related Record JSON</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/nebula-logger/main/logger/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/main/logger/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -419,6 +419,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.RelatedRecordJson__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.RelatedRecordLink__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/logger/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/main/logger/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -375,6 +375,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.RelatedRecordJson__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.RelatedRecordLink__c</field>
         <readable>false</readable>
     </fieldPermissions>

--- a/nebula-logger/main/logger/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/main/logger/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -363,6 +363,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.RelatedRecordJson__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.RelatedRecordLink__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
Closes #31 
- Added fields `LogEntryEvent__e.RelatedRecordJson__c` and `LogEntry__c.RelatedRecordJson__c` 
- `LoggerSettings__c.StoreRelatedRecordJson__c` controls if `LogEntryBuilder` populates the record JSON on the log entry