### PR TITLE
Added log fields for "release number" and "release version"

### DIFF
--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -10,6 +10,9 @@
 public without sharing class LogEntryEventHandler {
     private static final Log__c LOG = new Log__c();
 
+    @TestVisible
+    private static Boolean shouldCallStatusApi = Test.isRunningTest() == false;
+
     private List<LogEntry__c> logEntries;
     private Map<LogEntry__c, List<String>> logEntryToTopics;
     private Set<String> topicNames;
@@ -100,8 +103,7 @@ public without sharing class LogEntryEventHandler {
         upsert LOG TransactionId__c;
 
         // If no recent logs have the details, and there is not another instance of the job in progress, then start a new one
-        // TODO probably need to remove the check for Test.isRunningTest() == false/add callout mocks to unit tests
-        if (Test.isRunningTest() == false && recentLogWithDetails == null == true && getCountOfOpenJobs() == 0) {
+        if (shouldCallStatusApi == true && recentLogWithDetails == null && getCountOfOpenJobs() == 0) {
             setStatusApiDetails();
         }
     }
@@ -269,22 +271,40 @@ public without sharing class LogEntryEventHandler {
         request.setMethod('GET');
 
         HttpResponse response = new Http().send(request);
+
+        if (response.getStatusCode() >= 400) {
+            String errorMessage =
+                'Callout failed for ' +
+                statusApiEndpoint +
+                '\nReceived request status code ' +
+                response.getStatusCode() +
+                ', status message: ' +
+                response.getStatus();
+            throw new StatusApiResponseException(errorMessage);
+        }
+
         StatusApiResponse statusApiResponse = (StatusApiResponse) JSON.deserialize(response.getBody(), StatusApiResponse.class);
         System.debug('statusApiResponse==' + statusApiResponse);
 
         List<Log__c> logsToUpdate = new List<Log__c>();
-        for (Log__c log : [SELECT Id FROM Log__c WHERE DAY_ONLY(CreatedDate) = TODAY AND ApiReleaseNumber__c = NULL FOR UPDATE]) {
+        for (Log__c log : [SELECT Id FROM Log__c WHERE DAY_ONLY(CreatedDate) = TODAY AND ApiReleaseNumber__c = NULL ORDER BY CreatedDate LIMIT :Limits.getLimitDmlRows()]) {
             log.ApiReleaseNumber__c = statusApiResponse.releaseNumber;
             log.ApiReleaseVersion__c = statusApiResponse.releaseVersion;
 
             logsToUpdate.add(log);
         }
+        System.debug('logsToUpdate==' + logsToUpdate);
         update logsToUpdate;
     }
 
     // Private class for handling the response from api.status.salesforce.com
+    @TestVisible
     private class StatusApiResponse {
         public String releaseNumber { get; set; }
         public String releaseVersion { get; set; }
+    }
+
+    @TestVisible
+    private class StatusApiResponseException extends Exception {
     }
 }

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -89,10 +89,27 @@ public without sharing class LogEntryEventHandler {
         LOG.UserRoleName__c = logEntryEvent.UserRoleName__c;
         LOG.UserType__c = logEntryEvent.UserType__c;
 
+        // To avoid making a callout for every log, try to query recent logs first
+        Datetime eightHoursAgo = System.now().addMinutes(-8 * 60);
+        List<Log__c> recentLogsWithDetails = [
+            SELECT Id, ApiReleaseNumber__c, ApiReleaseVersion__c
+            FROM Log__c
+            WHERE CreatedDate >= :eightHoursAgo AND DAY_ONLY(CreatedDate) = :System.today() AND ApiReleaseNumber__c != NULL
+            LIMIT 1
+        ];
+
+        // If there are recent logs with the details already populated, copy the field values before upserting the log
+        if (recentLogsWithDetails.isEmpty() == false) {
+            LOG.ApiReleaseNumber__c = recentLogsWithDetails.get(0).ApiReleaseNumber__c;
+            LOG.ApiReleaseVersion__c = recentLogsWithDetails.get(0).ApiReleaseVersion__c;
+        }
+
         upsert LOG TransactionId__c;
 
-        // TODO improve this - try to avoid making a callout for every log
-        setSalesforceStatusSiteDetails(LOG.Id);
+        // If no recent logs have the details, then resort to making an async callout to update the log
+        if (recentLogsWithDetails.isEmpty() == true) {
+            setStatusApiDetails(LOG.Id);
+        }
     }
 
     private void insertLogEntries(List<LogEntryEvent__e> logEntryEvents) {
@@ -214,39 +231,27 @@ public without sharing class LogEntryEventHandler {
     }
 
     @future(callout=true)
-    private static void setSalesforceStatusSiteDetails(Id logId) {
-        System.debug('starting getSalesforceStatusSiteResponse()');
-        // TODO cleanup/finish try-catch
-        //try {
-            // TODO might be able to eliminate this query by looking at first `LogEntryEvent__e` record
-            Organization organization = [SELECT InstanceName FROM Organization];
+    private static void setStatusApiDetails(Id logId) {
+        System.debug('Running setStatusApiDetails(Id logId), logId==' + logId);
 
-            String statusApiEndpoint = 'https://api.status.salesforce.com/v1/instances/' + organization.InstanceName + '/status';
+        Organization organization = [SELECT InstanceName FROM Organization];
+        String statusApiEndpoint = 'https://api.status.salesforce.com/v1/instances/' + organization.InstanceName + '/status';
 
-            HttpRequest request = new HttpRequest();
-            request.setEndpoint(statusApiEndpoint);
-            request.setMethod('GET');
+        HttpRequest request = new HttpRequest();
+        request.setEndpoint(statusApiEndpoint);
+        request.setMethod('GET');
 
-            HttpResponse response = new Http().send(request);
-            System.debug('SITE STATUS API RESPONSE==' + response.getBody());
-            SalesforceStatusSiteResponse statusApiResponse = (SalesforceStatusSiteResponse)JSON.deserialize(response.getBody(), SalesforceStatusSiteResponse.class);
+        HttpResponse response = new Http().send(request);
+        System.debug('Status API response==' + response.getBody());
+        StatusApiResponse statusApiResponse = (StatusApiResponse) JSON.deserialize(response.getBody(), StatusApiResponse.class);
 
-            Log__c log = new Log__c(
-                Id = logId,
-                ApiReleaseNumber__c = statusApiResponse?.releaseNumber,
-                ApiReleaseVersion__c = statusApiResponse?.releaseVersion
-            );
-            update log;
-        // } catch(Exception ex) {
-        //     // Eat any exceptions - it's better successfully log the entries without this info...
-        //     // ...instead of letting the exception ruin everything
-        //     return null;
-        // }
+        Log__c log = new Log__c(Id = logId, ApiReleaseNumber__c = statusApiResponse.releaseNumber, ApiReleaseVersion__c = statusApiResponse.releaseVersion);
+        update log;
     }
 
     // Private class for handling the response from api.status.salesforce.com
-    private class SalesforceStatusSiteResponse {
-        public String releaseNumber {get; set;}
-        public String releaseVersion {get; set;}
+    private class StatusApiResponse {
+        public String releaseNumber { get; set; }
+        public String releaseVersion { get; set; }
     }
 }

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -90,6 +90,9 @@ public without sharing class LogEntryEventHandler {
         LOG.UserType__c = logEntryEvent.UserType__c;
 
         upsert LOG TransactionId__c;
+
+        // TODO improve this - try to avoid making a callout for every log
+        setSalesforceStatusSiteDetails(LOG.Id);
     }
 
     private void insertLogEntries(List<LogEntryEvent__e> logEntryEvents) {
@@ -208,5 +211,42 @@ public without sharing class LogEntryEventHandler {
             }
         }
         insert new List<TopicAssignment>(topicAssignments);
+    }
+
+    @future(callout=true)
+    private static void setSalesforceStatusSiteDetails(Id logId) {
+        System.debug('starting getSalesforceStatusSiteResponse()');
+        // TODO cleanup/finish try-catch
+        //try {
+            // TODO might be able to eliminate this query by looking at first `LogEntryEvent__e` record
+            Organization organization = [SELECT InstanceName FROM Organization];
+
+            String statusApiEndpoint = 'https://api.status.salesforce.com/v1/instances/' + organization.InstanceName + '/status';
+
+            HttpRequest request = new HttpRequest();
+            request.setEndpoint(statusApiEndpoint);
+            request.setMethod('GET');
+
+            HttpResponse response = new Http().send(request);
+            System.debug('SITE STATUS API RESPONSE==' + response.getBody());
+            SalesforceStatusSiteResponse statusApiResponse = (SalesforceStatusSiteResponse)JSON.deserialize(response.getBody(), SalesforceStatusSiteResponse.class);
+
+            Log__c log = new Log__c(
+                Id = logId,
+                ApiReleaseNumber__c = statusApiResponse?.releaseNumber,
+                ApiReleaseVersion__c = statusApiResponse?.releaseVersion
+            );
+            update log;
+        // } catch(Exception ex) {
+        //     // Eat any exceptions - it's better successfully log the entries without this info...
+        //     // ...instead of letting the exception ruin everything
+        //     return null;
+        // }
+    }
+
+    // Private class for handling the response from api.status.salesforce.com
+    private class SalesforceStatusSiteResponse {
+        public String releaseNumber {get; set;}
+        public String releaseVersion {get; set;}
     }
 }

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -90,18 +90,18 @@ public without sharing class LogEntryEventHandler {
         LOG.UserType__c = logEntryEvent.UserType__c;
 
         // To avoid making a callout for every log, try to query recent logs first
-        // If there are recent logs with the details already populated, copy the field values before upserting the log
-        List<Log__c> recentLogsWithDetails = getRecentLogsWithDetails();
-        if (recentLogsWithDetails.isEmpty() == false) {
-            LOG.ApiReleaseNumber__c = recentLogsWithDetails.get(0).ApiReleaseNumber__c;
-            LOG.ApiReleaseVersion__c = recentLogsWithDetails.get(0).ApiReleaseVersion__c;
+        // If there is a recent log with the details already populated, copy the field values before upserting the log
+        Log__c recentLogWithDetails = getRecentLogWithDetails();
+        if (recentLogWithDetails != null) {
+            LOG.ApiReleaseNumber__c = recentLogWithDetails.ApiReleaseNumber__c;
+            LOG.ApiReleaseVersion__c = recentLogWithDetails.ApiReleaseVersion__c;
         }
 
         upsert LOG TransactionId__c;
 
         // If no recent logs have the details, and there is not another instance of the job in progress, then start a new one
         // TODO probably need to remove the check for Test.isRunningTest() == false/add callout mocks to unit tests
-        if (Test.isRunningTest() == false && recentLogsWithDetails.isEmpty() == true && getCountOfOpenJobs() == 0) {
+        if (Test.isRunningTest() == false && recentLogWithDetails == null == true && getCountOfOpenJobs() == 0) {
             setStatusApiDetails();
         }
     }
@@ -225,19 +225,25 @@ public without sharing class LogEntryEventHandler {
     }
 
     // Private static methods
-    private static List<Log__c> getRecentLogsWithDetails() {
+    private static Log__c getRecentLogWithDetails() {
         // Query for recent logs created only today - the status API should be called...
         // ...at least once per day to make sure that status details are still accurate.
         // This query should make a callout approximately every 4 hours.
         Datetime fourHoursAgo = System.now().addMinutes(-4 * 60);
 
-        return [
+        List<Log__c> logs = [
             SELECT Id, ApiReleaseNumber__c, ApiReleaseVersion__c
             FROM Log__c
             WHERE CreatedDate >= :fourHoursAgo AND DAY_ONLY(CreatedDate) = TODAY AND ApiReleaseNumber__c != NULL
             ORDER BY CreatedDate DESC
             LIMIT 1
         ];
+
+        if (logs.isEmpty()) {
+            return null;
+        } else {
+            return logs.get(0);
+        }
     }
 
     private static Integer getCountOfOpenJobs() {
@@ -267,7 +273,7 @@ public without sharing class LogEntryEventHandler {
         System.debug('statusApiResponse==' + statusApiResponse);
 
         List<Log__c> logsToUpdate = new List<Log__c>();
-        for (Log__c log : [SELECT Id FROM Log__c WHERE DAY_ONLY(CreatedDate) = TODAY AND ApiReleaseNumber__c = NULL]) {
+        for (Log__c log : [SELECT Id FROM Log__c WHERE DAY_ONLY(CreatedDate) = TODAY AND ApiReleaseNumber__c = NULL FOR UPDATE]) {
             log.ApiReleaseNumber__c = statusApiResponse.releaseNumber;
             log.ApiReleaseVersion__c = statusApiResponse.releaseVersion;
 

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -226,14 +226,15 @@ public without sharing class LogEntryEventHandler {
 
     // Private static methods
     private static List<Log__c> getRecentLogsWithDetails() {
-        // Query for recent logs created only today - the status API should be called at least...
-        // ... once per day to make sure that status details are still accurate
-        Datetime sixHoursAgo = System.now().addMinutes(-6 * 60);
+        // Query for recent logs created only today - the status API should be called...
+        // ...at least once per day to make sure that status details are still accurate.
+        // This query should make a callout approximately every 4 hours.
+        Datetime fourHoursAgo = System.now().addMinutes(-4 * 60);
 
         return [
             SELECT Id, ApiReleaseNumber__c, ApiReleaseVersion__c
             FROM Log__c
-            WHERE CreatedDate >= :sixHoursAgo AND DAY_ONLY(CreatedDate) = TODAY AND ApiReleaseNumber__c != NULL
+            WHERE CreatedDate >= :fourHoursAgo AND DAY_ONLY(CreatedDate) = TODAY AND ApiReleaseNumber__c != NULL
             ORDER BY CreatedDate DESC
             LIMIT 1
         ];

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -101,7 +101,8 @@ public without sharing class LogEntryEventHandler {
         upsert LOG TransactionId__c;
 
         // If no recent logs have the details, and there is not another instance of the job in progress, then start a new one
-        if (recentLogsWithDetails.isEmpty() == true && getCountOfOpenJobs() == 0) {
+        // TODO probably need to remove the check for Test.isRunningTest() == false
+        if (Test.isRunningTest() == false && recentLogsWithDetails.isEmpty() == true && getCountOfOpenJobs() == 0) {
             System.enqueueJob(new QueueableStatusApiCaller());
         }
     }

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -89,7 +89,6 @@ public without sharing class LogEntryEventHandler {
         LOG.UserRoleName__c = logEntryEvent.UserRoleName__c;
         LOG.UserType__c = logEntryEvent.UserType__c;
 
-        // TODO cleanup
         // To avoid making a callout for every log, try to query recent logs first
         // If there are recent logs with the details already populated, copy the field values before upserting the log
         List<Log__c> recentLogsWithDetails = getRecentLogsWithDetails();
@@ -101,9 +100,9 @@ public without sharing class LogEntryEventHandler {
         upsert LOG TransactionId__c;
 
         // If no recent logs have the details, and there is not another instance of the job in progress, then start a new one
-        // TODO probably need to remove the check for Test.isRunningTest() == false
+        // TODO probably need to remove the check for Test.isRunningTest() == false/add callout mocks to unit tests
         if (Test.isRunningTest() == false && recentLogsWithDetails.isEmpty() == true && getCountOfOpenJobs() == 0) {
-            System.enqueueJob(new QueueableStatusApiCaller());
+            setStatusApiDetails();
         }
     }
 
@@ -227,12 +226,15 @@ public without sharing class LogEntryEventHandler {
 
     // Private static methods
     private static List<Log__c> getRecentLogsWithDetails() {
-        Datetime eightHoursAgo = System.now().addMinutes(-8 * 60);
+        // Query for recent logs created only today - the status API should be called at least...
+        // ... once per day to make sure that status details are still accurate
+        Datetime sixHoursAgo = System.now().addMinutes(-6 * 60);
 
         return [
             SELECT Id, ApiReleaseNumber__c, ApiReleaseVersion__c
             FROM Log__c
-            WHERE CreatedDate >= :eightHoursAgo AND DAY_ONLY(CreatedDate) = :System.today() AND ApiReleaseNumber__c != NULL
+            WHERE CreatedDate >= :sixHoursAgo AND DAY_ONLY(CreatedDate) = TODAY AND ApiReleaseNumber__c != NULL
+            ORDER BY CreatedDate DESC
             LIMIT 1
         ];
     }
@@ -241,36 +243,36 @@ public without sharing class LogEntryEventHandler {
         return [
             SELECT COUNT()
             FROM AsyncApexJob
-            WHERE ApexClass.Name = :QueueableStatusApiCaller.class.getName() AND Status IN ('Holding', 'Queued', 'Preparing', 'Processing')
+            WHERE
+                ApexClass.Name = :LogEntryEventHandler.class.getName()
+                AND MethodName = 'setStatusApiDetails'
+                AND Status IN ('Holding', 'Queued', 'Preparing', 'Processing')
         ];
     }
 
-    // Private class for calling the Status API and updating `Log__c` records
-    // TODO this name is terrible
-    private class QueueableStatusApiCaller implements Queueable, Database.AllowsCallouts {
-        public void execute(System.QueueableContext queueableContext) {
-            System.debug('Running QueueableStatusApiCaller.execute(System.QueueableContext queueableContext)');
+    @future(callout=true)
+    private static void setStatusApiDetails() {
+        System.debug('Running setStatusApiDetails()');
 
-            Organization organization = [SELECT InstanceName FROM Organization];
-            String statusApiEndpoint = 'https://api.status.salesforce.com/v1/instances/' + organization.InstanceName + '/status';
+        Organization organization = [SELECT InstanceName FROM Organization];
+        String statusApiEndpoint = 'https://api.status.salesforce.com/v1/instances/' + organization.InstanceName + '/status';
 
-            HttpRequest request = new HttpRequest();
-            request.setEndpoint(statusApiEndpoint);
-            request.setMethod('GET');
+        HttpRequest request = new HttpRequest();
+        request.setEndpoint(statusApiEndpoint);
+        request.setMethod('GET');
 
-            HttpResponse response = new Http().send(request);
-            StatusApiResponse statusApiResponse = (StatusApiResponse) JSON.deserialize(response.getBody(), StatusApiResponse.class);
-            System.debug('statusApiResponse==' + statusApiResponse);
+        HttpResponse response = new Http().send(request);
+        StatusApiResponse statusApiResponse = (StatusApiResponse) JSON.deserialize(response.getBody(), StatusApiResponse.class);
+        System.debug('statusApiResponse==' + statusApiResponse);
 
-            List<Log__c> logsToUpdate = new List<Log__c>();
-            for (Log__c log : [SELECT Id FROM Log__c WHERE DAY_ONLY(CreatedDate) = TODAY AND ApiReleaseNumber__c = NULL]) {
-                log.ApiReleaseNumber__c = statusApiResponse.releaseNumber;
-                log.ApiReleaseVersion__c = statusApiResponse.releaseVersion;
+        List<Log__c> logsToUpdate = new List<Log__c>();
+        for (Log__c log : [SELECT Id FROM Log__c WHERE DAY_ONLY(CreatedDate) = TODAY AND ApiReleaseNumber__c = NULL]) {
+            log.ApiReleaseNumber__c = statusApiResponse.releaseNumber;
+            log.ApiReleaseVersion__c = statusApiResponse.releaseVersion;
 
-                logsToUpdate.add(log);
-            }
-            update logsToUpdate;
+            logsToUpdate.add(log);
         }
+        update logsToUpdate;
     }
 
     // Private class for handling the response from api.status.salesforce.com

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -89,16 +89,10 @@ public without sharing class LogEntryEventHandler {
         LOG.UserRoleName__c = logEntryEvent.UserRoleName__c;
         LOG.UserType__c = logEntryEvent.UserType__c;
 
+        // TODO cleanup
         // To avoid making a callout for every log, try to query recent logs first
-        Datetime eightHoursAgo = System.now().addMinutes(-8 * 60);
-        List<Log__c> recentLogsWithDetails = [
-            SELECT Id, ApiReleaseNumber__c, ApiReleaseVersion__c
-            FROM Log__c
-            WHERE CreatedDate >= :eightHoursAgo AND DAY_ONLY(CreatedDate) = :System.today() AND ApiReleaseNumber__c != NULL
-            LIMIT 1
-        ];
-
         // If there are recent logs with the details already populated, copy the field values before upserting the log
+        List<Log__c> recentLogsWithDetails = getRecentLogsWithDetails();
         if (recentLogsWithDetails.isEmpty() == false) {
             LOG.ApiReleaseNumber__c = recentLogsWithDetails.get(0).ApiReleaseNumber__c;
             LOG.ApiReleaseVersion__c = recentLogsWithDetails.get(0).ApiReleaseVersion__c;
@@ -106,9 +100,9 @@ public without sharing class LogEntryEventHandler {
 
         upsert LOG TransactionId__c;
 
-        // If no recent logs have the details, then resort to making an async callout to update the log
-        if (recentLogsWithDetails.isEmpty() == true) {
-            setStatusApiDetails(LOG.Id);
+        // If no recent logs have the details, and there is not another instance of the job in progress, then start a new one
+        if (recentLogsWithDetails.isEmpty() == true && getCountOfOpenJobs() == 0) {
+            System.enqueueJob(new QueueableStatusApiCaller());
         }
     }
 
@@ -230,23 +224,52 @@ public without sharing class LogEntryEventHandler {
         insert new List<TopicAssignment>(topicAssignments);
     }
 
-    @future(callout=true)
-    private static void setStatusApiDetails(Id logId) {
-        System.debug('Running setStatusApiDetails(Id logId), logId==' + logId);
+    // Private static methods
+    private static List<Log__c> getRecentLogsWithDetails() {
+        Datetime eightHoursAgo = System.now().addMinutes(-8 * 60);
 
-        Organization organization = [SELECT InstanceName FROM Organization];
-        String statusApiEndpoint = 'https://api.status.salesforce.com/v1/instances/' + organization.InstanceName + '/status';
+        return [
+            SELECT Id, ApiReleaseNumber__c, ApiReleaseVersion__c
+            FROM Log__c
+            WHERE CreatedDate >= :eightHoursAgo AND DAY_ONLY(CreatedDate) = :System.today() AND ApiReleaseNumber__c != NULL
+            LIMIT 1
+        ];
+    }
 
-        HttpRequest request = new HttpRequest();
-        request.setEndpoint(statusApiEndpoint);
-        request.setMethod('GET');
+    private static Integer getCountOfOpenJobs() {
+        return [
+            SELECT COUNT()
+            FROM AsyncApexJob
+            WHERE ApexClass.Name = :QueueableStatusApiCaller.class.getName() AND Status IN ('Holding', 'Queued', 'Preparing', 'Processing')
+        ];
+    }
 
-        HttpResponse response = new Http().send(request);
-        System.debug('Status API response==' + response.getBody());
-        StatusApiResponse statusApiResponse = (StatusApiResponse) JSON.deserialize(response.getBody(), StatusApiResponse.class);
+    // Private class for calling the Status API and updating `Log__c` records
+    // TODO this name is terrible
+    private class QueueableStatusApiCaller implements Queueable, Database.AllowsCallouts {
+        public void execute(System.QueueableContext queueableContext) {
+            System.debug('Running QueueableStatusApiCaller.execute(System.QueueableContext queueableContext)');
 
-        Log__c log = new Log__c(Id = logId, ApiReleaseNumber__c = statusApiResponse.releaseNumber, ApiReleaseVersion__c = statusApiResponse.releaseVersion);
-        update log;
+            Organization organization = [SELECT InstanceName FROM Organization];
+            String statusApiEndpoint = 'https://api.status.salesforce.com/v1/instances/' + organization.InstanceName + '/status';
+
+            HttpRequest request = new HttpRequest();
+            request.setEndpoint(statusApiEndpoint);
+            request.setMethod('GET');
+
+            HttpResponse response = new Http().send(request);
+            StatusApiResponse statusApiResponse = (StatusApiResponse) JSON.deserialize(response.getBody(), StatusApiResponse.class);
+            System.debug('statusApiResponse==' + statusApiResponse);
+
+            List<Log__c> logsToUpdate = new List<Log__c>();
+            for (Log__c log : [SELECT Id FROM Log__c WHERE DAY_ONLY(CreatedDate) = TODAY AND ApiReleaseNumber__c = NULL]) {
+                log.ApiReleaseNumber__c = statusApiResponse.releaseNumber;
+                log.ApiReleaseVersion__c = statusApiResponse.releaseVersion;
+
+                logsToUpdate.add(log);
+            }
+            update logsToUpdate;
+        }
     }
 
     // Private class for handling the response from api.status.salesforce.com

--- a/nebula-logger/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
+++ b/nebula-logger/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
@@ -669,7 +669,7 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.OrganizationDomainUrl__c</fieldItem>
+                <fieldItem>Record.OrganizationNamespacePrefix__c</fieldItem>
             </fieldInstance>
         </itemInstances>
         <name>Facet-c4a1f400-d677-4197-9c0c-60bb1e5b426d</name>
@@ -718,7 +718,7 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.OrganizationNamespacePrefix__c</fieldItem>
+                <fieldItem>Record.OrganizationDomainUrl__c</fieldItem>
             </fieldInstance>
         </itemInstances>
         <name>Facet-7a49dd50-62e1-43c4-a95b-81a04f2e4a8e</name>

--- a/nebula-logger/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
+++ b/nebula-logger/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
@@ -663,10 +663,6 @@
                 <fieldItem>Record.OrganizationEnvironmentType__c</fieldItem>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-c4a1f400-d677-4197-9c0c-60bb1e5b426d</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -676,6 +672,10 @@
                 <fieldItem>Record.OrganizationDomainUrl__c</fieldItem>
             </fieldInstance>
         </itemInstances>
+        <name>Facet-c4a1f400-d677-4197-9c0c-60bb1e5b426d</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -692,6 +692,24 @@
                     <value>readonly</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.ApiVersion__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.ApiReleaseVersion__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.ApiReleaseNumber__c</fieldItem>
             </fieldInstance>
         </itemInstances>
         <itemInstances>

--- a/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
+++ b/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
@@ -27,14 +27,6 @@
                 <behavior>Readonly</behavior>
                 <field>TotalLimitsCpuTimeUsed__c</field>
             </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>ApiReleaseNumber__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
-                <field>ApiReleaseVersion__c</field>
-            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
+++ b/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
@@ -264,10 +264,10 @@
             </layoutItems>
 			<layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OrganizationDomainUrl__c</field>
+                <field>OrganizationNamespacePrefix__c</field>
             </layoutItems>
         </layoutColumns>
-        <layoutColumns>            
+        <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>OrganizationInstanceName__c</field>
@@ -286,7 +286,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OrganizationNamespacePrefix__c</field>
+                <field>OrganizationDomainUrl__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>

--- a/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
+++ b/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
@@ -276,11 +276,11 @@
                 <behavior>Readonly</behavior>
                 <field>ApiVersion__c</field>
             </layoutItems>
-			<layoutItems>
+            <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>ApiReleaseVersion__c</field>
             </layoutItems>
-			<layoutItems>
+            <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>ApiReleaseNumber__c</field>
             </layoutItems>

--- a/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
+++ b/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
@@ -27,6 +27,14 @@
                 <behavior>Readonly</behavior>
                 <field>TotalLimitsCpuTimeUsed__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>ApiReleaseNumber__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>ApiReleaseVersion__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -262,12 +270,12 @@
                 <behavior>Readonly</behavior>
                 <field>OrganizationEnvironmentType__c</field>
             </layoutItems>
-        </layoutColumns>
-        <layoutColumns>
-            <layoutItems>
+			<layoutItems>
                 <behavior>Readonly</behavior>
                 <field>OrganizationDomainUrl__c</field>
             </layoutItems>
+        </layoutColumns>
+        <layoutColumns>            
             <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>OrganizationInstanceName__c</field>
@@ -275,6 +283,14 @@
             <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>ApiVersion__c</field>
+            </layoutItems>
+			<layoutItems>
+                <behavior>Readonly</behavior>
+                <field>ApiReleaseVersion__c</field>
+            </layoutItems>
+			<layoutItems>
+                <behavior>Readonly</behavior>
+                <field>ApiReleaseNumber__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>

--- a/nebula-logger/main/log-management/objects/Log__c/fields/ApiReleaseNumber__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/ApiReleaseNumber__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ApiReleaseNumber__c</fullName>
+    <description>The release number for the org&apos;s instance - determined by making a callout to trust.salesforce.com</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The release number for the org&apos;s instance - determined by making a callout to trust.salesforce.com</inlineHelpText>
+    <label>API Release Number</label>
+    <length>255</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/main/log-management/objects/Log__c/fields/ApiReleaseNumber__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/ApiReleaseNumber__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ApiReleaseNumber__c</fullName>
-    <description>The release number for the org&apos;s instance - determined by making a callout to trust.salesforce.com</description>
+    <description>The release number for the org&apos;s instance - determined by making a callout to status.salesforce.com</description>
     <externalId>false</externalId>
-    <inlineHelpText>The release number for the org&apos;s instance - determined by making a callout to trust.salesforce.com</inlineHelpText>
+    <inlineHelpText>The release number for the org&apos;s instance - determined by making a callout to status.salesforce.com</inlineHelpText>
     <label>API Release Number</label>
     <length>255</length>
     <required>false</required>

--- a/nebula-logger/main/log-management/objects/Log__c/fields/ApiReleaseVersion__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/ApiReleaseVersion__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ApiReleaseVersion__c</fullName>
+    <description>The release version for the org&apos;s instance - determined by making a callout to trust.salesforce.com</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The release version for the org&apos;s instance - determined by making a callout to trust.salesforce.com</inlineHelpText>
+    <label>API Release Version</label>
+    <length>255</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/main/log-management/objects/Log__c/fields/ApiReleaseVersion__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/ApiReleaseVersion__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ApiReleaseVersion__c</fullName>
-    <description>The release version for the org&apos;s instance - determined by making a callout to trust.salesforce.com</description>
+    <description>The release version for the org&apos;s instance - determined by making a callout to status.salesforce.com</description>
     <externalId>false</externalId>
-    <inlineHelpText>The release version for the org&apos;s instance - determined by making a callout to trust.salesforce.com</inlineHelpText>
+    <inlineHelpText>The release version for the org&apos;s instance - determined by making a callout to status.salesforce.com</inlineHelpText>
     <label>API Release Version</label>
     <length>255</length>
     <required>false</required>

--- a/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -447,6 +447,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.ApiReleaseNumber__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.ApiReleaseVersion__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.ApiVersion__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -400,6 +400,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.ApiReleaseNumber__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.ApiReleaseVersion__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.ApiVersion__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -407,6 +407,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.ApiReleaseNumber__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.ApiReleaseVersion__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.ApiVersion__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/log-management/remoteSiteSettings/Salesforce_Status_API.remoteSite-meta.xml
+++ b/nebula-logger/main/log-management/remoteSiteSettings/Salesforce_Status_API.remoteSite-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RemoteSiteSetting xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Used by Logger to retrieve additional details about the current org</description>
+    <disableProtocolSecurity>false</disableProtocolSecurity>
+    <isActive>true</isActive>
+    <url>https://api.status.salesforce.com</url>
+</RemoteSiteSetting>

--- a/nebula-logger/main/log-management/remoteSiteSettings/Salesforce_Status_API.remoteSite-meta.xml
+++ b/nebula-logger/main/log-management/remoteSiteSettings/Salesforce_Status_API.remoteSite-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <RemoteSiteSetting xmlns="http://soap.sforce.com/2006/04/metadata">
-    <description>Used by Logger to retrieve additional details about the current org</description>
+    <description>Used to retrieve additional details about the current org</description>
     <disableProtocolSecurity>false</disableProtocolSecurity>
     <isActive>true</isActive>
     <url>https://api.status.salesforce.com</url>

--- a/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -4,6 +4,9 @@
 //------------------------------------------------------------------------------------------------//
 @isTest
 private class LogEntryEventHandler_Tests {
+    private static final String MOCK_RELEASE_NUMBER = '230.12.2';
+    private static final String MOCK_RELEASE_VERSION = 'Spring \'21 Patch 12.2';
+
     static User getCurrentUser() {
         return [
             SELECT
@@ -24,6 +27,8 @@ private class LogEntryEventHandler_Tests {
     static Log__c getLog() {
         return [
             SELECT
+                ApiReleaseNumber__c,
+                ApiReleaseVersion__c,
                 ApiVersion__c,
                 Id,
                 Locale__c,
@@ -119,6 +124,29 @@ private class LogEntryEventHandler_Tests {
                 )
             FROM Log__c
         ];
+    }
+
+    private class SuccessCalloutMock implements HttpCalloutMock {
+        public HttpResponse respond(HttpRequest request) {
+            LogEntryEventHandler.StatusApiResponse apiResponse = new LogEntryEventHandler.StatusApiResponse();
+            apiResponse.releaseNumber = MOCK_RELEASE_NUMBER;
+            apiResponse.releaseVersion = MOCK_RELEASE_VERSION;
+
+            HttpResponse response = new HttpResponse();
+            response.setBody(JSON.serialize(apiResponse));
+            response.setHeader('Content-Type', 'application/json');
+            response.setStatusCode(200);
+
+            return response;
+        }
+    }
+
+    private class FailureCalloutMock implements HttpCalloutMock {
+        public HttpResponse respond(HttpRequest request) {
+            HttpResponse response = new HttpResponse();
+            response.setStatusCode(400);
+            return response;
+        }
     }
 
     static void validateLogFields(LogEntryEvent__e logEntryEvent, Log__c log) {
@@ -370,5 +398,79 @@ private class LogEntryEventHandler_Tests {
         for (TopicAssignment topicAssignment : topicAssignments) {
             System.assert(topicsSet.contains(topicAssignment.Topic.Name));
         }
+    }
+
+    @isTest
+    static void it_should_set_api_release_number_and_api_release_version_from_callout() {
+        Test.setMock(HttpCalloutMock.class, new SuccessCalloutMock());
+        LogEntryEventHandler.shouldCallStatusApi = true;
+
+        String transactionId = '123-456-789-0';
+        LogEntryEvent__e logEntryEvent = new LogEntryEvent__e(Message__c = 'my message', Timestamp__c = System.now(), TransactionId__c = transactionId);
+
+
+        Database.SaveResult saveResult;
+
+        Test.startTest();
+
+        saveResult = EventBus.publish(logEntryEvent);
+        // Normally, you don't have to call Test.getEventBus().deliver() if you're also using Test.stopTest()
+        // But, in this case, there are 3 transactions happening (original test, async platform event, and async future method)
+        // So, call Test.getEventBus().deliver() and Test.stopTest() to make sure all transactions are completed before running asserts
+        Test.getEventBus().deliver();
+
+        Test.stopTest();
+
+        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
+
+        Log__c log = getLog();
+        System.assertEquals(1, log.LogEntries__r.size());
+        LogEntry__c logEntry = log.LogEntries__r.get(0);
+
+        System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c);
+        System.assertEquals(MOCK_RELEASE_NUMBER, log.ApiReleaseNumber__c);
+        System.assertEquals(MOCK_RELEASE_VERSION, log.ApiReleaseVersion__c);
+        validateLogFields(logEntryEvent, log);
+        validateLogEntryFields(logEntryEvent, logEntry);
+    }
+
+    @isTest
+    static void it_should_skip_setting_api_release_number_and_api_release_version_when_callout_fails() {
+        Test.setMock(HttpCalloutMock.class, new FailureCalloutMock());
+        LogEntryEventHandler.shouldCallStatusApi = true;
+
+        String transactionId = '123-456-789-0';
+        LogEntryEvent__e logEntryEvent = new LogEntryEvent__e(Message__c = 'my message', Timestamp__c = System.now(), TransactionId__c = transactionId);
+
+        Database.SaveResult saveResult;
+        try {
+            Test.startTest();
+
+            saveResult = EventBus.publish(logEntryEvent);
+            // Normally, you don't have to call Test.getEventBus().deliver() if you're also using Test.stopTest()
+            // But, in this case, there are 3 transactions happening (original test, async platform event, and async future method)
+            // So, call Test.getEventBus().deliver() and Test.stopTest() to make sure all transactions are completed before running asserts
+            Test.getEventBus().deliver();
+
+            Test.stopTest();
+            System.assert(false, 'Exception expected, this assert should not run');
+        } catch (Exception ex) {
+            System.assertEquals(LogEntryEventHandler.StatusApiResponseException.class.getName(), ex.getTypeName());
+
+            String expectedErrorMessage = 'Callout failed for https://api.status.salesforce.com/v1/instances/';
+            System.assert(ex.getMessage().contains(expectedErrorMessage));
+        }
+
+        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
+
+        Log__c log = getLog();
+        System.assertEquals(1, log.LogEntries__r.size());
+        LogEntry__c logEntry = log.LogEntries__r.get(0);
+
+        System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c);
+        System.assertEquals(null, log.ApiReleaseNumber__c);
+        System.assertEquals(null, log.ApiReleaseVersion__c);
+        validateLogFields(logEntryEvent, log);
+        validateLogEntryFields(logEntryEvent, logEntry);
     }
 }


### PR DESCRIPTION
Closes #102 with a couple of changes:

- Added 2 new fields to `Log__c`: `ApiReleaseNumber__c` and `ApiReleaseVersion__c`
- `LogEntryEventHandler` now has a private future method that's used to make a callout to `https://api.status.salesforce.com/v1/instances/{sfInstanceHere}/status`
  - To try to minimize the number of callouts made, `LogEntryEventHandler` first tries to query for recent `Log__c` records with the 2 new fields already populated. If a match is found, the existing log's values are copied; if no match is found, the callout is made to the status API.
  - Currently, I have not included a way to enable/disable the callouts. Since the callout happens in a `@future` method, if the remote site setting is disabled, an exception will occur in the future method but it will not impact the log from being saved. I may eventually include a way to prevent the callouts from executing, but I'm skipping that for now.
- Updated page layout and flexipage to show the 2 new fields

![image](https://user-images.githubusercontent.com/1267157/111223061-e3024780-8599-11eb-96c5-45ab27296bab.png)
