### PR TITLE
Batch purge enhancements

### DIFF
--- a/nebula-logger/main/log-management/classes/LogBatchPurgeScheduler.cls
+++ b/nebula-logger/main/log-management/classes/LogBatchPurgeScheduler.cls
@@ -1,0 +1,13 @@
+/*************************************************************************************************
+ * This file is part of the Nebula Logger project, released under the MIT License.                *
+ * See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    *
+ *************************************************************************************************/
+/*************************************************************************************************
+ * This file is part of the Nebula Logger project, released under the MIT License.                *
+ * See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    *
+ *************************************************************************************************/
+global with sharing class LogBatchPurgeScheduler implements System.Schedulable {
+    global void execute(SchedulableContext schedulableContext) {
+        Database.executebatch(new LogBatchPurger());
+    }
+}

--- a/nebula-logger/main/log-management/classes/LogBatchPurgeScheduler.cls
+++ b/nebula-logger/main/log-management/classes/LogBatchPurgeScheduler.cls
@@ -2,10 +2,6 @@
  * This file is part of the Nebula Logger project, released under the MIT License.                *
  * See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    *
  *************************************************************************************************/
-/*************************************************************************************************
- * This file is part of the Nebula Logger project, released under the MIT License.                *
- * See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    *
- *************************************************************************************************/
 global with sharing class LogBatchPurgeScheduler implements System.Schedulable {
     global void execute(SchedulableContext schedulableContext) {
         Database.executebatch(new LogBatchPurger());

--- a/nebula-logger/main/log-management/classes/LogBatchPurgeScheduler.cls-meta.xml
+++ b/nebula-logger/main/log-management/classes/LogBatchPurgeScheduler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/main/log-management/classes/LogBatchPurger.cls
+++ b/nebula-logger/main/log-management/classes/LogBatchPurger.cls
@@ -2,7 +2,7 @@
  * This file is part of the Nebula Logger project, released under the MIT License.                *
  * See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    *
  *************************************************************************************************/
-global without sharing class LogBatchPurger implements Database.Batchable<SObject>, Database.Stateful {
+global with sharing class LogBatchPurger implements Database.Batchable<SObject>, Database.Stateful {
     private String originalTransactionId;
     private Integer totalProcessedRecords = 0;
 

--- a/nebula-logger/main/log-management/classes/LogHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogHandler.cls
@@ -58,6 +58,7 @@ public without sharing class LogHandler {
 
     private void setLogRetentionDate(List<Log__c> logs) {
         for (Log__c log : logs) {
+            // If the retention date has already been populated, leave it as-is
             if (log.LogRetentionDate__c != null) {
                 continue;
             }
@@ -65,6 +66,8 @@ public without sharing class LogHandler {
             LoggerSettings__c loggerSettings = LoggerSettings__c.getInstance(log.LoggedBy__c);
             Integer daysToRetainLog = Integer.valueOf(loggerSettings.DefaultNumberOfDaysToRetainLogs__c);
 
+            // When loggerSettings.DefaultNumberOfDaysToRetainLogs__c is null, assume that the log should be kept forever,
+            // ...and set the retention date to null so that LogBatchPurger filters out/ignores the record
             log.LogRetentionDate__c = daysToRetainLog == null ? null : System.today().addDays(daysToRetainLog);
         }
     }

--- a/nebula-logger/main/log-management/classes/LogHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogHandler.cls
@@ -25,6 +25,8 @@ public without sharing class LogHandler {
         switch on Trigger.operationType {
             when BEFORE_INSERT {
                 this.setClosedStatusFields(logs);
+                // The log retention date field should support being manually changed, so only auto-set it on insert
+                this.setLogRetentionDate(logs);
             }
             when BEFORE_UPDATE {
                 this.setClosedStatusFields(logs);
@@ -51,6 +53,19 @@ public without sharing class LogHandler {
                 log.ClosedBy__c = log.ClosedBy__c == null ? UserInfo.getUserId() : log.ClosedBy__c;
                 log.ClosedDate__c = log.ClosedDate__c == null ? System.now() : log.ClosedDate__c;
             }
+        }
+    }
+
+    private void setLogRetentionDate(List<Log__c> logs) {
+        for (Log__c log : logs) {
+            if (log.LogRetentionDate__c != null) {
+                continue;
+            }
+
+            LoggerSettings__c loggerSettings = LoggerSettings__c.getInstance(log.LoggedBy__c);
+            Integer daysToRetainLog = Integer.valueOf(loggerSettings.DefaultNumberOfDaysToRetainLogs__c);
+
+            log.LogRetentionDate__c = daysToRetainLog == null ? null : System.today().addDays(daysToRetainLog);
         }
     }
 

--- a/nebula-logger/main/log-management/objects/Log__c/fields/LogRetentionDate__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/LogRetentionDate__c.field-meta.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LogRetentionDate__c</fullName>
-    <defaultValue>TODAY() + 7</defaultValue>
-    <description>The date that this log can be automatically deleted by the batch job LogBatchPurger. 
+    <description>The date that this log can be automatically deleted by the batch job LogBatchPurger.
 
-It defaults to 1 week after creation (TODAY + 7), but the date can be set manually or via automation if certain logs need to be kept longer/indefinitely.</description>
+It defaults to 2 weeks after creation (configurable in Logger Settings), but the date can be set manually or via automation if certain logs need to be kept longer/indefinitely.</description>
     <externalId>false</externalId>
     <inlineHelpText>The date that this log can be automatically deleted by the batch job LogBatchPurger.</inlineHelpText>
     <label>Log Retention Date</label>

--- a/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -9,6 +9,14 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>LogBatchPurgeScheduler</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>LogBatchPurgeScheduler_Tests</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>LogBatchPurger</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/nebula-logger/main/logger-engine/objects/LoggerSettings__c/fields/DefaultNumberOfDaysToRetainLogs__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LoggerSettings__c/fields/DefaultNumberOfDaysToRetainLogs__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DefaultNumberOfDaysToRetainLogs__c</fullName>
+    <defaultValue>14</defaultValue>
+    <description>This value is used to set the field Log__c.LogRetentionDate__c,  which is then used by LogBatchPurger to delete old logs. To keep  logs indefinitely, set this field to blank (null).</description>
+    <externalId>false</externalId>
+    <inlineHelpText>This value is used to set the field Log__c.LogRetentionDate__c,  which is then used by LogBatchPurger to delete old logs. To keep  logs indefinitely, set this field to blank (null).</inlineHelpText>
+    <label>Default Number of Days to Retain Logs</label>
+    <precision>3</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <trackTrending>false</trackTrending>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/tests/log-management/classes/LogBatchPurgeScheduler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogBatchPurgeScheduler_Tests.cls
@@ -21,7 +21,7 @@ private class LogBatchPurgeScheduler_Tests {
         CronTrigger cronTrigger = [
             SELECT Id, CronExpression, TimesTriggered, NextFireTime
             FROM CronTrigger
-            WHERE id = :jobId
+            WHERE Id = :jobId
         ];
         System.assertEquals(TEST_CRON_EXPRESSION, cronTrigger.CronExpression);
         System.assertEquals(0, cronTrigger.TimesTriggered);

--- a/nebula-logger/tests/log-management/classes/LogBatchPurgeScheduler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogBatchPurgeScheduler_Tests.cls
@@ -1,0 +1,29 @@
+/*************************************************************************************************
+ * This file is part of the Nebula Logger project, released under the MIT License.                *
+ * See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    *
+ *************************************************************************************************/
+@isTest
+private class LogBatchPurgeScheduler_Tests {
+    private static final String TEST_CRON_EXPRESSION = '0 0 23 * * ?';
+
+    @isTest
+    static void it_should_schedule_job() {
+        Test.startTest();
+
+        Id jobId = System.schedule(
+            'Test schedule of LogBatchPurgeScheduler',
+            TEST_CRON_EXPRESSION,
+            new LogBatchPurgeScheduler()
+        );
+
+        Test.stopTest();
+
+        CronTrigger cronTrigger = [
+            SELECT Id, CronExpression, TimesTriggered, NextFireTime
+            FROM CronTrigger
+            WHERE id = :jobId
+        ];
+        System.assertEquals(TEST_CRON_EXPRESSION, cronTrigger.CronExpression);
+        System.assertEquals(0, cronTrigger.TimesTriggered);
+    }
+}

--- a/nebula-logger/tests/log-management/classes/LogBatchPurgeScheduler_Tests.cls-meta.xml
+++ b/nebula-logger/tests/log-management/classes/LogBatchPurgeScheduler_Tests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/tests/log-management/classes/LogHandler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogHandler_Tests.cls
@@ -100,6 +100,69 @@ private class LogHandler_Tests {
     }
 
     @isTest
+    static void it_should_keep_existing_retention_date_when_populated() {
+        Integer defaultDaysToRetainLog = 10;
+
+        LoggerSettings__c settings = LoggerSettings__c.getInstance();
+        settings.DefaultNumberOfDaysToRetainLogs__c = defaultDaysToRetainLog;
+        upsert settings;
+
+        Test.startTest();
+
+        Integer specifiedDaysToRetainLog = 50;
+        Date retentionDate = System.today().addDays(specifiedDaysToRetainLog);
+        Log__c log = new Log__c(
+            LoggedBy__c = UserInfo.getUserId(),
+            LogRetentionDate__c = retentionDate,
+            TransactionId__c = '1234'
+        );
+        insert log;
+
+        Test.stopTest();
+
+        log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
+        System.assertNotEquals(defaultDaysToRetainLog, specifiedDaysToRetainLog);
+        System.assertEquals(retentionDate, log.LogRetentionDate__c);
+    }
+
+    @isTest
+    static void it_should_set_retention_date_when_configured() {
+        Integer daysToRetainLog = 90;
+        Date expectedRetentionDate = System.today().addDays(daysToRetainLog);
+
+        LoggerSettings__c settings = LoggerSettings__c.getInstance();
+        settings.DefaultNumberOfDaysToRetainLogs__c = daysToRetainLog;
+        upsert settings;
+
+        Test.startTest();
+
+        Log__c log = new Log__c(LoggedBy__c = UserInfo.getUserId(), TransactionId__c = '1234');
+        insert log;
+
+        Test.stopTest();
+
+        log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
+        System.assertEquals(expectedRetentionDate, log.LogRetentionDate__c);
+    }
+
+    @isTest
+    static void it_should_have_null_retention_date_when_no_retention_configured() {
+        LoggerSettings__c settings = LoggerSettings__c.getInstance();
+        settings.DefaultNumberOfDaysToRetainLogs__c = null;
+        upsert settings;
+
+        Test.startTest();
+
+        Log__c log = new Log__c(LoggedBy__c = UserInfo.getUserId(), TransactionId__c = '1234');
+        insert log;
+
+        Test.stopTest();
+
+        log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
+        System.assertEquals(null, log.LogRetentionDate__c);
+    }
+
+    @isTest
     static void it_should_set_priority_to_high_when_there_are_errors() {
         Log__c log = new Log__c(Priority__c = LOW_PRIORITY, TransactionId__c = '1234');
         insert log;

--- a/nebula-logger/tests/log-management/testSuites/LogManagement.testSuite-meta.xml
+++ b/nebula-logger/tests/log-management/testSuites/LogManagement.testSuite-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexTestSuite xmlns="http://soap.sforce.com/2006/04/metadata">
     <testClassName>LogBatchPurger_Tests</testClassName>
+    <testClassName>LogBatchPurgeScheduler_Tests</testClassName>
     <testClassName>LogEntryEventHandler_Tests</testClassName>
     <testClassName>LogEntryHandler_Tests</testClassName>
     <testClassName>LogHandler_Tests</testClassName>


### PR DESCRIPTION
- **Added a basic schedulable class `LogBatchPurgeScheduler`** - the repo did not previously have a schedulable class at all, so I've added a simple schedulable class
- **`LogBatchPurger` now uses 'with sharing'** - Since this class is deleting data, it should only query data that the running user can access. If a non-admin (someone without 'view all' access on `Log__c`) runs the job, then only the logs that they can access will be deleted.
- **The default value for `Log__c.LogRetentionDate__c` is now configured via `LoggerSettings__c`** - previously, the field had a default value of `TODAY() + 7`, but moving the configuration to the custom setting lets it be configured at the org, profile & user levels