### PR TITLE
Added support for SObject record parameter in flows

### DIFF
--- a/nebula-logger/main/logger/classes/FlowLogEntry.cls
+++ b/nebula-logger/main/logger/classes/FlowLogEntry.cls
@@ -13,6 +13,9 @@ public without sharing class FlowLogEntry {
     @InvocableVariable(required=true label='Save Log')
     public Boolean saveLog = true;
 
+    @InvocableVariable(label='(Optional) Record')
+    public SObject record;
+
     @InvocableVariable(label='(Optional) Record ID')
     public Id recordId;
 

--- a/nebula-logger/main/logger/classes/LogEntryBuilder.cls
+++ b/nebula-logger/main/logger/classes/LogEntryBuilder.cls
@@ -74,8 +74,13 @@ public without sharing virtual class LogEntryBuilder {
         this.logEntryEvent.LoggingLevel__c    = flowLogEntry.loggingLevelName;
         this.logEntryEvent.OriginLocation__c  = flowLogEntry.flowName;
         this.logEntryEvent.OriginType__c      = ORIGIN_TYPE_FLOW;
-        this.logEntryEvent.RelatedRecordId__c = flowLogEntry.recordId;
         this.logEntryEvent.Timestamp__c       = flowLogEntry.timestamp;
+
+        if(flowLogEntry.record != null) {
+            this.setRecordId(flowLogEntry.record);
+        } else if(flowLogEntry.recordId != null) {
+            this.setRecordId(flowLogEntry.recordId);
+        }
 
         return this.setMessage(flowLogEntry.message);
     }

--- a/nebula-logger/tests/logger/classes/FlowLogEntry_Tests.cls
+++ b/nebula-logger/tests/logger/classes/FlowLogEntry_Tests.cls
@@ -70,6 +70,31 @@ private class FlowLogEntry_Tests {
         System.assertEquals(0, logEntries.size());
     }
 
+    @isTest
+    static void it_should_set_related_record_id_when_id_parameter_is_used() {
+        String userLoggingLevel      = 'FINEST';
+        String flowEntryLoggingLevel = 'DEBUG';
+
+        LoggerSettings__c loggerSettings = LoggerSettings__c.getInstance();
+        loggerSettings.LoggingLevel__c   = userLoggingLevel;
+        update loggerSettings;
+
+        Test.startTest();
+
+        List<FlowLogEntry> flowLogEntries = new List<FlowLogEntry>();
+        FlowLogEntry flowEntry = createFlowLogEntry();
+        flowEntry.loggingLevelName = flowEntryLoggingLevel;
+        flowEntry.recordId = UserInfo.getUserId();
+        FlowLogEntry.addFlowEntries(new List<FlowLogEntry>{flowEntry});
+        Logger.saveLog();
+
+        Test.stopTest();
+
+
+        LogEntry__c logEntry = [SELECT Id, RelatedRecordId__c, RelatedRecordJson__c FROM LogEntry__c ORDER BY CreatedDate LIMIT 1];
+        System.assertEquals(UserInfo.getUserId(), logEntry.RelatedRecordId__c);
+        System.assertEquals(null, logEntry.RelatedRecordJson__c);
+    }
 
     @isTest
     static void it_should_store_record_json_when_sobject_parameter_is_used() {

--- a/nebula-logger/tests/logger/classes/FlowLogEntry_Tests.cls
+++ b/nebula-logger/tests/logger/classes/FlowLogEntry_Tests.cls
@@ -70,4 +70,34 @@ private class FlowLogEntry_Tests {
         System.assertEquals(0, logEntries.size());
     }
 
+
+    @isTest
+    static void it_should_store_record_json_when_sobject_parameter_is_used() {
+        String userLoggingLevel      = 'FINEST';
+        String flowEntryLoggingLevel = 'DEBUG';
+
+        LoggerSettings__c loggerSettings = LoggerSettings__c.getInstance();
+        loggerSettings.LoggingLevel__c   = userLoggingLevel;
+        update loggerSettings;
+
+        Test.startTest();
+
+        User currentUser = [SELECT Id, Name, Username FROM User WHERE Id = :UserInfo.getUserId()];
+
+        List<FlowLogEntry> flowLogEntries = new List<FlowLogEntry>();
+        FlowLogEntry flowEntry = createFlowLogEntry();
+        flowEntry.loggingLevelName = flowEntryLoggingLevel;
+        flowEntry.record = currentUser;
+        FlowLogEntry.addFlowEntries(new List<FlowLogEntry>{flowEntry});
+        Logger.saveLog();
+
+        Test.stopTest();
+
+        String expectedUserJson = Json.serializePretty(currentUser);
+
+        LogEntry__c logEntry = [SELECT Id, RelatedRecordId__c, RelatedRecordJson__c FROM LogEntry__c ORDER BY CreatedDate LIMIT 1];
+        System.assertEquals(currentUser.Id, logEntry.RelatedRecordId__c);
+        System.assertEquals(expectedUserJson, logEntry.RelatedRecordJson__c);
+    }
+
 }


### PR DESCRIPTION
`FlowLogEntry` already had an optional `Id recordId` parameter - but since #36 has been implemented & SObject records can now be automatically stored as JSON, it's useful to also support an `SObject record` parameter for flows.