### PR TITLE
 Updated flexipages to match latest page layout changes

### DIFF
--- a/nebula-logger/main/logger/flexipages/LogEntryRecordPage.flexipage-meta.xml
+++ b/nebula-logger/main/logger/flexipages/LogEntryRecordPage.flexipage-meta.xml
@@ -79,7 +79,7 @@
                 <fieldItem>Record.Timestamp__c</fieldItem>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-fdbf35ea-d04f-4ae1-abcb-da7b4072d59f</name>
+        <name>Facet-7f7fbd23-d9c3-45a7-9966-5b53ef6c3760</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -126,7 +126,7 @@
                 </visibilityRule>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-cc527f31-c809-421e-9f95-4dae4a042e53</name>
+        <name>Facet-3c239c0f-eea9-4d54-a5fb-e540e0281d62</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -134,7 +134,7 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-fdbf35ea-d04f-4ae1-abcb-da7b4072d59f</value>
+                    <value>Facet-7f7fbd23-d9c3-45a7-9966-5b53ef6c3760</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
             </componentInstance>
@@ -143,29 +143,12 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-cc527f31-c809-421e-9f95-4dae4a042e53</value>
+                    <value>Facet-3c239c0f-eea9-4d54-a5fb-e540e0281d62</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
             </componentInstance>
         </itemInstances>
-        <name>Facet-d149fcf5-e529-4661-a3a9-21cbc904fcf4</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>columns</name>
-                    <value>Facet-d149fcf5-e529-4661-a3a9-21cbc904fcf4</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>label</name>
-                    <value>Information</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:fieldSection</componentName>
-            </componentInstance>
-        </itemInstances>
-        <name>Facet-7c0e8ee2-1746-466c-abe1-c3249adeb76d</name>
+        <name>Facet-e0deee5b-d3a2-4f94-8203-70a62738a906</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -196,17 +179,7 @@
                 <fieldItem>Record.StackTrace__c</fieldItem>
             </fieldInstance>
         </itemInstances>
-        <itemInstances>
-            <fieldInstance>
-                <fieldItem>Record.Timestamp__c</fieldItem>
-            </fieldInstance>
-        </itemInstances>
-        <itemInstances>
-            <fieldInstance>
-                <fieldItem>Record.CreatedById</fieldItem>
-            </fieldInstance>
-        </itemInstances>
-        <name>Facet-8908979e-aa15-443f-9493-7d88dbb24ca1</name>
+        <name>Facet-30caba7c-11da-4321-bccd-e97e901d03f4</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -214,12 +187,12 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-8908979e-aa15-443f-9493-7d88dbb24ca1</value>
+                    <value>Facet-30caba7c-11da-4321-bccd-e97e901d03f4</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
             </componentInstance>
         </itemInstances>
-        <name>Facet-0ea6ea77-396b-48ac-93a6-027be8643c47</name>
+        <name>Facet-3a75f17f-589a-49f4-bdec-38f730e94676</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -232,7 +205,7 @@
                 <fieldItem>Record.RelatedRecordJson__c</fieldItem>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-296a30db-8e9b-4c9d-b3f7-db143697d0f8</name>
+        <name>Facet-1da92bf7-f9ed-4842-b880-7625370f3c70</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -240,12 +213,12 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-296a30db-8e9b-4c9d-b3f7-db143697d0f8</value>
+                    <value>Facet-1da92bf7-f9ed-4842-b880-7625370f3c70</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
             </componentInstance>
         </itemInstances>
-        <name>Facet-aa6e1f85-f135-4353-97c4-e95668065d3d</name>
+        <name>Facet-f6d04c17-cbcd-40c6-aa58-c46313ecd8c4</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -267,11 +240,7 @@
                 <fieldItem>Record.ExceptionStackTrace__c</fieldItem>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-4804181a-4a25-4662-ba83-92c1ecf10fa7</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
-        <name>Facet-7c0755c9-1e40-417b-9e10-15d01ef45a9c</name>
+        <name>Facet-2459e7ac-69ae-42c7-a640-3fd29367e57b</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -279,21 +248,12 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-4804181a-4a25-4662-ba83-92c1ecf10fa7</value>
+                    <value>Facet-2459e7ac-69ae-42c7-a640-3fd29367e57b</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
             </componentInstance>
         </itemInstances>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>body</name>
-                    <value>Facet-7c0755c9-1e40-417b-9e10-15d01ef45a9c</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:column</componentName>
-            </componentInstance>
-        </itemInstances>
-        <name>Facet-9b3fe934-8e4f-4d24-8b01-50a5b21eafbb</name>
+        <name>Facet-2a15cd64-78af-4727-8c6d-2913cb00a278</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -369,7 +329,7 @@
                 <fieldItem>Record.LimitsFutureCalls__c</fieldItem>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-8139eb1d-eefe-47b3-9c51-a58b5e2e9b39</name>
+        <name>Facet-8e5572ea-8a8e-4426-8154-004cbbcb1314</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -436,7 +396,7 @@
                 <fieldItem>Record.LimitsSoslSearches__c</fieldItem>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-7aedaf41-59bf-4fe8-81c0-affa33b62722</name>
+        <name>Facet-ce9617b4-fac3-4077-93b0-d2ced40ad0b1</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -444,7 +404,7 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-8139eb1d-eefe-47b3-9c51-a58b5e2e9b39</value>
+                    <value>Facet-8e5572ea-8a8e-4426-8154-004cbbcb1314</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
             </componentInstance>
@@ -453,12 +413,12 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-7aedaf41-59bf-4fe8-81c0-affa33b62722</value>
+                    <value>Facet-ce9617b4-fac3-4077-93b0-d2ced40ad0b1</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
             </componentInstance>
         </itemInstances>
-        <name>Facet-bdd9b114-1833-46dd-b0d6-df6b1e968e97</name>
+        <name>Facet-4fa5f475-f3a7-4ac0-b1cd-8285d7b369c7</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -466,7 +426,20 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>columns</name>
-                    <value>Facet-0ea6ea77-396b-48ac-93a6-027be8643c47</value>
+                    <value>Facet-e0deee5b-d3a2-4f94-8203-70a62738a906</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>label</name>
+                    <value>Information</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:fieldSection</componentName>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>columns</name>
+                    <value>Facet-3a75f17f-589a-49f4-bdec-38f730e94676</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
@@ -479,7 +452,7 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>columns</name>
-                    <value>Facet-aa6e1f85-f135-4353-97c4-e95668065d3d</value>
+                    <value>Facet-f6d04c17-cbcd-40c6-aa58-c46313ecd8c4</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
@@ -499,7 +472,7 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>columns</name>
-                    <value>Facet-9b3fe934-8e4f-4d24-8b01-50a5b21eafbb</value>
+                    <value>Facet-2a15cd64-78af-4727-8c6d-2913cb00a278</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
@@ -519,68 +492,13 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>columns</name>
-                    <value>Facet-bdd9b114-1833-46dd-b0d6-df6b1e968e97</value>
+                    <value>Facet-4fa5f475-f3a7-4ac0-b1cd-8285d7b369c7</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
                     <value>Limits</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:fieldSection</componentName>
-            </componentInstance>
-        </itemInstances>
-        <name>Facet-e2724ca9-2907-4418-b7a6-77c45719feb4</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>body</name>
-                    <value>Facet-7c0e8ee2-1746-466c-abe1-c3249adeb76d</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>label</name>
-                    <value>Standard.Tab.fields</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>name</name>
-                    <value>accordionSection1</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:accordionSection</componentName>
-            </componentInstance>
-        </itemInstances>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>body</name>
-                    <value>Facet-e2724ca9-2907-4418-b7a6-77c45719feb4</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>label</name>
-                    <value>Standard.Tab.additionalFields</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>name</name>
-                    <value>accordionSection2</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:accordionSection</componentName>
-            </componentInstance>
-        </itemInstances>
-        <name>Facet-285295bc-25c0-4d98-bc60-5878da7797d8</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>accordionSections</name>
-                    <value>Facet-285295bc-25c0-4d98-bc60-5878da7797d8</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>defaultSectionName</name>
-                    <value>accordionSection1</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:accordion</componentName>
             </componentInstance>
         </itemInstances>
         <itemInstances>

--- a/nebula-logger/main/logger/flexipages/LogRecordPage.flexipage-meta.xml
+++ b/nebula-logger/main/logger/flexipages/LogRecordPage.flexipage-meta.xml
@@ -113,10 +113,14 @@
         </itemInstances>
         <itemInstances>
             <fieldInstance>
-                <fieldItem>Record.LoggedBy__c</fieldItem>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.LogRetentionDate__c</fieldItem>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-7276b452-a743-4135-a902-92f6dae86577</name>
+        <name>Facet-4400e57b-e799-42fe-a489-30dd5ee55415</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -156,12 +160,7 @@
                 <fieldItem>Record.ParentLog__c</fieldItem>
             </fieldInstance>
         </itemInstances>
-        <itemInstances>
-            <fieldInstance>
-                <fieldItem>Record.HasExceptionLogEntries__c</fieldItem>
-            </fieldInstance>
-        </itemInstances>
-        <name>Facet-57c33ec2-fcb8-428b-905c-a5b6ffc21345</name>
+        <name>Facet-0cb5a6fa-36b6-4f6d-b823-8e5956999c43</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -169,7 +168,7 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-7276b452-a743-4135-a902-92f6dae86577</value>
+                    <value>Facet-4400e57b-e799-42fe-a489-30dd5ee55415</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
             </componentInstance>
@@ -178,29 +177,12 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-57c33ec2-fcb8-428b-905c-a5b6ffc21345</value>
+                    <value>Facet-0cb5a6fa-36b6-4f6d-b823-8e5956999c43</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
             </componentInstance>
         </itemInstances>
-        <name>Facet-2f1141f5-a8de-408c-abe5-65809abf27a2</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>columns</name>
-                    <value>Facet-2f1141f5-a8de-408c-abe5-65809abf27a2</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>label</name>
-                    <value>Information</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:fieldSection</componentName>
-            </componentInstance>
-        </itemInstances>
-        <name>Facet-8bfd1a00-fcf2-4971-8018-a8d223570540</name>
+        <name>Facet-c8e9ea70-60ad-498d-aa85-3bfb4b4ae4a2</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -219,7 +201,7 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.UserType__c</fieldItem>
+                <fieldItem>Record.UserLoggingLevel__c</fieldItem>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -240,19 +222,19 @@
                 <fieldItem>Record.UserRoleLink__c</fieldItem>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-c1e2a04c-b280-4275-b419-b53a61a6ed54</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
                     <name>uiBehavior</name>
-                    <value>required</value>
+                    <value>none</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.UserLoggingLevel__c</fieldItem>
+                <fieldItem>Record.UserType__c</fieldItem>
             </fieldInstance>
         </itemInstances>
+        <name>Facet-41157e95-741f-45a2-8866-db34e5ab6ebe</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -271,7 +253,34 @@
                 <fieldItem>Record.TimeZoneName__c</fieldItem>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-494f5402-8a05-400f-b6c5-def90c68d286</name>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.UserLicenseId__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.UserLicenseName__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.UserLicenseDefinitionKey__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-1d1e46b1-5129-4fe3-b7e6-859faf73ed6f</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -279,7 +288,7 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-c1e2a04c-b280-4275-b419-b53a61a6ed54</value>
+                    <value>Facet-41157e95-741f-45a2-8866-db34e5ab6ebe</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
             </componentInstance>
@@ -288,15 +297,33 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-494f5402-8a05-400f-b6c5-def90c68d286</value>
+                    <value>Facet-1d1e46b1-5129-4fe3-b7e6-859faf73ed6f</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
             </componentInstance>
         </itemInstances>
-        <name>Facet-945a7a5e-bd0d-466f-b804-0253e5188f64</name>
+        <name>Facet-5c500508-afda-4a8a-9373-e511461102c0</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.OrganizationId__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.OrganizationName__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -321,15 +348,6 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.ContextThemeDisplayed__c</fieldItem>
-            </fieldInstance>
-        </itemInstances>
-        <itemInstances>
-            <fieldInstance>
-                <fieldInstanceProperties>
-                    <name>uiBehavior</name>
-                    <value>none</value>
-                </fieldInstanceProperties>
                 <fieldItem>Record.SessionSecurityLevel__c</fieldItem>
             </fieldInstance>
         </itemInstances>
@@ -339,13 +357,22 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.SourceIp__c</fieldItem>
+                <fieldItem>Record.ContextThemeDisplayed__c</fieldItem>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-fcb1ca7b-9243-439c-985f-bab175875272</name>
+        <name>Facet-dd96d4ec-6034-459e-8813-ed90a6140a25</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.SourceIp__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -382,7 +409,7 @@
                 <fieldItem>Record.LogoutUrl__c</fieldItem>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-afd61d50-3d9f-4d29-a07c-fb8be7f981dd</name>
+        <name>Facet-fff43cf2-fc7e-4e7d-b627-6bc893e330da</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -390,7 +417,7 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-fcb1ca7b-9243-439c-985f-bab175875272</value>
+                    <value>Facet-dd96d4ec-6034-459e-8813-ed90a6140a25</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
             </componentInstance>
@@ -399,12 +426,96 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>body</name>
-                    <value>Facet-afd61d50-3d9f-4d29-a07c-fb8be7f981dd</value>
+                    <value>Facet-fff43cf2-fc7e-4e7d-b627-6bc893e330da</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:column</componentName>
             </componentInstance>
         </itemInstances>
-        <name>Facet-37803fba-b82c-4e23-bb69-8a3145d2baa2</name>
+        <name>Facet-2886487b-f420-41b7-b9ae-39107fdfd690</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.NetworkId__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.NetworkName__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.NetworkUrlPathPrefix__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-9d23c49c-32e6-473d-a47c-678899253e19</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.NetworkSelfRegistrationUrl__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.NetworkLoginUrl__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.NetworkLogoutUrl__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-72cc629b-dd6d-4814-bfbd-9b666b06a707</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-9d23c49c-32e6-473d-a47c-678899253e19</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-72cc629b-dd6d-4814-bfbd-9b666b06a707</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-f79fb2be-79cd-4cea-a3f8-fa0cbe1fd7f5</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
@@ -412,7 +523,20 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>columns</name>
-                    <value>Facet-945a7a5e-bd0d-466f-b804-0253e5188f64</value>
+                    <value>Facet-c8e9ea70-60ad-498d-aa85-3bfb4b4ae4a2</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>label</name>
+                    <value>Information</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:fieldSection</componentName>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>columns</name>
+                    <value>Facet-5c500508-afda-4a8a-9373-e511461102c0</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
@@ -425,7 +549,7 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>columns</name>
-                    <value>Facet-37803fba-b82c-4e23-bb69-8a3145d2baa2</value>
+                    <value>Facet-2886487b-f420-41b7-b9ae-39107fdfd690</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
@@ -440,59 +564,23 @@
                 </visibilityRule>
             </componentInstance>
         </itemInstances>
-        <name>Facet-a4a3ff6a-6c40-4037-805c-7d1baedf7127</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
-                    <name>body</name>
-                    <value>Facet-8bfd1a00-fcf2-4971-8018-a8d223570540</value>
+                    <name>columns</name>
+                    <value>Facet-f79fb2be-79cd-4cea-a3f8-fa0cbe1fd7f5</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
-                    <value>Standard.Tab.fields</value>
+                    <value>Community Details</value>
                 </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>name</name>
-                    <value>accordionSection1</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:accordionSection</componentName>
-            </componentInstance>
-        </itemInstances>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>body</name>
-                    <value>Facet-a4a3ff6a-6c40-4037-805c-7d1baedf7127</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>label</name>
-                    <value>Standard.Tab.additionalFields</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>name</name>
-                    <value>accordionSection2</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:accordionSection</componentName>
-            </componentInstance>
-        </itemInstances>
-        <name>Facet-041cc850-4627-4362-83ed-b0b177a85fd8</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>accordionSections</name>
-                    <value>Facet-041cc850-4627-4362-83ed-b0b177a85fd8</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>defaultSectionName</name>
-                    <value>accordionSection1</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:accordion</componentName>
+                <componentName>flexipage:fieldSection</componentName>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.NetworkId__c}</leftValue>
+                        <operator>NE</operator>
+                    </criteria>
+                </visibilityRule>
             </componentInstance>
         </itemInstances>
         <itemInstances>

--- a/nebula-logger/main/logger/layouts/Log__c-Log Layout.layout-meta.xml
+++ b/nebula-logger/main/logger/layouts/Log__c-Log Layout.layout-meta.xml
@@ -34,10 +34,6 @@
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
-                <behavior>Edit</behavior>
-                <field>UserLoggingLevel__c</field>
-            </layoutItems>
-            <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>TotalLogEntries__c</field>
             </layoutItems>
@@ -67,6 +63,10 @@
                 <field>LoggedByUsernameLink__c</field>
             </layoutItems>
             <layoutItems>
+                <behavior>Edit</behavior>
+                <field>UserLoggingLevel__c</field>
+            </layoutItems>
+            <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>ProfileLink__c</field>
             </layoutItems>
@@ -76,17 +76,17 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Locale__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>TimeZoneName__c</field>
+                <field>UserType__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>UserType__c</field>
+                <field>Locale__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>TimeZoneName__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -220,22 +220,27 @@
             <sortOrder>0</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
-            <actionName>Share</actionName>
-            <actionType>StandardButton</actionType>
-            <sortOrder>1</sortOrder>
-        </platformActionListItems>
-        <platformActionListItems>
-            <actionName>FeedItem.TextPost</actionName>
+            <actionName>Log__c.ChangeLogRetentionDate</actionName>
             <actionType>QuickAction</actionType>
-            <sortOrder>2</sortOrder>
+            <sortOrder>1</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
             <actionName>Log__c.ViewJSON</actionName>
             <actionType>QuickAction</actionType>
-            <sortOrder>3</sortOrder>
+            <sortOrder>2</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
             <actionName>Delete</actionName>
+            <actionType>StandardButton</actionType>
+            <sortOrder>3</sortOrder>
+        </platformActionListItems>
+        <platformActionListItems>
+            <actionName>FeedItem.TextPost</actionName>
+            <actionType>QuickAction</actionType>
+            <sortOrder>5</sortOrder>
+        </platformActionListItems>
+        <platformActionListItems>
+            <actionName>Share</actionName>
             <actionType>StandardButton</actionType>
             <sortOrder>4</sortOrder>
         </platformActionListItems>

--- a/nebula-logger/main/logger/objects/Log__c/Log__c.object-meta.xml
+++ b/nebula-logger/main/logger/objects/Log__c/Log__c.object-meta.xml
@@ -177,10 +177,10 @@
         <customTabListAdditionalFields>CREATED_DATE</customTabListAdditionalFields>
         <excludedStandardButtons>New</excludedStandardButtons>
         <excludedStandardButtons>OpenListInQuip</excludedStandardButtons>
-        <excludedStandardButtons>PrintableListView</excludedStandardButtons>
+        <excludedStandardButtons>Accept</excludedStandardButtons>
         <excludedStandardButtons>ChangeOwner</excludedStandardButtons>
         <excludedStandardButtons>MassChangeOwner</excludedStandardButtons>
-        <excludedStandardButtons>Accept</excludedStandardButtons>
+        <excludedStandardButtons>PrintableListView</excludedStandardButtons>
         <lookupDialogsAdditionalFields>TransactionId__c</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>OWNER.ALIAS</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>UserLoggingLevel__c</lookupDialogsAdditionalFields>

--- a/nebula-logger/main/logger/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/main/logger/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -117,7 +117,7 @@
         <field>LogEntry__c.FlowName__c</field>
         <readable>true</readable>
     </fieldPermissions>
-        <fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>LogEntry__c.HasException__c</field>
         <readable>true</readable>
@@ -508,6 +508,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>Log__c.LogRetentionDate__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Log__c.LoggedByUsernameLink__c</field>
         <readable>true</readable>
@@ -600,11 +605,6 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Log__c.ProfileName__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
-        <field>Log__c.LogRetentionDate__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/nebula-logger/main/logger/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/main/logger/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -465,6 +465,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.LogRetentionDate__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.LoggedByUsernameLink__c</field>
         <readable>false</readable>
     </fieldPermissions>
@@ -556,11 +561,6 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Log__c.ProfileName__c</field>
-        <readable>false</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
-        <field>Log__c.LogRetentionDate__c</field>
         <readable>false</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/nebula-logger/main/logger/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/main/logger/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -61,7 +61,7 @@
         <field>LogEntry__c.FlowName__c</field>
         <readable>true</readable>
     </fieldPermissions>
-        <fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>LogEntry__c.HasException__c</field>
         <readable>true</readable>
@@ -453,6 +453,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.LogRetentionDate__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.LoggedByUsernameLink__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -544,11 +549,6 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Log__c.ProfileName__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
-        <field>Log__c.LogRetentionDate__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/nebula-logger/tests/logger/classes/ComponentLogEntry_Tests.cls
+++ b/nebula-logger/tests/logger/classes/ComponentLogEntry_Tests.cls
@@ -18,6 +18,7 @@ private class ComponentLogEntry_Tests {
     static void setup() {
         LoggerSettings__c settings = LoggerSettings__c.getInstance();
         settings.IsEnabled__c = true;
+        settings.EnableSystemMessages__c = false;
         upsert settings;
     }
 

--- a/nebula-logger/tests/logger/classes/FlowLogEntry_Tests.cls
+++ b/nebula-logger/tests/logger/classes/FlowLogEntry_Tests.cls
@@ -18,6 +18,7 @@ private class FlowLogEntry_Tests {
     static void setup() {
         LoggerSettings__c settings = LoggerSettings__c.getInstance();
         settings.IsEnabled__c = true;
+        settings.EnableSystemMessages__c = false;
         upsert settings;
     }
 

--- a/nebula-logger/tests/logger/classes/FlowLogRepo_Tests.cls
+++ b/nebula-logger/tests/logger/classes/FlowLogRepo_Tests.cls
@@ -13,6 +13,7 @@ private class FlowLogRepo_Tests {
     static void it_should_return_most_recent_log_in_flow_compatible_list() {
         LoggerSettings__c settings = LoggerSettings__c.getInstance();
         settings.IsEnabled__c = true;
+        settings.EnableSystemMessages__c = false;
         upsert settings;
 
         Test.startTest();

--- a/nebula-logger/tests/logger/classes/FlowRecordLogEntry_Tests.cls
+++ b/nebula-logger/tests/logger/classes/FlowRecordLogEntry_Tests.cls
@@ -18,6 +18,7 @@ private class FlowRecordLogEntry_Tests {
     static void setup() {
         LoggerSettings__c settings = LoggerSettings__c.getInstance();
         settings.IsEnabled__c = true;
+        settings.EnableSystemMessages__c = false;
         upsert settings;
     }
 


### PR DESCRIPTION
1. A few new fields were missing on the flexipages (since those 
2. I also eliminated the accordions for the dynamic fields - we're using conditional rendering on several field sections, and it's convenient seeing all rendered data at the same time (instead of expanding/collapsing the accordion tabs)

