### PR TITLE
Added record SObject classification

### DIFF
--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -138,6 +138,7 @@ public without sharing class LogEntryEventHandler {
                 RecordJson__c = logEntryEvent.RecordJson__c,
                 RecordSObjectClassification__c = logEntryEvent.RecordSObjectClassification__c,
                 RecordSObjectType__c = logEntryEvent.RecordSObjectType__c,
+                RecordSObjectTypeNamespace__c = logEntryEvent.RecordSObjectTypeNamespace__c,
                 StackTrace__c = logEntryEvent.StackTrace__c,
                 Timestamp__c = timestamp,
                 TriggerIsExecuting__c = logEntryEvent.TriggerIsExecuting__c,

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -136,6 +136,8 @@ public without sharing class LogEntryEventHandler {
                 OriginLocation__c = logEntryEvent.OriginLocation__c,
                 RecordId__c = logEntryEvent.RecordId__c,
                 RecordJson__c = logEntryEvent.RecordJson__c,
+                RecordSObjectClassification__c = logEntryEvent.RecordSObjectClassification__c,
+                RecordSObjectType__c = logEntryEvent.RecordSObjectType__c,
                 StackTrace__c = logEntryEvent.StackTrace__c,
                 Timestamp__c = timestamp,
                 TriggerIsExecuting__c = logEntryEvent.TriggerIsExecuting__c,

--- a/nebula-logger/main/log-management/classes/LogEntryHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryHandler.cls
@@ -96,16 +96,11 @@ public without sharing class LogEntryHandler {
             Id recordId = (Id) logEntry.RecordId__c;
             Schema.SObjectType sobjectType = recordId.getSObjectType();
 
-            logEntry.RecordSObjectType__c = String.valueOf(sobjectType);
-
             String sobjectDisplayFieldName = this.getDisplayFieldApiName(sobjectType);
-
-            if (sobjectDisplayFieldName == null) {
-                continue;
+            if (sobjectDisplayFieldName != null) {
+                String recordName = (String) recordIdToRecord.get(logEntry.RecordId__c).get(sobjectDisplayFieldName);
+                logEntry.RecordName__c = recordName;
             }
-
-            String recordName = (String) recordIdToRecord.get(logEntry.RecordId__c).get(sobjectDisplayFieldName);
-            logEntry.RecordName__c = recordName;
         }
     }
 

--- a/nebula-logger/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
+++ b/nebula-logger/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
@@ -216,7 +216,16 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.RecordDetailedLink__c</fieldItem>
+                <fieldItem>Record.RecordSObjectType__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.RecordLink__c</fieldItem>
             </fieldInstance>
         </itemInstances>
         <itemInstances>

--- a/nebula-logger/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
+++ b/nebula-logger/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
@@ -207,6 +207,15 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
+                <fieldItem>Record.RecordSObjectClassification__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.RecordDetailedLink__c</fieldItem>
             </fieldInstance>
         </itemInstances>

--- a/nebula-logger/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
+++ b/nebula-logger/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
@@ -216,6 +216,15 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
+                <fieldItem>Record.RecordSObjectTypeNamespace__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.RecordSObjectType__c</fieldItem>
             </fieldInstance>
         </itemInstances>

--- a/nebula-logger/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
+++ b/nebula-logger/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
@@ -82,6 +82,10 @@
                 <field>RecordSObjectClassification__c</field>
             </layoutItems>
             <layoutItems>
+                <behavior>Edit</behavior>
+                <field>RecordSObjectTypeNamespace__c</field>
+            </layoutItems>
+            <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>RecordSObjectType__c</field>
             </layoutItems>

--- a/nebula-logger/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
+++ b/nebula-logger/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
@@ -29,6 +29,10 @@
                 <behavior>Readonly</behavior>
                 <field>Timestamp__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>RecordSObjectClassification__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/nebula-logger/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
+++ b/nebula-logger/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
@@ -29,10 +29,6 @@
                 <behavior>Readonly</behavior>
                 <field>Timestamp__c</field>
             </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>RecordSObjectClassification__c</field>
-            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -83,7 +79,15 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>RecordDetailedLink__c</field>
+                <field>RecordSObjectClassification__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>RecordSObjectType__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>RecordLink__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>

--- a/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordDetailedLink__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordDetailedLink__c.field-meta.xml
@@ -23,9 +23,13 @@
         &apos;_top&apos;
     ),
     IF(
-        ISBLANK(RecordName__c),
-        TEXT(RecordSObjectType__c) + &apos;: &apos; + RecordId__c,
-        TEXT(RecordSObjectType__c) + &apos;: &apos; + RecordName__c
+        ISBLANK(RecordId__c),
+        null,
+        IF(
+            ISBLANK(RecordName__c) &amp;&amp; NOT(ISBLANK(RecordId__c)),
+            TEXT(RecordSObjectType__c) + &apos;: &apos; + RecordId__c,
+            TEXT(RecordSObjectType__c) + &apos;: &apos; + RecordName__c
+        )
     ) 
 )</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>

--- a/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordDetailedLink__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordDetailedLink__c.field-meta.xml
@@ -2,18 +2,31 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>RecordDetailedLink__c</fullName>
     <externalId>false</externalId>
-    <formula>IF(
-    RecordId__c == null,
-    &apos;&apos;,
-    HYPERLINK(
+    <formula>CASE(
+    TEXT(RecordSObjectClassification__c),
+    &apos;Custom Object&apos;, HYPERLINK(
         &apos;/&apos; + RecordId__c,
         TEXT(RecordSObjectType__c) + &apos;: &apos; + IF(
             ISBLANK(RecordName__c),
             RecordId__c,
             RecordName__c
         ),
-    &apos;_top&apos;
-    )
+        &apos;_top&apos;
+    ),
+    &apos;Standard Object&apos;, HYPERLINK(
+        &apos;/&apos; + RecordId__c,
+        TEXT(RecordSObjectType__c) + &apos;: &apos; + IF(
+            ISBLANK(RecordName__c),
+            RecordId__c,
+            RecordName__c
+        ),
+        &apos;_top&apos;
+    ),
+    IF(
+        ISBLANK(RecordName__c),
+        TEXT(RecordSObjectType__c) + &apos;: &apos; + RecordId__c,
+        TEXT(RecordSObjectType__c) + &apos;: &apos; + RecordName__c
+    ) 
 )</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Related Record</label>

--- a/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordLink__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordLink__c.field-meta.xml
@@ -2,14 +2,31 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>RecordLink__c</fullName>
     <externalId>false</externalId>
-    <formula>HYPERLINK(
-    &apos;/&apos; + RecordId__c,
+    <formula>CASE(
+    TEXT(RecordSObjectClassification__c),
+    &apos;Custom Object&apos;, HYPERLINK(
+        &apos;/&apos; + RecordId__c,
+        IF(
+            ISBLANK(RecordName__c),
+            RecordId__c,
+            RecordName__c
+        ),
+        &apos;_top&apos;
+    ),
+    &apos;Standard Object&apos;, HYPERLINK(
+        &apos;/&apos; + RecordId__c,
+        IF(
+            ISBLANK(RecordName__c),
+            RecordId__c,
+            RecordName__c
+        ),
+        &apos;_top&apos;
+    ),
     IF(
         ISBLANK(RecordName__c),
         RecordId__c,
         RecordName__c
-    ),
-    &apos;_top&apos;
+    ) 
 )</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Related Record</label>

--- a/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordSObjectClassification__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordSObjectClassification__c.field-meta.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RecordSObjectClassification__c</fullName>
+    <externalId>false</externalId>
+    <label>Related Record SObject Classification</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Change Event Object</fullName>
+                <default>false</default>
+                <label>Change Event Object</label>
+            </value>
+            <value>
+                <fullName>Chatter Feed Object</fullName>
+                <default>false</default>
+                <label>Chatter Feed Object</label>
+            </value>
+            <value>
+                <fullName>Custom Metadata Type Object</fullName>
+                <default>false</default>
+                <label>Custom Metadata Type Object</label>
+            </value>
+            <value>
+                <fullName>Custom Object</fullName>
+                <default>false</default>
+                <label>Custom Object</label>
+            </value>
+            <value>
+                <fullName>Custom Setting Object</fullName>
+                <default>false</default>
+                <label>Custom Setting Object</label>
+            </value>
+            <value>
+                <fullName>Field History Tracking Object</fullName>
+                <default>false</default>
+                <label>Field History Tracking Object</label>
+            </value>
+            <value>
+                <fullName>Platform Event Object</fullName>
+                <default>false</default>
+                <label>Platform Event Object</label>
+            </value>
+            <value>
+                <fullName>Sharing Object</fullName>
+                <default>false</default>
+                <label>Sharing Object</label>
+            </value>
+            <value>
+                <fullName>Standard Object</fullName>
+                <default>false</default>
+                <label>Standard Object</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordSObjectClassification__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordSObjectClassification__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>RecordSObjectClassification__c</fullName>
     <externalId>false</externalId>
-    <label>Related Record SObject Classification</label>
+    <label>Related Record Object Classification</label>
     <required>false</required>
     <trackFeedHistory>false</trackFeedHistory>
     <trackTrending>false</trackTrending>

--- a/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordSObjectClassification__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordSObjectClassification__c.field-meta.xml
@@ -46,9 +46,9 @@
                 <label>Platform Event Object</label>
             </value>
             <value>
-                <fullName>Sharing Object</fullName>
+                <fullName>Record Share Object</fullName>
                 <default>false</default>
-                <label>Sharing Object</label>
+                <label>Record Share Object</label>
             </value>
             <value>
                 <fullName>Standard Object</fullName>

--- a/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordSObjectTypeNamespace__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordSObjectTypeNamespace__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RecordSObjectTypeNamespace__c</fullName>
+    <externalId>false</externalId>
+    <label>Related Record Object Namespace</label>
+    <length>255</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordSObjectTypeNamespace__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/LogEntry__c/fields/RecordSObjectTypeNamespace__c.field-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>RecordSObjectTypeNamespace__c</fullName>
-    <externalId>false</externalId>
+    <externalId>true</externalId>
     <label>Related Record Object Namespace</label>
     <length>255</length>
     <required>false</required>

--- a/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -387,6 +387,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.RecordSObjectClassification__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.RecordSObjectType__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -397,6 +397,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.RecordSObjectTypeNamespace__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.StackTrace__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -365,6 +365,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.RecordSObjectTypeNamespace__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.Timestamp__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -355,6 +355,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.RecordSObjectClassification__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.RecordSObjectType__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -347,6 +347,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.RecordSObjectClassification__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.RecordSObjectType__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -357,6 +357,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.RecordSObjectTypeNamespace__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.StackTrace__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -314,7 +314,7 @@ global with sharing class LogEntryEventBuilder {
             sobjectClassification = 'Field History Tracking Object';
         } else if(String.isBlank(sobjectClassification) && sobjectName.endsWith('Share')) {
             // Examples: AccountShare and Log__Share
-            sobjectClassification = 'Share Object';
+            sobjectClassification = 'Record Share Object';
         } else if(String.isBlank(sobjectClassification) && sobjectType.getDescribe().isCustom() == false) {
             sobjectClassification = 'Standard Object';
         }

--- a/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -266,7 +266,6 @@ global with sharing class LogEntryEventBuilder {
     }
 
     private String getSObjectClassification(Schema.SObjectType sobjectType) {
-        // This method could definitely use some cleanup
         String sobjectName = sobjectType.getDescribe().getName();
 
         // Check the map to see if we've already determined the classification for this SObject type
@@ -276,56 +275,45 @@ global with sharing class LogEntryEventBuilder {
 
         String sobjectClassification;
 
-        // Check several details about the SObject type to determine the classification
+        // Custom settings and custom objects both end in '__c', so explicitly check if it's a custom setting
         if(sobjectType.getDescribe().isCustomSetting()) {
-            // Custom settings and custom objects both end in '__c', so explicitly check if it's a custom setting
             sobjectClassification = 'Custom Setting Object';
-        } else if(sobjectType.getDescribe().isCustom() == true) {
-            Integer delimiterIndex = sobjectName.lastIndexOf('__');
-            String sobjectSuffix = sobjectName.substring(delimiterIndex, sobjectName.length());
+        }
 
-            // Some suffixes only apply to custom objects
-            switch on sobjectSuffix {
-                when '__b' {
-                    // Example: MyBigObject__b
-                    sobjectClassification = 'Big Object';
-                }
-                when '__c' {
-                    // Example: Log__c
-                    sobjectClassification = 'Custom Object';
-                }
-                when '__e' {
-                    // LogEntryEvent__e
-                    sobjectClassification = 'Platform Event Object';
-                }
-                when '__mdt' {
-                    // Example: LogStatus__mdt
-                    sobjectClassification = 'Custom Metadata Type Object';
-                }
+        // Store the key-values for Salesforce's list of object suffixes
+        Map<String, String> sobjectSuffixToClassification = new Map<String, String>{
+            // Example: MyBigObject__b
+            '__b' => 'Big Object',
+            // Example: Log__c
+            '__c' => 'Custom Object',
+            // Example: LogEntryEvent__e
+            '__e' => 'Platform Event Object',
+            // Example: LogStatus__mdt
+            '__mdt' => 'Custom Metadata Type Object',
+            // Examples: AccountChangeEvent and Log__ChangeEvent
+            'ChangeEvent' => 'Change Event Object',
+            // Examples: AccountFeed and Log__Feed
+            'Feed' => 'Chatter Feed Object',
+            // Examples: AccountHistory and Log__History
+            'History' => 'Field History Tracking Object',
+            // Examples: AccountShare and Log__Share
+            'Share' => 'Record Share Object'
+        };
+
+        for(String sobjectSuffix : sobjectSuffixToClassification.keySet()) {
+            if(String.isBlank(sobjectClassification) && sobjectName.endsWith(sobjectSuffix)) {
+                sobjectClassification = sobjectSuffixToClassification.get(sobjectSuffix);
+                break;
             }
         }
 
-        // Now, all other object classifications can be determined based on suffix (for both standard & custom)
-        if(String.isBlank(sobjectClassification) && sobjectName.endsWith('ChangeEvent')) {
-            // Examples: AccountChangeEvent and Log__ChangeEvent
-            sobjectClassification = 'Change Event Object';
-        } else if(String.isBlank(sobjectClassification) && sobjectName.endsWith('Feed')) {
-            // Examples: AccountFeed and Log__Feed
-            sobjectClassification = 'Chatter Feed Object';
-        } else if(String.isBlank(sobjectClassification) && sobjectName.endsWith('History')) {
-            // Examples: AccountHistory and Log__History
-            sobjectClassification = 'Field History Tracking Object';
-        } else if(String.isBlank(sobjectClassification) && sobjectName.endsWith('Share')) {
-            // Examples: AccountShare and Log__Share
-            sobjectClassification = 'Record Share Object';
-        } else if(String.isBlank(sobjectClassification) && sobjectType.getDescribe().isCustom() == false) {
+        // Finally, if we still don't have a classification, assume it's a standard object
+        if(String.isBlank(sobjectClassification) && sobjectType.getDescribe().isCustom() == false) {
             sobjectClassification = 'Standard Object';
         }
 
-        // Cache the results in case there are other entries related to the same SObject type
-        if(String.isNotBlank(sobjectClassification)) {
-            SOBJECT_NAME_TO_CLASSIFICATION.put(sobjectName, sobjectClassification);
-        }
+        // Cache the results in case there are other entries related to the same SObject Type
+        SOBJECT_NAME_TO_CLASSIFICATION.put(sobjectName, sobjectClassification);
 
         return sobjectClassification;
     }

--- a/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -323,7 +323,11 @@ global with sharing class LogEntryEventBuilder {
         String sobjectLocalName = sobjectType.getDescribe().getLocalName();
 
         // Remove the trailing '__' if present
-        return sobjectFullName.replace(sobjectLocalName, '').replace('__', '');
+        String namespace = sobjectFullName.replace(sobjectLocalName, '').replace('__', '');
+        if(String.isBlank(namespace)) {
+            namespace = null;
+        }
+        return namespace;
     }
 
     private void setUserSessionDetails() {

--- a/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -17,6 +17,8 @@ global with sharing class LogEntryEventBuilder {
     // private static final String ORIGIN_TYPE_COMPONENT = 'Component';
     // private static final String ORIGIN_TYPE_FLOW = 'Flow';
     private static final Map<String, String> SOBJECT_NAME_TO_CLASSIFICATION = new Map<String, String>();
+    private static final Map<String, String> SOBJECT_SUFFIX_TO_CLASSIFICATION = getSObjectSuffixToClassification();
+
     private static final Boolean USER_CAN_CREATE_LOG_ENTRY_EVENTS = SObjectType.LogEntryEvent__e.isCreateable();
 
     private final LogEntryEvent__e logEntryEvent;
@@ -280,29 +282,9 @@ global with sharing class LogEntryEventBuilder {
             sobjectClassification = 'Custom Setting Object';
         }
 
-        // Store the key-values for Salesforce's list of object suffixes
-        Map<String, String> sobjectSuffixToClassification = new Map<String, String>{
-            // Example: MyBigObject__b
-            '__b' => 'Big Object',
-            // Example: Log__c
-            '__c' => 'Custom Object',
-            // Example: LogEntryEvent__e
-            '__e' => 'Platform Event Object',
-            // Example: LogStatus__mdt
-            '__mdt' => 'Custom Metadata Type Object',
-            // Examples: AccountChangeEvent and Log__ChangeEvent
-            'ChangeEvent' => 'Change Event Object',
-            // Examples: AccountFeed and Log__Feed
-            'Feed' => 'Chatter Feed Object',
-            // Examples: AccountHistory and Log__History
-            'History' => 'Field History Tracking Object',
-            // Examples: AccountShare and Log__Share
-            'Share' => 'Record Share Object'
-        };
-
-        for(String sobjectSuffix : sobjectSuffixToClassification.keySet()) {
+        for(String sobjectSuffix : SOBJECT_SUFFIX_TO_CLASSIFICATION.keySet()) {
             if(String.isBlank(sobjectClassification) && sobjectName.endsWith(sobjectSuffix)) {
-                sobjectClassification = sobjectSuffixToClassification.get(sobjectSuffix);
+                sobjectClassification = SOBJECT_SUFFIX_TO_CLASSIFICATION.get(sobjectSuffix);
                 break;
             }
         }
@@ -394,13 +376,14 @@ global with sharing class LogEntryEventBuilder {
         return userJson.substringAfter('/data/').substringBefore('.0/sobjects/');
     }
 
-    private static List<String> getignoredClasses() {
+    private static List<String> getIgnoredClasses() {
         return new List<String>{
             Logger.class.getName(),
             LogMessage.class.getName(),
             LogEntryEventBuilder.class.getName()
         };
     }
+
 
     // TODO move namespace methods to separate Namespace class (again) if other classes end up needing this info
     /* private static Boolean hasNamespacePrefix() {
@@ -412,6 +395,27 @@ global with sharing class LogEntryEventBuilder {
         String namespacePrefix = className.contains('.') ? className.substringBefore('.') : '';
 
         return namespacePrefix;
+    }
+
+    private static Map<String, String> getSObjectSuffixToClassification() {
+       return new Map<String, String>{
+            // Example: MyBigObject__b
+            '__b' => 'Big Object',
+            // Example: Log__c
+            '__c' => 'Custom Object',
+            // Example: LogEntryEvent__e
+            '__e' => 'Platform Event Object',
+            // Example: LogStatus__mdt
+            '__mdt' => 'Custom Metadata Type Object',
+            // Examples: AccountChangeEvent and Log__ChangeEvent
+            'ChangeEvent' => 'Change Event Object',
+            // Examples: AccountFeed and Log__Feed
+            'Feed' => 'Chatter Feed Object',
+            // Examples: AccountHistory and Log__History
+            'History' => 'Field History Tracking Object',
+            // Examples: AccountShare and Log__Share
+            'Share' => 'Record Share Object'
+        };
     }
 
     // private static String getPrefixWithDelimiter(String delimiter) {

--- a/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -137,6 +137,10 @@ global with sharing class LogEntryEventBuilder {
             return this;
         }
 
+        if(record == null) {
+            return this;
+        }
+
         String truncatedRecordJson = truncateFieldValue(Schema.LogEntryEvent__e.RecordJson__c, Json.serializePretty(record));
         this.logEntryEvent.RecordJson__c = truncatedRecordJson;
 
@@ -150,6 +154,10 @@ global with sharing class LogEntryEventBuilder {
      */
     global LogEntryEventBuilder setRecordId(Id recordId) {
         if (!this.shouldSave) {
+            return this;
+        }
+
+        if(String.isBlank(recordId)) {
             return this;
         }
 

--- a/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -143,6 +143,7 @@ global with sharing class LogEntryEventBuilder {
         this.logEntryEvent.RecordId__c = record.Id;
         this.logEntryEvent.RecordSObjectClassification__c = getSObjectClassification(record.getSObjectType());
         this.logEntryEvent.RecordSObjectType__c = record.getSObjectType().getDescribe().getName();
+        this.logEntryEvent.RecordSObjectTypeNamespace__c = getSObjectTypeNamespace(record.getSObjectType());
 
         String truncatedRecordJson = truncateFieldValue(Schema.LogEntryEvent__e.RecordJson__c, Json.serializePretty(record));
         this.logEntryEvent.RecordJson__c = truncatedRecordJson;
@@ -327,6 +328,14 @@ global with sharing class LogEntryEventBuilder {
         }
 
         return sobjectClassification;
+    }
+
+    private String getSObjectTypeNamespace(Schema.SObjectType sobjectType) {
+        String sobjectFullName = sobjectType.getDescribe().getName();
+        String sobjectLocalName = sobjectType.getDescribe().getLocalName();
+
+        // Remove the trailing '__' if present
+        return sobjectFullName.replace(sobjectLocalName, '').replace('__', '');
     }
 
     private void setUserSessionDetails() {

--- a/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -140,11 +140,14 @@ global with sharing class LogEntryEventBuilder {
         if(record == null) {
             return this;
         }
+        this.logEntryEvent.RecordId__c = record.Id;
+        this.logEntryEvent.RecordSObjectClassification__c = getSObjectClassification(record.getSObjectType());
+        this.logEntryEvent.RecordSObjectType__c = record.getSObjectType().getDescribe().getName();
 
         String truncatedRecordJson = truncateFieldValue(Schema.LogEntryEvent__e.RecordJson__c, Json.serializePretty(record));
         this.logEntryEvent.RecordJson__c = truncatedRecordJson;
 
-        return this.setRecordId(record.Id);
+        return this;
     }
 
     /**
@@ -162,7 +165,7 @@ global with sharing class LogEntryEventBuilder {
         }
 
         this.logEntryEvent.RecordId__c = recordId;
-        this.logEntryEvent.RecordSObjectClassification__c = getSObjectClassification(recordId);
+        this.logEntryEvent.RecordSObjectClassification__c = getSObjectClassification(recordId.getSObjectType());
         this.logEntryEvent.RecordSObjectType__c = recordId.getSObjectType().getDescribe().getName();
         return this;
     }
@@ -261,9 +264,8 @@ global with sharing class LogEntryEventBuilder {
         return this.logEntryEvent;
     }
 
-    private String getSObjectClassification(Id recordId) {
+    private String getSObjectClassification(Schema.SObjectType sobjectType) {
         // This method could definitely use some cleanup
-        Schema.SObjectType sobjectType = recordId.getSObjectType();
         String sobjectName = sobjectType.getDescribe().getName();
 
         // Check the map to see if we've already determined the classification for this SObject type

--- a/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -16,6 +16,7 @@ global with sharing class LogEntryEventBuilder {
     // TODO future enhancement: consider converting strings to enum and add overload for `parseStackTrace(OriginType, String)
     // private static final String ORIGIN_TYPE_COMPONENT = 'Component';
     // private static final String ORIGIN_TYPE_FLOW = 'Flow';
+    private static final Map<String, String> SOBJECT_NAME_TO_CLASSIFICATION = new Map<String, String>();
     private static final Boolean USER_CAN_CREATE_LOG_ENTRY_EVENTS = SObjectType.LogEntryEvent__e.isCreateable();
 
     private final LogEntryEvent__e logEntryEvent;
@@ -153,6 +154,8 @@ global with sharing class LogEntryEventBuilder {
         }
 
         this.logEntryEvent.RecordId__c = recordId;
+        this.logEntryEvent.RecordSObjectClassification__c = getSObjectClassification(recordId);
+        this.logEntryEvent.RecordSObjectType__c = recordId.getSObjectType().getDescribe().getName();
         return this;
     }
 
@@ -248,6 +251,72 @@ global with sharing class LogEntryEventBuilder {
         }
 
         return this.logEntryEvent;
+    }
+
+    private String getSObjectClassification(Id recordId) {
+        // This method could definitely use some cleanup
+        Schema.SObjectType sobjectType = recordId.getSObjectType();
+        String sobjectName = sobjectType.getDescribe().getName();
+
+        // Check the map to see if we've already determined the classification for this SObject type
+        if(SOBJECT_NAME_TO_CLASSIFICATION.containsKey(sobjectName)) {
+            return SOBJECT_NAME_TO_CLASSIFICATION.get(sobjectName);
+        }
+
+        String sobjectClassification;
+
+        // Check several details about the SObject type to determine the classification
+        if(sobjectType.getDescribe().isCustomSetting()) {
+            // Custom settings and custom objects both end in '__c', so explicitly check if it's a custom setting
+            sobjectClassification = 'Custom Setting Object';
+        } else if(sobjectType.getDescribe().isCustom() == true) {
+            Integer delimiterIndex = sobjectName.lastIndexOf('__');
+            String sobjectSuffix = sobjectName.substring(delimiterIndex, sobjectName.length());
+
+            // Some suffixes only apply to custom objects
+            switch on sobjectSuffix {
+                when '__b' {
+                    // Example: MyBigObject__b
+                    sobjectClassification = 'Big Object';
+                }
+                when '__c' {
+                    // Example: Log__c
+                    sobjectClassification = 'Custom Object';
+                }
+                when '__e' {
+                    // LogEntryEvent__e
+                    sobjectClassification = 'Platform Event Object';
+                }
+                when '__mdt' {
+                    // Example: LogStatus__mdt
+                    sobjectClassification = 'Custom Metadata Type Object';
+                }
+            }
+        }
+
+        // Now, all other object classifications can be determined based on suffix (for both standard & custom)
+        if(String.isBlank(sobjectClassification) && sobjectName.endsWith('ChangeEvent')) {
+            // Examples: AccountChangeEvent and Log__ChangeEvent
+            sobjectClassification = 'Change Event Object';
+        } else if(String.isBlank(sobjectClassification) && sobjectName.endsWith('Feed')) {
+            // Examples: AccountFeed and Log__Feed
+            sobjectClassification = 'Chatter Feed Object';
+        } else if(String.isBlank(sobjectClassification) && sobjectName.endsWith('History')) {
+            // Examples: AccountHistory and Log__History
+            sobjectClassification = 'Field History Tracking Object';
+        } else if(String.isBlank(sobjectClassification) && sobjectName.endsWith('Share')) {
+            // Examples: AccountShare and Log__Share
+            sobjectClassification = 'Share Object';
+        } else if(String.isBlank(sobjectClassification) && sobjectType.getDescribe().isCustom() == false) {
+            sobjectClassification = 'Standard Object';
+        }
+
+        // Cache the results in case there are other entries related to the same SObject type
+        if(String.isNotBlank(sobjectClassification)) {
+            SOBJECT_NAME_TO_CLASSIFICATION.put(sobjectName, sobjectClassification);
+        }
+
+        return sobjectClassification;
     }
 
     private void setUserSessionDetails() {

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/RecordSObjectClassification__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/RecordSObjectClassification__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RecordSObjectClassification__c</fullName>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Related Record SObject Classification</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/RecordSObjectTypeNamespace__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/RecordSObjectTypeNamespace__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RecordSObjectTypeNamespace__c</fullName>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Related Record Object Namespace</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/RecordSObjectType__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/RecordSObjectType__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RecordSObjectType__c</fullName>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Related Record SObject Type</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/main/logger-engine/objects/LoggerSettings__c/listViews/All.listView-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LoggerSettings__c/listViews/All.listView-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListView xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>All</fullName>
+    <columns>SETUP_OWNER_NAME</columns>
+    <columns>SETUP_TYPE</columns>
+    <columns>IsEnabled__c</columns>
+    <columns>LoggingLevel__c</columns>
+    <columns>EnableSystemMessages__c</columns>
+    <columns>DefaultNumberOfDaysToRetainLogs__c</columns>
+    <filterScope>Everything</filterScope>
+    <label>All</label>
+</ListView>

--- a/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -109,6 +109,7 @@ private class LogEntryEventHandler_Tests {
                         RecordJson__c,
                         RecordSObjectClassification__c,
                         RecordSObjectType__c,
+                        RecordSObjectTypeNamespace__c,
                         StackTrace__c,
                         Timestamp__c,
                         TriggerIsExecuting__c,
@@ -218,6 +219,7 @@ private class LogEntryEventHandler_Tests {
         System.assertEquals(logEntryEvent.RecordJson__c, logEntry.RecordJson__c);
         System.assertEquals(logEntryEvent.RecordSObjectClassification__c, logEntry.RecordSObjectClassification__c);
         System.assertEquals(logEntryEvent.RecordSObjectType__c, logEntry.RecordSObjectType__c);
+        System.assertEquals(logEntryEvent.RecordSObjectTypeNamespace__c, logEntry.RecordSObjectTypeNamespace__c);
         System.assertEquals(logEntryEvent.StackTrace__c, logEntry.StackTrace__c);
         System.assertEquals(logEntryEvent.Timestamp__c, logEntry.Timestamp__c);
         System.assertEquals(logEntryEvent.TriggerIsExecuting__c, logEntry.TriggerIsExecuting__c);

--- a/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -107,6 +107,8 @@ private class LogEntryEventHandler_Tests {
                         OriginLocation__c,
                         RecordId__c,
                         RecordJson__c,
+                        RecordSObjectClassification__c,
+                        RecordSObjectType__c,
                         StackTrace__c,
                         Timestamp__c,
                         TriggerIsExecuting__c,
@@ -214,6 +216,8 @@ private class LogEntryEventHandler_Tests {
         System.assertEquals(logEntryEvent.OriginLocation__c, logEntry.OriginLocation__c);
         System.assertEquals(logEntryEvent.RecordId__c, logEntry.RecordId__c);
         System.assertEquals(logEntryEvent.RecordJson__c, logEntry.RecordJson__c);
+        System.assertEquals(logEntryEvent.RecordSObjectClassification__c, logEntry.RecordSObjectClassification__c);
+        System.assertEquals(logEntryEvent.RecordSObjectType__c, logEntry.RecordSObjectType__c);
         System.assertEquals(logEntryEvent.StackTrace__c, logEntry.StackTrace__c);
         System.assertEquals(logEntryEvent.Timestamp__c, logEntry.Timestamp__c);
         System.assertEquals(logEntryEvent.TriggerIsExecuting__c, logEntry.TriggerIsExecuting__c);
@@ -297,6 +301,8 @@ private class LogEntryEventHandler_Tests {
             ProfileId__c = currentUser.ProfileId,
             RecordId__c = currentUser.Id,
             RecordJson__c = Json.serializePretty(currentUser),
+            RecordSObjectClassification__c = 'Standard Object',
+            RecordSObjectType__c = 'User',
             SessionId__c = null,
             SessionSecurityLevel__c = null,
             SessionType__c = null,

--- a/nebula-logger/tests/log-management/classes/LogEntryHandler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogEntryHandler_Tests.cls
@@ -36,10 +36,9 @@ private class LogEntryHandler_Tests {
         insert logEntry;
         Test.stopTest();
 
-        logEntry = [SELECT Id, RecordId__c, RecordName__c, RecordSObjectType__c FROM LogEntry__c WHERE Id = :logEntry.Id];
+        logEntry = [SELECT Id, RecordId__c, RecordName__c FROM LogEntry__c WHERE Id = :logEntry.Id];
         System.assertEquals(currentUser.Id, logEntry.RecordId__c);
         System.assertEquals(currentUser.Username, logEntry.RecordName__c);
-        System.assertEquals('User', logEntry.RecordSObjectType__c);
     }
 
     @isTest
@@ -53,10 +52,9 @@ private class LogEntryHandler_Tests {
         insert logEntry;
         Test.stopTest();
 
-        logEntry = [SELECT Id, RecordId__c, RecordName__c, RecordSObjectType__c FROM LogEntry__c WHERE Id = :logEntry.Id];
+        logEntry = [SELECT Id, RecordId__c, RecordName__c FROM LogEntry__c WHERE Id = :logEntry.Id];
         System.assertEquals(currentProfile.Id, logEntry.RecordId__c);
         System.assertEquals(currentProfile.Name, logEntry.RecordName__c);
-        System.assertEquals('Profile', logEntry.RecordSObjectType__c);
     }
 
     @isTest

--- a/nebula-logger/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -115,6 +115,8 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(LoggingLevel.INFO, true);
         System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
         System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
 
         Test.startTest();
 
@@ -125,6 +127,8 @@ private class LogEntryEventBuilder_Tests {
 
         System.assertEquals(currentUserId, builder.getLogEntryEvent().RecordId__c);
         System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals('Standard Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.assertEquals('User', builder.getLogEntryEvent().RecordSObjectType__c);
     }
 
     @isTest
@@ -132,6 +136,8 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(LoggingLevel.INFO, true);
         System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
         System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
 
         Test.startTest();
 
@@ -142,6 +148,8 @@ private class LogEntryEventBuilder_Tests {
 
         System.assertEquals(currentUser.Id, builder.getLogEntryEvent().RecordId__c);
         System.assertEquals(Json.serializePretty(currentUser), builder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals('Standard Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.assertEquals('User', builder.getLogEntryEvent().RecordSObjectType__c);
     }
 
     @isTest

--- a/nebula-logger/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -19,8 +19,8 @@ private class LogEntryEventBuilder_Tests {
 
     @isTest
     static void it_should_short_circuit_when_enabled_logging_level_above_called_level() {
-        Boolean shouldSave = Logger.isEnabled(LoggingLevel.FINE);
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(LoggingLevel.FINE, false);
+        Boolean shouldSave = false;
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(LoggingLevel.FINE, shouldSave);
 
         System.assertEquals(null, builder.getLogEntryEvent());
     }
@@ -111,12 +111,13 @@ private class LogEntryEventBuilder_Tests {
     }
 
     @isTest
-    static void it_should_set_record_fields_for_recordId() {
+    static void it_should_set_record_fields_for_recordId_when_standard_object() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(LoggingLevel.INFO, true);
         System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
         System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
         System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
         System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         Test.startTest();
 
@@ -129,15 +130,62 @@ private class LogEntryEventBuilder_Tests {
         System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
         System.assertEquals('Standard Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
         System.assertEquals('User', builder.getLogEntryEvent().RecordSObjectType__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
     }
 
     @isTest
-    static void it_should_set_record_fields_for_record() {
+    static void it_should_set_record_fields_for_recordId_when_custom_object() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(LoggingLevel.INFO, true);
         System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
         System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
         System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
         System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+
+        Test.startTest();
+
+        Log__c log = new Log__c(TransactionId__c = '1234');
+        insert log;
+        builder.setRecordId(log.Id);
+
+        Test.stopTest();
+
+        System.assertEquals(log.Id, builder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals('Custom Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.assertEquals(Log__c.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
+    }
+
+    @isTest
+    static void it_should_set_record_fields_for_recordId_when_custom_metadata_type() {
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(LoggingLevel.INFO, true);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+
+        Test.startTest();
+
+        LogStatus__mdt status = [SELECT Id, MasterLabel, DeveloperName FROM LogStatus__mdt LIMIT 1];
+        builder.setRecordId(status.Id);
+
+        Test.stopTest();
+
+        System.assertEquals(status.Id, builder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals('Custom Metadata Type Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.assertEquals(LogStatus__mdt.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
+    }
+
+    @isTest
+    static void it_should_set_record_fields_for_record_when_standard_object() {
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(LoggingLevel.INFO, true);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         Test.startTest();
 
@@ -150,6 +198,52 @@ private class LogEntryEventBuilder_Tests {
         System.assertEquals(Json.serializePretty(currentUser), builder.getLogEntryEvent().RecordJson__c);
         System.assertEquals('Standard Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
         System.assertEquals('User', builder.getLogEntryEvent().RecordSObjectType__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+    }
+
+    @isTest
+    static void it_should_set_record_fields_for_record_when_custom_object() {
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(LoggingLevel.INFO, true);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+
+        Test.startTest();
+
+        Log__c log = new Log__c(TransactionId__c = '1234');
+        insert log;
+        builder.setRecordId(log);
+
+        Test.stopTest();
+
+        System.assertEquals(log.Id, builder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(Json.serializePretty(log), builder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals('Custom Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.assertEquals(Log__c.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
+    }
+
+    @isTest
+    static void it_should_set_record_fields_for_record_when_custom_metadata_type() {
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(LoggingLevel.INFO, true);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
+        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+
+        Test.startTest();
+
+        LogStatus__mdt status = [SELECT Id, MasterLabel, DeveloperName FROM LogStatus__mdt LIMIT 1];
+        builder.setRecordId(status);
+
+        Test.stopTest();
+
+        System.assertEquals(status.Id, builder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(Json.serializePretty(status), builder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals('Custom Metadata Type Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.assertEquals(LogStatus__mdt.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
     }
 
     @isTest


### PR DESCRIPTION
Closed #82 by adding 2 new fields to both `LogEntryEvent__e` and `LogEntry__c` (4 fields total)

- "Related Record Object Namespace" (`LogEntry__c.RecordSObjectTypeNamespace__c`) - the namespace of the related record's SObject Type
- "Related Record Object Classification" (`LogEntry__c.RecordSObjectClassification__c`) - a picklist values of the 'classification' of the object. Possible values are
  - Change Event Object
  - Chatter Feed Object
  - Custom Metadata Type Object
  - Custom Object
  - Custom Setting Object
  - Field History Tracking Object
  - Platform Event Object
  - Record Share Object
  - Standard Object