### PR TITLE
Updated to the latest version of ApexCallouts library

### DIFF
--- a/nebula-logger/main/callouts/classes/Callout.cls
+++ b/nebula-logger/main/callouts/classes/Callout.cls
@@ -10,12 +10,18 @@ public class Callout {
     @testVisible private HttpRequest request;
 
     public Callout(String namedCredential, String endpointPath) {
-        this('callout:' + namedCredential + endpointPath);
+        this();
+
+        this.endpoint = 'callout:' + namedCredential + endpointPath;
     }
 
     public Callout(String endpoint) {
-        this.endpoint = endpoint;
+        this();
 
+        this.endpoint = endpoint;
+    }
+
+    private Callout() {
         this.headers    = new Map<String, String>();
         this.parameters = new Map<String, String>();
         this.request    = new HttpRequest();

--- a/nebula-logger/main/callouts/classes/RestApi.cls
+++ b/nebula-logger/main/callouts/classes/RestApi.cls
@@ -15,7 +15,7 @@ public with sharing class RestApi {
     }
 
     public static List<RestApi.SaveResult> insertRecords(List<SObject> records, Boolean allOrNone) {
-        HttpResponse response = generateRestApiCallout(COMPOSITE_ENDPOINT)
+        HttpResponse response = getRestApiCallout(COMPOSITE_ENDPOINT)
             .post(new RestApi.SaveRequest(records, allOrNone));
 
         return getSaveResults(response);
@@ -26,7 +26,7 @@ public with sharing class RestApi {
     }
 
     public static List<RestApi.SaveResult> updateRecords(List<SObject> records, Boolean allOrNone) {
-        HttpResponse response = generateRestApiCallout(COMPOSITE_ENDPOINT)
+        HttpResponse response = getRestApiCallout(COMPOSITE_ENDPOINT)
             .setParameter('_HttpMethod', 'PATCH')
             .post(new RestApi.SaveRequest(records, allOrNone));
 
@@ -48,7 +48,7 @@ public with sharing class RestApi {
     }
 
     public static List<RestApi.SaveResult> deleteRecords(List<Id> recordIds, Boolean allOrNone) {
-        HttpResponse response = generateRestApiCallout(COMPOSITE_ENDPOINT)
+        HttpResponse response = getRestApiCallout(COMPOSITE_ENDPOINT)
             .setParameter('allOrNone', String.valueOf(allOrNone))
             .setParameter('ids', String.join(recordIds, ','))
             .del();
@@ -62,15 +62,15 @@ public with sharing class RestApi {
         List<String> endpointParameters = new List<String>{sobjectName, listViewFilterId};
 
         String listViewEndpoint       = String.format(LISTVIEW_ENDPOINT, endpointParameters);
-        HttpResponse listViewResponse = generateRestApiCallout(listViewEndpoint).get();
+        HttpResponse listViewResponse = getRestApiCallout(listViewEndpoint).get();
 
         String listViewDescribeEndpoint       = String.format(LISTVIEW_DESCRIBE_ENDPOINT, endpointParameters);
-        HttpResponse listViewDescribeResponse = generateRestApiCallout(listViewDescribeEndpoint).get();
+        HttpResponse listViewDescribeResponse = getRestApiCallout(listViewDescribeEndpoint).get();
 
         return getListViewResult(listViewResponse, listViewDescribeResponse);
     }
 
-    private static Callout generateRestApiCallout(String endpoint) {
+    public static Callout getRestApiCallout(String endpoint) {
         return new Callout(endpoint)
             .setHeader('Authorization', 'Bearer ' + UserInfo.getSessionId())
             .setHeader('Content-Type', 'application/json');

--- a/nebula-logger/tests/callouts/classes/RestApi_Tests.cls
+++ b/nebula-logger/tests/callouts/classes/RestApi_Tests.cls
@@ -43,53 +43,85 @@ private class RestApi_Tests {
     static void it_should_insert_records() {
         Test.setMock(HttpCalloutMock.class, new SaveResultCalloutMock());
 
-        List<Account> accounts = new List<Account>();
-        Account account = new Account();
-        new TestDataFactory(account).populateRequiredFields();
-        accounts.add(account);
+        User user = new User(
+            FirstName = 'Test insert',
+            Id        = UserInfo.getUserId()
+        );
+        List<User> users = new List<User>{user};
 
         Test.startTest();
-        RestApi.insertRecords(accounts);
+        List<RestApi.SaveResult> saveResults = RestApi.insertRecords(users);
         Test.stopTest();
+
+        System.assertEquals(1, saveResults.size());
+
+        RestApi.SaveResult saveResult = saveResults.get(0);
+
+        System.assertEquals(UserInfo.getUserId(), saveResult.id);
+        System.assertEquals(true, saveResult.success);
+        System.assertEquals(true, saveResult.errors.isEmpty());
     }
 
     @isTest
     static void it_should_update_records() {
         Test.setMock(HttpCalloutMock.class, new SaveResultCalloutMock());
 
-        List<Account> accounts = new List<Account>();
-        Account account = new Account();
-        new TestDataFactory(account).populateRequiredFields();
-        accounts.add(account);
+        User user = new User(
+            FirstName = 'Test update',
+            Id        = UserInfo.getUserId()
+        );
+        List<User> users = new List<User>{user};
 
         Test.startTest();
-        RestApi.updateRecords(accounts);
+        List<RestApi.SaveResult> saveResults = RestApi.updateRecords(users);
         Test.stopTest();
+
+        System.assertEquals(1, saveResults.size());
+
+        RestApi.SaveResult saveResult = saveResults.get(0);
+
+        System.assertEquals(UserInfo.getUserId(), saveResult.id);
+        System.assertEquals(true, saveResult.success);
+        System.assertEquals(true, saveResult.errors.isEmpty());
     }
 
     @isTest
     static void it_should_delete_records() {
         Test.setMock(HttpCalloutMock.class, new SaveResultCalloutMock());
 
-        List<User> users = [SELECT Id FROM User LIMIT 2];
+        User user = new User(
+            FirstName = 'Test delete',
+            Id        = UserInfo.getUserId()
+        );
+        List<User> users = new List<User>{user};
 
         Test.startTest();
-        RestApi.deleteRecords(users);
+        List<RestApi.SaveResult> saveResults = RestApi.deleteRecords(users);
         Test.stopTest();
+
+        System.assertEquals(1, saveResults.size());
+
+        RestApi.SaveResult saveResult = saveResults.get(0);
+
+        System.assertEquals(UserInfo.getUserId(), saveResult.id);
+        System.assertEquals(true, saveResult.success);
+        System.assertEquals(true, saveResult.errors.isEmpty());
     }
 
     @isTest
     static void it_should_get_list_view() {
         Test.setMock(HttpCalloutMock.class, new ListViewResultCalloutMock());
 
-        List<Account> accounts = new List<Account>();
-        Account account = new Account();
-        new TestDataFactory(account).populateRequiredFields();
-        accounts.add(account);
-
         Test.startTest();
-        RestApi.getListView('Account', null);
+        RestApi.ListViewResult listViewResult = RestApi.getListView('Account', null);
         Test.stopTest();
+
+        System.assertEquals(UserInfo.getUserId(), listViewResult.id);
+        System.assertEquals('some_name', listViewResult.developerName);
+        System.assertEquals('some name', listViewResult.label);
+        System.assertEquals('Account', listViewResult.sobjectType);
+        System.assertEquals(true, listViewResult.soqlCompatible);
+        System.assertEquals('SELECT Id FROM Account', listViewResult.query);
     }
 
 }


### PR DESCRIPTION
This partially helps solve #26 - the latest version of ApexCallouts no longer uses `TestDataFactory`. Once the refs to `TestDataFactory` within logger tests are removed, then `TestDataFactory` can be removed from the repo