### PR TITLE
Added better support for SObject record parameters in Flow

### DIFF
--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -10,6 +10,8 @@
         <members>FlowLogEntry_Tests</members>
         <members>FlowLogRepo</members>
         <members>FlowLogRepo_Tests</members>
+        <members>FlowRecordLogEntry</members>
+        <members>FlowRecordLogEntry_Tests</members>
         <members>LogBatchPurger</members>
         <members>LogBatchPurger_Tests</members>
         <members>LogEntryBuilder</members>

--- a/nebula-logger/main/logger/classes/ComponentLogEntry.cls
+++ b/nebula-logger/main/logger/classes/ComponentLogEntry.cls
@@ -24,11 +24,28 @@ public without sharing class ComponentLogEntry {
         for(ComponentLogEntry componentLogEntry : componentLogEntries) {
             LoggingLevel loggingLevel = Logger.getLoggingLevel(componentLogEntry.loggingLevelName);
 
-            LogEntryBuilder logEntryBuilder = Logger.createLogEntryBuilder(loggingLevel).parseComponentLogEntry(componentLogEntry);
+            LogEntryBuilder logEntryBuilder = Logger.createLogEntryBuilder(loggingLevel)
+                .setMessage(componentLogEntry.message)
+                .setTopics(componentLogEntry.topics);
+
             if(componentLogEntry.error != null) {
                 logEntryBuilder.setExceptionDetails('ComponentLogEntryException', componentLogEntry.error.stack);
             }
+
+            LogEntryEvent__e logEntryEvent = logEntryBuilder.getLogEntryEvent();
+
+            if(logEntryEvent == null) {
+                continue;
+            }
+
+            logEntryEvent.ContextIsLightningComponent__c   = componentLogEntry.componentName != null;
+            logEntryEvent.ContextLightningComponentName__c = componentLogEntry.componentName;
+            logEntryEvent.LoggingLevel__c                  = componentLogEntry.loggingLevelName;
+            logEntryEvent.OriginLocation__c                = componentLogEntry.originLocation;
+            logEntryEvent.OriginType__c                    = 'Component';
+            logEntryEvent.Timestamp__c                     = componentLogEntry.timestamp;
         }
+
         Logger.saveLog();
     }
 

--- a/nebula-logger/main/logger/classes/FlowLogEntry.cls
+++ b/nebula-logger/main/logger/classes/FlowLogEntry.cls
@@ -4,29 +4,28 @@
 *************************************************************************************************/
 public without sharing class FlowLogEntry {
 
-    @InvocableVariable(required=true label='Process Builder/Flow Name')
+    @InvocableVariable(required=true label='Flow or Process Builder Name')
     public String flowName;
 
     @InvocableVariable(required=true label='Log Entry Message')
     public String message;
 
-    @InvocableVariable(required=true label='Save Log')
+    @InvocableVariable(required=false label='(Optional) Save Log')
     public Boolean saveLog = true;
 
-
-    @InvocableVariable(label='(Optional) Record ID')
+    @InvocableVariable(required=false label='(Optional) Record ID')
     public Id recordId;
 
-    @InvocableVariable(label='(Optional) Logging Level')
+    @InvocableVariable(required=false label='(Optional) Logging Level')
     public String loggingLevelName = 'DEBUG';
 
-    @InvocableVariable(label='(Optional) Topics')
+    @InvocableVariable(required=false label='(Optional) Topics')
     public List<String> topics;
 
-    @InvocableVariable(label='(Optional) Timestamp')
+    @InvocableVariable(required=false label='(Optional) Timestamp')
     public DateTime timestamp = System.now();
 
-    @InvocableMethod(category='Logging' label='Add Log Entry' description='Creates a log entry for a process builder or flow')
+    @InvocableMethod(category='Logging' label='Add Log Entry' description='Creates a log entry for a flow or process builder')
     public static List<String> addFlowEntries(List<FlowLogEntry> flowLogEntries) {
         Boolean saveLog = false;
         for(FlowLogEntry flowLogEntry : flowLogEntries) {

--- a/nebula-logger/main/logger/classes/FlowLogEntry.cls
+++ b/nebula-logger/main/logger/classes/FlowLogEntry.cls
@@ -31,11 +31,31 @@ public without sharing class FlowLogEntry {
         for(FlowLogEntry flowLogEntry : flowLogEntries) {
             LoggingLevel loggingLevel = Logger.getLoggingLevel(flowLogEntry.loggingLevelName);
 
-            Logger.createLogEntryBuilder(loggingLevel).parseFlowLogEntry(flowLogEntry);
+            LogEntryBuilder logEntryBuilder = Logger.createLogEntryBuilder(loggingLevel)
+                .setMessage(flowLogEntry.message)
+                .setRecordId(flowLogEntry.recordId)
+                .setTopics(flowLogEntry.topics);
 
-            if(flowLogEntry.saveLog) saveLog = flowLogEntry.saveLog;
+            LogEntryEvent__e logEntryEvent = logEntryBuilder.getLogEntryEvent();
+
+            if(logEntryEvent == null) {
+                continue;
+            }
+
+            logEntryEvent.LoggingLevel__c    = flowLogEntry.loggingLevelName;
+            logEntryEvent.OriginLocation__c  = flowLogEntry.flowName;
+            logEntryEvent.OriginType__c      = 'Flow';
+            logEntryEvent.Timestamp__c       = flowLogEntry.timestamp;
+
+            if(flowLogEntry.saveLog) {
+                saveLog = flowLogEntry.saveLog;
+            }
         }
-        if(saveLog) Logger.saveLog();
+
+        if(saveLog) {
+            Logger.saveLog();
+        }
+
         return new List<String>{ Logger.getTransactionId() };
     }
 

--- a/nebula-logger/main/logger/classes/FlowLogEntry.cls
+++ b/nebula-logger/main/logger/classes/FlowLogEntry.cls
@@ -13,8 +13,6 @@ public without sharing class FlowLogEntry {
     @InvocableVariable(required=true label='Save Log')
     public Boolean saveLog = true;
 
-    @InvocableVariable(label='(Optional) Record')
-    public SObject record;
 
     @InvocableVariable(label='(Optional) Record ID')
     public Id recordId;

--- a/nebula-logger/main/logger/classes/FlowLogRepo.cls
+++ b/nebula-logger/main/logger/classes/FlowLogRepo.cls
@@ -11,7 +11,7 @@ public without sharing class FlowLogRepo {
      * @param  `List<String>` - should be populated with the single Transaction Id for the Log you'd like to retrieve the Id for
      * @return `List<Log__c>` - due to current Flow limitations, we return a list, but it will only ever have one Log__c entry in it
      */
-    @InvocableMethod(category='Logging' label='Retrieve current Log ID' description='Returns the created log to aid in record redirects if desired.')
+    @InvocableMethod(category='Logging' label='Retrieve Current Log ID' description='Returns the created log to aid in record redirects if desired.')
     public static List<Log__c> getLogIds() {
         List<Log__c> logs = [SELECT Id FROM Log__c WHERE TransactionId__c = :Logger.getTransactionId() LIMIT 1];
         return logs.isEmpty() ? null : logs;

--- a/nebula-logger/main/logger/classes/FlowLogRepo.cls
+++ b/nebula-logger/main/logger/classes/FlowLogRepo.cls
@@ -6,12 +6,12 @@
 public without sharing class FlowLogRepo {
 
     /**
-     * Returns the latest Log created to the Flow so that you can redirect a user to the Log record when required
+     * Returns the current Log created to the Flow so that you can redirect a user to the Log record when required
      *
      * @param  `List<String>` - should be populated with the single Transaction Id for the Log you'd like to retrieve the Id for
      * @return `List<Log__c>` - due to current Flow limitations, we return a list, but it will only ever have one Log__c entry in it
      */
-    @InvocableMethod(category='Logging' label='Retrieve most recent Log Id' description='Returns the created log to aid in record redirects if desired.')
+    @InvocableMethod(category='Logging' label='Retrieve current Log ID' description='Returns the created log to aid in record redirects if desired.')
     public static List<Log__c> getLogIds() {
         List<Log__c> logs = [SELECT Id FROM Log__c WHERE TransactionId__c = :Logger.getTransactionId() LIMIT 1];
         return logs.isEmpty() ? null : logs;

--- a/nebula-logger/main/logger/classes/FlowRecordLogEntry.cls
+++ b/nebula-logger/main/logger/classes/FlowRecordLogEntry.cls
@@ -25,7 +25,7 @@ public without sharing class FlowRecordLogEntry {
     @InvocableVariable(required=false label='(Optional) Timestamp')
     public DateTime timestamp = System.now();
 
-    @InvocableMethod(category='Logging' label='Add Log Entry for an SObject record' description='Creates a log entry a flow or process builder and stores the record as JSON')
+    @InvocableMethod(category='Logging' label='Add Log Entry for an SObject Record' description='Creates a log entry a flow or process builder and stores the record as JSON')
     public static List<String> addFlowRecordEntries(List<FlowRecordLogEntry> flowRecordLogEntries) {
         Boolean saveLog = false;
         for(FlowRecordLogEntry flowRecordLogEntry : flowRecordLogEntries) {

--- a/nebula-logger/main/logger/classes/FlowRecordLogEntry.cls
+++ b/nebula-logger/main/logger/classes/FlowRecordLogEntry.cls
@@ -31,7 +31,21 @@ public without sharing class FlowRecordLogEntry {
         for(FlowRecordLogEntry flowRecordLogEntry : flowRecordLogEntries) {
             LoggingLevel loggingLevel = Logger.getLoggingLevel(flowRecordLogEntry.loggingLevelName);
 
-            Logger.createLogEntryBuilder(loggingLevel).parseFlowRecordLogEntry(flowRecordLogEntry);
+            LogEntryBuilder logEntryBuilder = Logger.createLogEntryBuilder(loggingLevel)
+                .setMessage(flowRecordLogEntry.message)
+                .setRecordId(flowRecordLogEntry.record)
+                .setTopics(flowRecordLogEntry.topics);
+
+            LogEntryEvent__e logEntryEvent = logEntryBuilder.getLogEntryEvent();
+
+            if(logEntryEvent == null) {
+                continue;
+            }
+
+            logEntryEvent.LoggingLevel__c    = flowRecordLogEntry.loggingLevelName;
+            logEntryEvent.OriginLocation__c  = flowRecordLogEntry.flowName;
+            logEntryEvent.OriginType__c      = 'Flow';
+            logEntryEvent.Timestamp__c       = flowRecordLogEntry.timestamp;
 
             if(flowRecordLogEntry.saveLog) saveLog = flowRecordLogEntry.saveLog;
         }

--- a/nebula-logger/main/logger/classes/FlowRecordLogEntry.cls
+++ b/nebula-logger/main/logger/classes/FlowRecordLogEntry.cls
@@ -1,0 +1,42 @@
+/*************************************************************************************************
+ * This file is part of the Nebula Logger project, released under the MIT License.                *
+ * See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    *
+ *************************************************************************************************/
+public without sharing class FlowRecordLogEntry {
+
+    @InvocableVariable(required=true label='Flow or Process Builder Name')
+    public String flowName;
+
+    @InvocableVariable(required=true label='Log Entry Message')
+    public String message;
+
+    @InvocableVariable(required=true label='Record')
+    public SObject record;
+
+    @InvocableVariable(required=false label='(Optional) Save Log')
+    public Boolean saveLog = true;
+
+    @InvocableVariable(required=false label='(Optional) Logging Level')
+    public String loggingLevelName = 'DEBUG';
+
+    @InvocableVariable(required=false label='(Optional) Topics')
+    public List<String> topics;
+
+    @InvocableVariable(required=false label='(Optional) Timestamp')
+    public DateTime timestamp = System.now();
+
+    @InvocableMethod(category='Logging' label='Add Log Entry for an SObject record' description='Creates a log entry a flow or process builder and stores the record as JSON')
+    public static List<String> addFlowRecordEntries(List<FlowRecordLogEntry> flowRecordLogEntries) {
+        Boolean saveLog = false;
+        for(FlowRecordLogEntry flowRecordLogEntry : flowRecordLogEntries) {
+            LoggingLevel loggingLevel = Logger.getLoggingLevel(flowRecordLogEntry.loggingLevelName);
+
+            Logger.createLogEntryBuilder(loggingLevel).parseFlowRecordLogEntry(flowRecordLogEntry);
+
+            if(flowRecordLogEntry.saveLog) saveLog = flowRecordLogEntry.saveLog;
+        }
+        if(saveLog) Logger.saveLog();
+        return new List<String>{ Logger.getTransactionId() };
+    }
+
+}

--- a/nebula-logger/main/logger/classes/FlowRecordLogEntry.cls
+++ b/nebula-logger/main/logger/classes/FlowRecordLogEntry.cls
@@ -25,7 +25,7 @@ public without sharing class FlowRecordLogEntry {
     @InvocableVariable(required=false label='(Optional) Timestamp')
     public DateTime timestamp = System.now();
 
-    @InvocableMethod(category='Logging' label='Add Log Entry for an SObject Record' description='Creates a log entry a flow or process builder and stores the record as JSON')
+    @InvocableMethod(category='Logging' label='Add Log Entry for an SObject Record' description='Creates a log entry for a flow or process builder and stores the record as JSON')
     public static List<String> addFlowRecordEntries(List<FlowRecordLogEntry> flowRecordLogEntries) {
         Boolean saveLog = false;
         for(FlowRecordLogEntry flowRecordLogEntry : flowRecordLogEntries) {

--- a/nebula-logger/main/logger/classes/FlowRecordLogEntry.cls-meta.xml
+++ b/nebula-logger/main/logger/classes/FlowRecordLogEntry.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/main/logger/classes/LogEntryBuilder.cls
+++ b/nebula-logger/main/logger/classes/LogEntryBuilder.cls
@@ -79,6 +79,15 @@ public without sharing virtual class LogEntryBuilder {
         return this.setMessage(flowLogEntry.message).setRecordId(flowLogEntry.recordId);
     }
 
+    public LogEntryBuilder parseFlowRecordLogEntry(FlowRecordLogEntry flowRecordLogEntry) {
+        if(!this.shouldSave) return this;
+
+        this.logEntryEvent.LoggingLevel__c    = flowRecordLogEntry.loggingLevelName;
+        this.logEntryEvent.OriginLocation__c  = flowRecordLogEntry.flowName;
+        this.logEntryEvent.OriginType__c      = ORIGIN_TYPE_FLOW;
+        this.logEntryEvent.Timestamp__c       = flowRecordLogEntry.timestamp;
+
+        return this.setMessage(flowRecordLogEntry.message).setRecordId(flowRecordLogEntry.record);
     }
 
     public LogEntryBuilder setMessage(String message) {

--- a/nebula-logger/main/logger/classes/LogEntryBuilder.cls
+++ b/nebula-logger/main/logger/classes/LogEntryBuilder.cls
@@ -56,40 +56,6 @@ public without sharing virtual class LogEntryBuilder {
         );
     }
 
-    public LogEntryBuilder parseComponentLogEntry(ComponentLogEntry componentLogEntry) {
-        if(!this.shouldSave) return this;
-
-        this.logEntryEvent.ContextIsLightningComponent__c   = componentLogEntry.componentName != null;
-        this.logEntryEvent.ContextLightningComponentName__c = componentLogEntry.componentName;
-        this.logEntryEvent.OriginLocation__c                = componentLogEntry.originLocation;
-        this.logEntryEvent.OriginType__c                    = ORIGIN_TYPE_COMPONENT;
-        this.logEntryEvent.Timestamp__c                     = componentLogEntry.timestamp;
-
-        return this.setMessage(componentLogEntry.message).setTopics(componentLogEntry.topics);
-    }
-
-    public LogEntryBuilder parseFlowLogEntry(FlowLogEntry flowLogEntry) {
-        if(!this.shouldSave) return this;
-
-        this.logEntryEvent.LoggingLevel__c    = flowLogEntry.loggingLevelName;
-        this.logEntryEvent.OriginLocation__c  = flowLogEntry.flowName;
-        this.logEntryEvent.OriginType__c      = ORIGIN_TYPE_FLOW;
-        this.logEntryEvent.Timestamp__c       = flowLogEntry.timestamp;
-
-        return this.setMessage(flowLogEntry.message).setRecordId(flowLogEntry.recordId);
-    }
-
-    public LogEntryBuilder parseFlowRecordLogEntry(FlowRecordLogEntry flowRecordLogEntry) {
-        if(!this.shouldSave) return this;
-
-        this.logEntryEvent.LoggingLevel__c    = flowRecordLogEntry.loggingLevelName;
-        this.logEntryEvent.OriginLocation__c  = flowRecordLogEntry.flowName;
-        this.logEntryEvent.OriginType__c      = ORIGIN_TYPE_FLOW;
-        this.logEntryEvent.Timestamp__c       = flowRecordLogEntry.timestamp;
-
-        return this.setMessage(flowRecordLogEntry.message).setRecordId(flowRecordLogEntry.record);
-    }
-
     public LogEntryBuilder setMessage(String message) {
         if(!this.shouldSave) return this;
 

--- a/nebula-logger/main/logger/classes/LogEntryBuilder.cls
+++ b/nebula-logger/main/logger/classes/LogEntryBuilder.cls
@@ -76,13 +76,9 @@ public without sharing virtual class LogEntryBuilder {
         this.logEntryEvent.OriginType__c      = ORIGIN_TYPE_FLOW;
         this.logEntryEvent.Timestamp__c       = flowLogEntry.timestamp;
 
-        if(flowLogEntry.record != null) {
-            this.setRecordId(flowLogEntry.record);
-        } else if(flowLogEntry.recordId != null) {
-            this.setRecordId(flowLogEntry.recordId);
-        }
+        return this.setMessage(flowLogEntry.message).setRecordId(flowLogEntry.recordId);
+    }
 
-        return this.setMessage(flowLogEntry.message);
     }
 
     public LogEntryBuilder setMessage(String message) {

--- a/nebula-logger/tests/logger/classes/FlowLogEntry_Tests.cls
+++ b/nebula-logger/tests/logger/classes/FlowLogEntry_Tests.cls
@@ -94,35 +94,6 @@ private class FlowLogEntry_Tests {
     }
 
     @isTest
-    static void it_should_store_record_json_when_sobject_parameter_is_used() {
-        String userLoggingLevel      = 'FINEST';
-        String flowEntryLoggingLevel = 'DEBUG';
-
-        LoggerSettings__c loggerSettings = LoggerSettings__c.getInstance();
-        loggerSettings.LoggingLevel__c   = userLoggingLevel;
-        loggerSettings.StoreRelatedRecordJson__c = true;
-        update loggerSettings;
-
-        Test.startTest();
-
-        User currentUser = [SELECT Id, Name, Username FROM User WHERE Id = :UserInfo.getUserId()];
-
-        FlowLogEntry flowEntry = createFlowLogEntry();
-        flowEntry.loggingLevelName = flowEntryLoggingLevel;
-        flowEntry.record = currentUser;
-        FlowLogEntry.addFlowEntries(new List<FlowLogEntry>{flowEntry});
-        Logger.saveLog();
-
-        Test.stopTest();
-
-        String expectedUserJson = Json.serializePretty(currentUser);
-
-        LogEntry__c logEntry = [SELECT Id, RelatedRecordId__c, RelatedRecordJson__c FROM LogEntry__c ORDER BY CreatedDate LIMIT 1];
-        System.assertEquals(currentUser.Id, logEntry.RelatedRecordId__c);
-        System.assertEquals(expectedUserJson, logEntry.RelatedRecordJson__c);
-    }
-
-    @isTest
     static void it_should_allow_the_flow_to_retrieve_latest_log() {
         String flowEntryLoggingLevel = 'DEBUG';
 
@@ -141,4 +112,5 @@ private class FlowLogEntry_Tests {
         List<Log__c> returnedLogs = FlowLogRepo.getLogIds();
         System.assertEquals(log.Id, returnedLogs[0].Id);
     }
+
 }

--- a/nebula-logger/tests/logger/classes/FlowRecordLogEntry_Tests.cls
+++ b/nebula-logger/tests/logger/classes/FlowRecordLogEntry_Tests.cls
@@ -1,0 +1,101 @@
+/*************************************************************************************************
+* This file is part of the Nebula Logger project, released under the MIT License.                *
+* See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    *
+*************************************************************************************************/
+@isTest
+private class FlowRecordLogEntry_Tests {
+
+    static FlowRecordLogEntry createFlowRecordLogEntry() {
+        FlowRecordLogEntry flowRecordEntry     = new FlowRecordLogEntry();
+        flowRecordEntry.flowName         = 'my test message';
+        flowRecordEntry.message          = 'MyFlowOrProcessBuilder';
+        flowRecordEntry.saveLog          = true;
+        flowRecordEntry.loggingLevelName = 'DEBUG';
+
+        return flowRecordEntry;
+    }
+
+    @testSetup
+    static void setup() {
+        LoggerSettings__c settings = LoggerSettings__c.getInstance();
+        settings.IsEnabled__c      = true;
+        upsert settings;
+    }
+
+    @isTest
+    static void it_should_save_entry_when_logging_level_met() {
+        User currentUser = [SELECT Id, Name, Username FROM User WHERE Id = :UserInfo.getUserId()];
+        String userLoggingLevel      = 'FINEST';
+        String flowRecordEntryLoggingLevel = 'DEBUG';
+
+        LoggerSettings__c loggerSettings = LoggerSettings__c.getInstance();
+        loggerSettings.LoggingLevel__c   = userLoggingLevel;
+        loggerSettings.StoreRelatedRecordJson__c = true;
+        update loggerSettings;
+
+        Test.startTest();
+
+
+        FlowRecordLogEntry flowRecordEntry = createFlowRecordLogEntry();
+        flowRecordEntry.loggingLevelName = flowRecordEntryLoggingLevel;
+        flowRecordEntry.record = currentUser;
+        FlowRecordLogEntry.addFlowRecordEntries(new List<FlowRecordLogEntry>{flowRecordEntry});
+        Logger.saveLog();
+
+        Test.stopTest();
+
+        String expectedUserJson = Json.serializePretty(currentUser);
+
+        LogEntry__c logEntry = [SELECT Id, RelatedRecordId__c, RelatedRecordJson__c FROM LogEntry__c ORDER BY CreatedDate LIMIT 1];
+        System.assertEquals(currentUser.Id, logEntry.RelatedRecordId__c);
+        System.assertEquals(expectedUserJson, logEntry.RelatedRecordJson__c);
+    }
+
+    @isTest
+    static void it_should_not_save_entry_when_logging_level_not_met() {
+        User currentUser = new User(Id = UserInfo.getUserId());
+        String userLoggingLevel      = 'ERROR';
+        String flowRecordEntryLoggingLevel = 'DEBUG';
+
+        LoggerSettings__c loggerSettings = LoggerSettings__c.getInstance();
+        loggerSettings.LoggingLevel__c   = userLoggingLevel;
+        update loggerSettings;
+
+        Test.startTest();
+
+
+        FlowRecordLogEntry flowRecordEntry = createFlowRecordLogEntry();
+        flowRecordEntry.loggingLevelName = flowRecordEntryLoggingLevel;
+        flowRecordEntry.record = currentUser;
+        FlowRecordLogEntry.addFlowRecordEntries(new List<FlowRecordLogEntry>{flowRecordEntry});
+        Logger.saveLog();
+
+        Test.stopTest();
+
+        List<LogEntry__c> logEntries = [SELECT Id FROM LogEntry__c];
+        System.assertEquals(0, logEntries.size());
+    }
+
+    @isTest
+    static void it_should_allow_the_flow_to_retrieve_latest_log() {
+        User currentUser = new User(Id = UserInfo.getUserId());
+        String flowRecordEntryLoggingLevel = 'DEBUG';
+
+        Test.startTest();
+
+        FlowRecordLogEntry flowRecordEntry = createFlowRecordLogEntry();
+        flowRecordEntry.loggingLevelName = flowRecordEntryLoggingLevel;
+        flowRecordEntry.record = currentUser;
+        FlowRecordLogEntry.addFlowRecordEntries(new List<FlowRecordLogEntry>{flowRecordEntry});
+        Logger.saveLog();
+
+        Test.stopTest();
+
+        Log__c log = [SELECT Id, TransactionId__c FROM Log__c ORDER BY CreatedDate LIMIT 1];
+        System.assertEquals(log.TransactionId__c, Logger.getTransactionId());
+
+        List<Log__c> returnedLogs = FlowLogRepo.getLogIds();
+        System.assertEquals(log.Id, returnedLogs[0].Id);
+    }
+
+}

--- a/nebula-logger/tests/logger/classes/FlowRecordLogEntry_Tests.cls-meta.xml
+++ b/nebula-logger/tests/logger/classes/FlowRecordLogEntry_Tests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/tests/logger/classes/LogEntryBuilder_Tests.cls
+++ b/nebula-logger/tests/logger/classes/LogEntryBuilder_Tests.cls
@@ -14,14 +14,6 @@ private class LogEntryBuilder_Tests {
         LogEntryBuilder builder = new LogEntryBuilder(LoggingLevel.DEBUG);
 
         System.assertEquals(null, builder.getLogEntryEvent());
-        System.assertEquals(
-            null,
-            builder.parseComponentLogEntry(new ComponentLogEntry()).getLogEntryEvent()
-        );
-        System.assertEquals(
-            null,
-            builder.parseFlowLogEntry(new FlowLogEntry()).getLogEntryEvent()
-        );
         System.assertEquals(null, builder.setMessage('test').getLogEntryEvent());
         System.assertEquals(
             null,


### PR DESCRIPTION
Fixed #46 - the new Flow functionality to provide SObject record parameters (PR #43) works, but due to how Salesforce has implemented this feature, Flow always requires admins to select an SObject for the parameter (even though it's optional).

To avoid this annoyance, and because SObject parameters for Flow are still relatively new, I've removed `FlowLogEntry.record` and instead added a new class for passing SObject records, `FlowRecordLogEntry`. 
- When this action is called from Flow, the SObject parameter is required.
- `FlowLogEntry` still provides the optional parameter `FlowLogEntry.recordId` for situations where passing just an ID is sufficient (or easier)

![screenshot](https://user-images.githubusercontent.com/1267157/96076326-f5008280-0e61-11eb-9eee-21ab1e71f62b.png)
