### PR TITLE
Fixed some display issues in 'View JSON' quick action

### DIFF
--- a/nebula-logger/main/log-management/aura/logJSONViewer/logJSONViewer.cmp
+++ b/nebula-logger/main/log-management/aura/logJSONViewer/logJSONViewer.cmp
@@ -5,4 +5,29 @@
 <aura:component controller="Logger" implements="force:hasRecordId,force:lightningQuickActionWithoutHeader">
     <!-- TODO: recordId is a reserved keyword in LWC, can't name the variable recordId till LWC quick actions are GA -->
     <c:logViewer logId="{!v.recordId}"></c:logViewer>
+
+    <!-- Since quick actions don't support LWC yet, change some of the standard formatting that conflicts with lwc -->
+    <aura:html tag="style">
+        .cuf-content {
+            padding: 0 0rem !important;
+        }
+        .slds-p-around--medium {
+            padding: 0rem !important;
+        }
+        .slds-modal__content{
+            overflow-y:hidden !important;
+            height:unset !important;
+            max-height:unset !important;
+        }
+    </aura:html>
+
+    <!-- Make the quick action modal wider for desktop -->
+    <aura:if isTrue="{!$Browser.formFactor == 'DESKTOP'}">
+        <aura:html tag="style">
+            .slds-modal__container {
+                max-width : 85rem !important;
+                width     : 85% !important;
+            }
+        </aura:html>
+    </aura:if>
 </aura:component>

--- a/nebula-logger/main/log-management/aura/logJSONViewer/logJSONViewer.cmp
+++ b/nebula-logger/main/log-management/aura/logJSONViewer/logJSONViewer.cmp
@@ -6,7 +6,7 @@
     <!-- TODO: recordId is a reserved keyword in LWC, can't name the variable recordId till LWC quick actions are GA -->
     <c:logViewer logId="{!v.recordId}"></c:logViewer>
 
-    <!-- Since quick actions don't support LWC yet, change some of the standard formatting that conflicts with lwc -->
+    <!-- Fix some formatting issues that happen when displaying the lwc inside of aura inside of quick action modal -->
     <aura:html tag="style">
         .cuf-content {
             padding: 0 0rem !important;

--- a/nebula-logger/main/log-management/lwc/logViewer/logViewer.css
+++ b/nebula-logger/main/log-management/lwc/logViewer/logViewer.css
@@ -11,6 +11,7 @@ pre {
 .slds-p-around--medium {
     padding: 0rem !important;
 }
+
 .slds-modal__content {
     overflow-y: hidden !important;
     height: unset !important;

--- a/nebula-logger/main/log-management/lwc/logViewer/logViewer.js
+++ b/nebula-logger/main/log-management/lwc/logViewer/logViewer.js
@@ -17,7 +17,17 @@ export default class LogJSONViewer extends LightningElement {
     jsonCopied = false;
 
     get logJSON() {
-        return this.log.data ? JSON.stringify(this.log.data, null, '\t') : '';
+        let formattedLog;
+        // Sort the keys (fields) in the log object
+        if (this.log.data) {
+            formattedLog = Object.keys(this.log.data)
+                .sort()
+                .reduce((obj, key) => {
+                    obj[key] = this.log.data[key];
+                    return obj;
+                }, {});
+        }
+        return formattedLog ? JSON.stringify(formattedLog, null, '\t') : '';
     }
 
     get title() {
@@ -52,6 +62,6 @@ export default class LogJSONViewer extends LightningElement {
 
         setTimeout(() => {
             this.jsonCopied = false;
-        }, 5000)
+        }, 5000);
     }
 }


### PR DESCRIPTION
I fixed a few UI issues in the the 'View JSON' quick action

- Fixed issue with some double-scrollbar weirdness 
- Fixed alignment of footer so it goes the full width of the modal
- Enhancement: log JSON now has the fields sorted alphabetically
- Enhancement: re-added some extra HTML overrides in the aura wrapper component to make the quick action's modal wider.

**Before**
![image](https://user-images.githubusercontent.com/1267157/109607839-b2bca280-7add-11eb-941e-6a5dfada5cfa.png)

**After**
![image](https://user-images.githubusercontent.com/1267157/109609462-34153480-7ae0-11eb-99ff-4455b70e2df1.png)

