### PR TITLE
Added WARN overloads with exception parameter

### DIFF
--- a/nebula-logger/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/main/logger-engine/classes/Logger.cls
@@ -207,7 +207,7 @@ global with sharing class Logger {
 
     // ERROR logging level methods
     public static LogEntryEventBuilder error(LogMessage logMessage, Exception apexException, List<String> topics) {
-        return error().setMessage(logMessage).setTopics(topics).setExceptionDetails(apexException);
+        return error().setMessage(logMessage).setExceptionDetails(apexException).setTopics(topics);
     }
 
     global static LogEntryEventBuilder error(LogMessage logMessage, Exception apexException) {
@@ -215,7 +215,7 @@ global with sharing class Logger {
     }
 
     public static LogEntryEventBuilder error(LogMessage logMessage, Id recordId, Exception apexException, List<String> topics) {
-        return error().setMessage(logMessage).setRecordId(recordId).setTopics(topics).setExceptionDetails(apexException);
+        return error().setMessage(logMessage).setRecordId(recordId).setExceptionDetails(apexException).setTopics(topics);
     }
 
     global static LogEntryEventBuilder error(LogMessage logMessage, Id recordId, Exception apexException) {
@@ -235,7 +235,7 @@ global with sharing class Logger {
     }
 
     public static LogEntryEventBuilder error(LogMessage logMessage, SObject record, Exception apexException, List<String> topics) {
-        return error().setMessage(logMessage).setRecordId(record).setTopics(topics).setExceptionDetails(apexException);
+        return error().setMessage(logMessage).setRecordId(record).setExceptionDetails(apexException).setTopics(topics);
     }
 
     global static LogEntryEventBuilder error(LogMessage logMessage, SObject record, Exception apexException) {
@@ -255,7 +255,7 @@ global with sharing class Logger {
     }
 
     public static LogEntryEventBuilder error(String message, Exception apexException, List<String> topics) {
-        return error().setMessage(message).setTopics(topics).setExceptionDetails(apexException);
+        return error().setMessage(message).setExceptionDetails(apexException).setTopics(topics);
     }
 
     global static LogEntryEventBuilder error(String message, Exception apexException) {
@@ -263,7 +263,7 @@ global with sharing class Logger {
     }
 
     public static LogEntryEventBuilder error(String message, Id recordId, Exception apexException, List<String> topics) {
-        return error().setMessage(message).setRecordId(recordId).setTopics(topics).setExceptionDetails(apexException);
+        return error().setMessage(message).setRecordId(recordId).setExceptionDetails(apexException).setTopics(topics);
     }
 
     global static LogEntryEventBuilder error(String message, Id recordId, Exception apexException) {
@@ -283,7 +283,7 @@ global with sharing class Logger {
     }
 
     public static LogEntryEventBuilder error(String message, SObject record, Exception apexException, List<String> topics) {
-        return error().setMessage(message).setRecordId(record).setTopics(topics).setExceptionDetails(apexException);
+        return error().setMessage(message).setRecordId(record).setExceptionDetails(apexException).setTopics(topics);
     }
 
     global static LogEntryEventBuilder error(String message, SObject record, Exception apexException) {
@@ -303,6 +303,22 @@ global with sharing class Logger {
     }
 
     // WARN logging level methods
+    public static LogEntryEventBuilder warn(LogMessage logMessage, Exception apexException, List<String> topics) {
+        return warn().setMessage(logMessage).setExceptionDetails(apexException).setTopics(topics);
+    }
+
+    global static LogEntryEventBuilder warn(LogMessage logMessage, Exception apexException) {
+        return warn().setMessage(logMessage).setExceptionDetails(apexException);
+    }
+
+    public static LogEntryEventBuilder warn(LogMessage logMessage, Id recordId, Exception apexException, List<String> topics) {
+        return warn().setMessage(logMessage).setRecordId(recordId).setExceptionDetails(apexException).setTopics(topics);
+    }
+
+    global static LogEntryEventBuilder warn(LogMessage logMessage, Id recordId, Exception apexException) {
+        return warn().setMessage(logMessage).setRecordId(recordId).setExceptionDetails(apexException);
+    }
+
     public static LogEntryEventBuilder warn(LogMessage logMessage, Id recordId, List<String> topics) {
         return warn().setMessage(logMessage).setRecordId(recordId).setTopics(topics);
     }
@@ -313,6 +329,14 @@ global with sharing class Logger {
 
     public static LogEntryEventBuilder warn(LogMessage logMessage, List<String> topics) {
         return warn().setMessage(logMessage).setTopics(topics);
+    }
+
+    public static LogEntryEventBuilder warn(LogMessage logMessage, SObject record, Exception apexException, List<String> topics) {
+        return warn().setMessage(logMessage).setRecordId(record).setExceptionDetails(apexException).setTopics(topics);
+    }
+
+    global static LogEntryEventBuilder warn(LogMessage logMessage, SObject record, Exception apexException) {
+        return warn().setMessage(logMessage).setRecordId(record).setExceptionDetails(apexException);
     }
 
     public static LogEntryEventBuilder warn(LogMessage logMessage, SObject record, List<String> topics) {
@@ -327,6 +351,22 @@ global with sharing class Logger {
         return warn().setMessage(logMessage);
     }
 
+    public static LogEntryEventBuilder warn(String message, Exception apexException, List<String> topics) {
+        return warn().setMessage(message).setExceptionDetails(apexException).setTopics(topics);
+    }
+
+    global static LogEntryEventBuilder warn(String message, Exception apexException) {
+        return warn().setMessage(message).setExceptionDetails(apexException);
+    }
+
+    public static LogEntryEventBuilder warn(String message, Id recordId, Exception apexException, List<String> topics) {
+        return warn().setMessage(message).setRecordId(recordId).setExceptionDetails(apexException).setTopics(topics);
+    }
+
+    global static LogEntryEventBuilder warn(String message, Id recordId, Exception apexException) {
+        return warn().setMessage(message).setRecordId(recordId).setExceptionDetails(apexException);
+    }
+
     public static LogEntryEventBuilder warn(String message, Id recordId, List<String> topics) {
         return warn().setMessage(message).setRecordId(recordId).setTopics(topics);
     }
@@ -337,6 +377,14 @@ global with sharing class Logger {
 
     public static LogEntryEventBuilder warn(String message, List<String> topics) {
         return warn().setMessage(message).setTopics(topics);
+    }
+
+    public static LogEntryEventBuilder warn(String message, SObject record, Exception apexException, List<String> topics) {
+        return warn().setMessage(message).setRecordId(record).setExceptionDetails(apexException).setTopics(topics);
+    }
+
+    global static LogEntryEventBuilder warn(String message, SObject record, Exception apexException) {
+        return warn().setMessage(message).setRecordId(record).setExceptionDetails(apexException);
     }
 
     public static LogEntryEventBuilder warn(String message, SObject record, List<String> topics) {

--- a/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
@@ -1021,6 +1021,94 @@ private class Logger_Tests {
 
     // Start WARN methods for LogMessage
     @isTest
+    static void it_should_add_an_warn_entry_for_logMessage_with_exception_and_topics() {
+        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        setUserLoggingLevel(loggingLevel);
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Test.startTest();
+
+        LogEntryEventBuilder entryBuilder = Logger.warn(getLogMessage(), getException(), getTopics());
+
+        Test.stopTest();
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.assertEquals(String.join(getTopics(), ','), entryBuilder.getLogEntryEvent().Topics__c);
+    }
+
+    @isTest
+    static void it_should_add_an_warn_entry_for_logMessage_with_exception() {
+        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        setUserLoggingLevel(loggingLevel);
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Test.startTest();
+
+        LogEntryEventBuilder entryBuilder = Logger.warn(getLogMessage(), getException());
+
+        Test.stopTest();
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().Topics__c);
+    }
+
+    @isTest
+    static void it_should_add_an_warn_entry_for_logMessage_with_recordId_and_exception_and_topics() {
+        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        setUserLoggingLevel(loggingLevel);
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Test.startTest();
+
+        LogEntryEventBuilder entryBuilder = Logger.warn(getLogMessage(), getRecord().Id, getException(), getTopics());
+
+        Test.stopTest();
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.assertEquals(String.join(getTopics(), ','), entryBuilder.getLogEntryEvent().Topics__c);
+    }
+
+    @isTest
+    static void it_should_add_an_warn_entry_for_logMessage_with_recordId_and_exception() {
+        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        setUserLoggingLevel(loggingLevel);
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Test.startTest();
+
+        LogEntryEventBuilder entryBuilder = Logger.warn(getLogMessage(), getRecord().Id, getException());
+
+        Test.stopTest();
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().Topics__c);
+    }
+
+    @isTest
     static void it_should_add_an_warn_entry_for_logMessage_with_recordId_and_topics() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
@@ -1080,6 +1168,50 @@ private class Logger_Tests {
         System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
         System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
         System.assertEquals(String.join(getTopics(), ','), entryBuilder.getLogEntryEvent().Topics__c);
+    }
+
+    @isTest
+    static void it_should_add_an_warn_entry_for_logMessage_with_record_and_exception_and_topics() {
+        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        setUserLoggingLevel(loggingLevel);
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Test.startTest();
+
+        LogEntryEventBuilder entryBuilder = Logger.warn(getLogMessage(), getRecord(), getException(), getTopics());
+
+        Test.stopTest();
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(Json.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.assertEquals(String.join(getTopics(), ','), entryBuilder.getLogEntryEvent().Topics__c);
+    }
+
+    @isTest
+    static void it_should_add_an_warn_entry_for_logMessage_with_record_and_exception() {
+        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        setUserLoggingLevel(loggingLevel);
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Test.startTest();
+
+        LogEntryEventBuilder entryBuilder = Logger.warn(getLogMessage(), getRecord(), getException());
+
+        Test.stopTest();
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(Json.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().Topics__c);
     }
 
     @isTest
@@ -1147,8 +1279,97 @@ private class Logger_Tests {
         System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
         System.assertEquals(null, entryBuilder.getLogEntryEvent().Topics__c);
     }
+    // End WARN methods for LogMessage
 
     // Start WARN methods for String
+    @isTest
+    static void it_should_add_an_warn_entry_for_string_message_with_exception_and_topics() {
+        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        setUserLoggingLevel(loggingLevel);
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Test.startTest();
+
+        LogEntryEventBuilder entryBuilder = Logger.warn(getMessage(), getException(), getTopics());
+
+        Test.stopTest();
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.assertEquals(String.join(getTopics(), ','), entryBuilder.getLogEntryEvent().Topics__c);
+    }
+
+    @isTest
+    static void it_should_add_an_warn_entry_for_string_message_with_exception() {
+        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        setUserLoggingLevel(loggingLevel);
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Test.startTest();
+
+        LogEntryEventBuilder entryBuilder = Logger.warn(getMessage(), getException());
+
+        Test.stopTest();
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().Topics__c);
+    }
+
+    @isTest
+    static void it_should_add_an_warn_entry_for_string_message_with_recordId_and_exception_and_topics() {
+        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        setUserLoggingLevel(loggingLevel);
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Test.startTest();
+
+        LogEntryEventBuilder entryBuilder = Logger.warn(getMessage(), getRecord().Id, getException(), getTopics());
+
+        Test.stopTest();
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.assertEquals(String.join(getTopics(), ','), entryBuilder.getLogEntryEvent().Topics__c);
+    }
+
+    @isTest
+    static void it_should_add_an_warn_entry_for_string_message_with_recordId_and_exception() {
+        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        setUserLoggingLevel(loggingLevel);
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Test.startTest();
+
+        LogEntryEventBuilder entryBuilder = Logger.warn(getMessage(), getRecord().Id, getException());
+
+        Test.stopTest();
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().Topics__c);
+    }
+
     @isTest
     static void it_should_add_an_warn_entry_for_string_message_with_recordId_and_topics() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
@@ -1209,6 +1430,50 @@ private class Logger_Tests {
         System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
         System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
         System.assertEquals(String.join(getTopics(), ','), entryBuilder.getLogEntryEvent().Topics__c);
+    }
+
+    @isTest
+    static void it_should_add_an_warn_entry_for_string_message_with_record_and_exception_and_topics() {
+        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        setUserLoggingLevel(loggingLevel);
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Test.startTest();
+
+        LogEntryEventBuilder entryBuilder = Logger.warn(getMessage(), getRecord(), getException(), getTopics());
+
+        Test.stopTest();
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(Json.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.assertEquals(String.join(getTopics(), ','), entryBuilder.getLogEntryEvent().Topics__c);
+    }
+
+    @isTest
+    static void it_should_add_an_warn_entry_for_string_message_with_record_and_exception() {
+        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        setUserLoggingLevel(loggingLevel);
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Test.startTest();
+
+        LogEntryEventBuilder entryBuilder = Logger.warn(getMessage(), getRecord(), getException());
+
+        Test.stopTest();
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.assertEquals(Json.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.assertEquals(null, entryBuilder.getLogEntryEvent().Topics__c);
     }
 
     @isTest
@@ -1276,7 +1541,6 @@ private class Logger_Tests {
         System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
         System.assertEquals(null, entryBuilder.getLogEntryEvent().Topics__c);
     }
-
     // End WARN methods for String
 
     // Start INFO methods for LogMessage


### PR DESCRIPTION
Closes #86 - WARN and ERROR methods in `Logger` now have the same overloads, including overloads with `Exception apexException` as a parameter