### PR TITLE
Added workound for accurate timestamps on log entries

### DIFF
--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -81,6 +81,11 @@ public without sharing class LogEntryEventHandler {
         }
 
         for (LogEntryEvent__e logEntryEvent : (List<LogEntryEvent__e>) Trigger.new) {
+            // Workaround field for platform issue w/ accurate datetimes
+            Datetime timestamp = String.isNotBlank(logEntryEvent.TimestampString__c)
+                ? Datetime.valueOf(logEntryEvent.TimestampString__c)
+                : logEntryEvent.Timestamp__c;
+
             LogEntry__c logEntry = new LogEntry__c(
                 ExceptionMessage__c = logEntryEvent.ExceptionMessage__c,
                 ExceptionStackTrace__c = logEntryEvent.ExceptionStackTrace__c,
@@ -126,7 +131,7 @@ public without sharing class LogEntryEventHandler {
                 RecordId__c = logEntryEvent.RecordId__c,
                 RecordJson__c = logEntryEvent.RecordJson__c,
                 StackTrace__c = logEntryEvent.StackTrace__c,
-                Timestamp__c = Datetime.valueOf(logEntryEvent.TimestampString__c), // Workaround field for platform issue w/ accurate datetimes
+                Timestamp__c = timestamp,
                 TriggerIsExecuting__c = logEntryEvent.TriggerIsExecuting__c,
                 TriggerOperationType__c = logEntryEvent.TriggerOperationType__c,
                 TriggerSObjectType__c = logEntryEvent.TriggerSObjectType__c

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -126,7 +126,7 @@ public without sharing class LogEntryEventHandler {
                 RecordId__c = logEntryEvent.RecordId__c,
                 RecordJson__c = logEntryEvent.RecordJson__c,
                 StackTrace__c = logEntryEvent.StackTrace__c,
-                Timestamp__c = logEntryEvent.Timestamp__c,
+                Timestamp__c = Datetime.valueOf(logEntryEvent.TimestampString__c), // Workaround field for platform issue w/ accurate datetimes
                 TriggerIsExecuting__c = logEntryEvent.TriggerIsExecuting__c,
                 TriggerOperationType__c = logEntryEvent.TriggerOperationType__c,
                 TriggerSObjectType__c = logEntryEvent.TriggerSObjectType__c

--- a/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -196,6 +196,11 @@ global without sharing class LogEntryEventBuilder {
             this.setUserSessionDetails();
         }
 
+        // Set string value of timestamp as a workaround
+        // Salesforce does not provide precise datetimes in Apex triggers for platform events
+        // See https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_events_api_considerations.htm
+        this.logEntryEvent.TimestampString__c = String.valueOf(this.logEntryEvent.Timestamp__c);
+
         return this.logEntryEvent;
     }
 

--- a/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -196,8 +196,8 @@ global without sharing class LogEntryEventBuilder {
             this.setUserSessionDetails();
         }
 
-        // Set string value of timestamp as a workaround
         // Salesforce does not provide precise datetimes in Apex triggers for platform events
+        // Set the string value of timestamp to a second field as a workaround
         // See https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_events_api_considerations.htm
         if (this.logEntryEvent.Timestamp__c != null) {
             this.logEntryEvent.TimestampString__c = String.valueOf(this.logEntryEvent.Timestamp__c);

--- a/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -199,7 +199,9 @@ global without sharing class LogEntryEventBuilder {
         // Set string value of timestamp as a workaround
         // Salesforce does not provide precise datetimes in Apex triggers for platform events
         // See https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_events_api_considerations.htm
-        this.logEntryEvent.TimestampString__c = String.valueOf(this.logEntryEvent.Timestamp__c);
+        if (this.logEntryEvent.Timestamp__c != null) {
+            this.logEntryEvent.TimestampString__c = String.valueOf(this.logEntryEvent.Timestamp__c);
+        }
 
         return this.logEntryEvent;
     }

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/TimestampString__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/TimestampString__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>TimestampString__c</fullName>
+    <description>This field is used to circumvent a platform limitation - platform event datetimes are not accurately transferred to Apex triggers. This field stores a string version of the timestamp, which is then converted back to a datetime in Apex triggers.</description>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Timestamp String</label>
+    <length>40</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
Fixes #85 - As a workaround, I've added a new string field `LogEntryEvent__e.TimestampString__c` to store the string version of the log entry's timestamp. The handler class `LogEntryEventHandler` then converts the string back into a datetime value and sets it on `LogEntry__c.Timestamp__c`