### PR TITLE
View JSON quickAction enhancements

### DIFF
--- a/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewer.cmp
+++ b/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewer.cmp
@@ -23,6 +23,9 @@
 
     <!-- Styles for modal header & footer-->
     <aura:html tag="style">
+        .cuf-content {
+            padding: 0 0rem !important;
+        }
         .slds-p-around--medium {
             padding: 0rem !important;
         }

--- a/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewer.cmp
+++ b/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewer.cmp
@@ -11,6 +11,16 @@
     <!-- Handlers -->
     <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
 
+    <!-- Make the quick action modal wider for desktop -->
+    <aura:if isTrue="{!$Browser.formFactor == 'DESKTOP'}">
+        <aura:html tag="style">
+            .slds-modal__container {
+                max-width : 85rem !important;
+                width: 85% !important;
+            }
+        </aura:html>
+    </aura:if>
+
     <!-- Markup-->
     <div class="modal-header slds-modal__header slds-size_1-of-1">
         <h4 class="title slds-text-heading–large">{! 'JSON for ' + v.log.Name}</h4>

--- a/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewer.cmp
+++ b/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewer.cmp
@@ -16,17 +16,39 @@
         <aura:html tag="style">
             .slds-modal__container {
                 max-width : 85rem !important;
-                width: 85% !important;
+                width     : 85% !important;
             }
         </aura:html>
     </aura:if>
 
+    <!-- Styles for modal header & footer-->
+    <aura:html tag="style">
+        .slds-p-around--medium {
+            padding: 0rem !important;
+        }
+        .slds-modal__content {
+            overflow-y: hidden !important;
+            height: unset !important;
+            max-height: unset !important;
+        }
+    </aura:html>
+
     <!-- Markup-->
-    <div class="modal-header slds-modal__header slds-size_1-of-1">
-        <h4 class="title slds-text-heading–large">{! 'JSON for ' + v.log.Name}</h4>
+    <div class="slds-col modal-header slds-modal__header">
+        <h2 class="title slds-text-heading--medium">{! 'JSON for ' + v.log.Name}</h2>
     </div>
-    <div class="json-viewer">
+
+    <div class="slds-col modal-body scrollable slds-p-around--medium">
         <pre>{!v.logJSON}</pre>
+    </div>
+
+    <div class="slds-col modal-footer slds-modal__footer">
+        <lightning:button
+            iconName = "utility:copy_to_clipboard"
+            label    = "Copy JSON to Clipboard"
+            onclick  = "{!c.copyToClipboard}"
+            variant  = "brand"
+        />
     </div>
 
 </aura:component>

--- a/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewer.cmp
+++ b/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewer.cmp
@@ -7,6 +7,7 @@
     <!-- Private Attributes -->
     <aura:attribute access="private" type="Log__c" name="log" />
     <aura:attribute access="private" type="String" name="logJSON" />
+    <aura:attribute access="private" type="Boolean" name="jsonCopied" default="false" />
 
     <!-- Handlers -->
     <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
@@ -46,11 +47,14 @@
     </div>
 
     <div class="slds-col modal-footer slds-modal__footer">
-        <lightning:button
-            iconName = "utility:copy_to_clipboard"
-            label    = "Copy JSON to Clipboard"
-            onclick  = "{!c.copyToClipboard}"
-            variant  = "brand"
+        <lightning:buttonStateful
+            labelWhenOff="Copy JSON to Clipboard"
+            labelWhenOn="JSON Copied to Clipboard"
+            iconNameWhenOff="utility:copy_to_clipboard"
+            iconNameWhenOn="utility:check"
+            state="{!v.jsonCopied}"
+            onclick="{!c.copyToClipboard}"
+            variant="{!if(v.jsonCopied, 'success', 'brand')}"
         />
     </div>
 

--- a/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewer.css
+++ b/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewer.css
@@ -5,10 +5,8 @@
 .THIS {
     height: 100%;
 }
-.THIS .slds-textarea {
-    height: 100%;
-}
 .THIS pre {
-    max-height: 540px;
+    max-height: 500px;
+    margin: auto 10px;
     overflow-y: scroll;
 }

--- a/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewerController.js
+++ b/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewerController.js
@@ -21,7 +21,7 @@
 
         // Update the button to show that the JSON has been copied
         event.getSource().set('v.iconName' , 'utility:check');
-        event.getSource().set('v.label', 'JSON Copied');
+        event.getSource().set('v.label', 'JSON Copied to Clipboard');
         event.getSource().set('v.variant', 'success');
     }
 })

--- a/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewerController.js
+++ b/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewerController.js
@@ -9,19 +9,8 @@
     copyToClipboard : function(component, event, helper) {
         var logJSON = component.get('v.logJSON');
 
-        // Add a hidden input to store the JSON
-        var hiddenJSONInput = document.createElement('input');
-        hiddenJSONInput.setAttribute('value', logJSON);
-        document.body.appendChild(hiddenJSONInput);
-        hiddenJSONInput.select();
+        helper.copyValueToClipboard(logJSON);
 
-        // Copy to clipboard
-        document.execCommand('copy');
-        document.body.removeChild(hiddenJSONInput);
-
-        // Update the button to show that the JSON has been copied
-        event.getSource().set('v.iconName' , 'utility:check');
-        event.getSource().set('v.label', 'JSON Copied to Clipboard');
-        event.getSource().set('v.variant', 'success');
+        component.set('v.jsonCopied', true);
     }
 })

--- a/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewerController.js
+++ b/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewerController.js
@@ -5,5 +5,23 @@
 ({
     doInit : function(component, event, helper) {
         helper.queryLog(component, event);
+    },
+    copyToClipboard : function(component, event, helper) {
+        var logJSON = component.get('v.logJSON');
+
+        // Add a hidden input to store the JSON
+        var hiddenJSONInput = document.createElement('input');
+        hiddenJSONInput.setAttribute('value', logJSON);
+        document.body.appendChild(hiddenJSONInput);
+        hiddenJSONInput.select();
+
+        // Copy to clipboard
+        document.execCommand('copy');
+        document.body.removeChild(hiddenJSONInput);
+
+        // Update the button to show that the JSON has been copied
+        event.getSource().set('v.iconName' , 'utility:check');
+        event.getSource().set('v.label', 'JSON Copied');
+        event.getSource().set('v.variant', 'success');
     }
 })

--- a/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewerHelper.js
+++ b/nebula-logger/main/logger/aura/logJSONViewer/logJSONViewerHelper.js
@@ -24,5 +24,16 @@
             }
         });
         $A.enqueueAction(action);
+    },
+    copyValueToClipboard : function(value) {
+        // Add a hidden input to store the JSON
+        var hiddenJSONInput = document.createElement('input');
+        hiddenJSONInput.setAttribute('value', value);
+        document.body.appendChild(hiddenJSONInput);
+        hiddenJSONInput.select();
+
+        // Copy to clipboard
+        document.execCommand('copy');
+        document.body.removeChild(hiddenJSONInput);
     }
 })


### PR DESCRIPTION
- **Added new 'Copy JSON to Clipboard'** button
- **Cleaned up formatting** to make it more consistent with other SLDS modals
- **Quick action modal is now wider on desktop**. Salesforce has designed quick actions to have a fixed width, even on wide screens. To better leverage wider screens, I've added a workaround in `logJSONViewer.cmp` to make the quick action wider on desktop

![image](https://user-images.githubusercontent.com/1267157/96086603-6d257300-0e77-11eb-8cb5-acd312766f8e.png)

