### PR TITLE
Created console app + tab for LogEntry__c

### DIFF
--- a/nebula-logger/main/log-management/applications/LoggerConsole.app-meta.xml
+++ b/nebula-logger/main/log-management/applications/LoggerConsole.app-meta.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomApplication xmlns="http://soap.sforce.com/2006/04/metadata">
     <brand>
-        <headerColor>#D0380D</headerColor>
-        <shouldOverrideOrgTheme>false</shouldOverrideOrgTheme>
+        <headerColor>#1E1E1E</headerColor>
+        <shouldOverrideOrgTheme>true</shouldOverrideOrgTheme>
     </brand>
     <formFactors>Small</formFactors>
     <formFactors>Large</formFactors>

--- a/nebula-logger/main/log-management/applications/LoggerConsole.app-meta.xml
+++ b/nebula-logger/main/log-management/applications/LoggerConsole.app-meta.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomApplication xmlns="http://soap.sforce.com/2006/04/metadata">
+    <brand>
+        <headerColor>#D0380D</headerColor>
+        <shouldOverrideOrgTheme>false</shouldOverrideOrgTheme>
+    </brand>
+    <formFactors>Small</formFactors>
+    <formFactors>Large</formFactors>
+    <isNavAutoTempTabsDisabled>false</isNavAutoTempTabsDisabled>
+    <isNavPersonalizationDisabled>false</isNavPersonalizationDisabled>
+    <label>Logger Console</label>
+    <navType>Console</navType>
+    <tabs>Log__c</tabs>
+    <tabs>LogEntry__c</tabs>
+    <uiType>Lightning</uiType>
+    <utilityBar>LoggerConsole_UtilityBar</utilityBar>
+    <workspaceConfig>
+        <mappings>
+            <fieldName>Log__c</fieldName>
+            <tab>LogEntry__c</tab>
+        </mappings>
+        <mappings>
+            <tab>Log__c</tab>
+        </mappings>
+    </workspaceConfig>
+</CustomApplication>

--- a/nebula-logger/main/log-management/applications/LoggerConsole.app-meta.xml
+++ b/nebula-logger/main/log-management/applications/LoggerConsole.app-meta.xml
@@ -12,6 +12,8 @@
     <navType>Console</navType>
     <tabs>Log__c</tabs>
     <tabs>LogEntry__c</tabs>
+    <tabs>standard-report</tabs>
+    <tabs>standard-Dashboard</tabs>
     <uiType>Lightning</uiType>
     <utilityBar>LoggerConsole_UtilityBar</utilityBar>
     <workspaceConfig>
@@ -21,6 +23,12 @@
         </mappings>
         <mappings>
             <tab>Log__c</tab>
+        </mappings>
+        <mappings>
+            <tab>standard-Dashboard</tab>
+        </mappings>
+        <mappings>
+            <tab>standard-report</tab>
         </mappings>
     </workspaceConfig>
 </CustomApplication>

--- a/nebula-logger/main/log-management/applications/LoggerConsole.app-meta.xml
+++ b/nebula-logger/main/log-management/applications/LoggerConsole.app-meta.xml
@@ -15,7 +15,7 @@
     <tabs>standard-report</tabs>
     <tabs>standard-Dashboard</tabs>
     <uiType>Lightning</uiType>
-    <utilityBar>LoggerConsole_UtilityBar</utilityBar>
+    <utilityBar>LoggerConsoleUtilityBar</utilityBar>
     <workspaceConfig>
         <mappings>
             <fieldName>Log__c</fieldName>

--- a/nebula-logger/main/log-management/flexipages/LoggerConsoleUtilityBar.flexipage-meta.xml
+++ b/nebula-logger/main/log-management/flexipages/LoggerConsoleUtilityBar.flexipage-meta.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentName>console:history</componentName>
+            </componentInstance>
+        </itemInstances>
         <name>utilityItems</name>
         <type>Region</type>
     </flexiPageRegions>

--- a/nebula-logger/main/log-management/flexipages/LoggerConsoleUtilityBar.flexipage-meta.xml
+++ b/nebula-logger/main/log-management/flexipages/LoggerConsoleUtilityBar.flexipage-meta.xml
@@ -3,6 +3,11 @@
     <flexiPageRegions>
         <itemInstances>
             <componentInstance>
+                <componentName>macros:macroUtilityItem</componentName>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
                 <componentName>console:history</componentName>
             </componentInstance>
         </itemInstances>
@@ -18,7 +23,7 @@
         <name>one:utilityBarTemplateDesktop</name>
         <properties>
             <name>isLeftAligned</name>
-            <value>true</value>
+            <value>false</value>
         </properties>
     </template>
     <type>UtilityBar</type>

--- a/nebula-logger/main/log-management/flexipages/LoggerConsoleUtilityBar.flexipage-meta.xml
+++ b/nebula-logger/main/log-management/flexipages/LoggerConsoleUtilityBar.flexipage-meta.xml
@@ -8,7 +8,7 @@
         <name>backgroundComponents</name>
         <type>Background</type>
     </flexiPageRegions>
-    <masterLabel>Logger UtilityBar</masterLabel>
+    <masterLabel>Logger Console Utility Bar</masterLabel>
     <template>
         <name>one:utilityBarTemplateDesktop</name>
         <properties>

--- a/nebula-logger/main/log-management/flexipages/LoggerConsole_UtilityBar.flexipage-meta.xml
+++ b/nebula-logger/main/log-management/flexipages/LoggerConsole_UtilityBar.flexipage-meta.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <flexiPageRegions>
+        <name>utilityItems</name>
+        <type>Region</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <name>backgroundComponents</name>
+        <type>Background</type>
+    </flexiPageRegions>
+    <masterLabel>Logger UtilityBar</masterLabel>
+    <template>
+        <name>one:utilityBarTemplateDesktop</name>
+        <properties>
+            <name>isLeftAligned</name>
+            <value>true</value>
+        </properties>
+    </template>
+    <type>UtilityBar</type>
+</FlexiPage>

--- a/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
+++ b/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
@@ -262,7 +262,7 @@
                 <behavior>Readonly</behavior>
                 <field>OrganizationEnvironmentType__c</field>
             </layoutItems>
-			<layoutItems>
+            <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>OrganizationNamespacePrefix__c</field>
             </layoutItems>

--- a/nebula-logger/main/log-management/objects/LogEntry__c/LogEntry__c.object-meta.xml
+++ b/nebula-logger/main/log-management/objects/LogEntry__c/LogEntry__c.object-meta.xml
@@ -158,6 +158,7 @@
     <enableSearch>true</enableSearch>
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
+    <externalSharingModel>ControlledByParent</externalSharingModel>
     <label>Log Entry</label>
     <nameField>
         <label>Entry ID</label>
@@ -167,6 +168,7 @@
     <pluralLabel>Log Entries</pluralLabel>
     <searchLayouts>
         <excludedStandardButtons>New</excludedStandardButtons>
+        <excludedStandardButtons>PrintableListView</excludedStandardButtons>
         <excludedStandardButtons>ChangeOwner</excludedStandardButtons>
         <excludedStandardButtons>Accept</excludedStandardButtons>
         <lookupDialogsAdditionalFields>Log__c</lookupDialogsAdditionalFields>

--- a/nebula-logger/main/log-management/objects/LogEntry__c/listViews/All.listView-meta.xml
+++ b/nebula-logger/main/log-management/objects/LogEntry__c/listViews/All.listView-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListView xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>All</fullName>
+    <columns>NAME</columns>
+    <columns>Log__c</columns>
+    <columns>LoggingLevelWithImage__c</columns>
+    <columns>LoggedByUsernameLink__c</columns>
+    <columns>Message__c</columns>
+    <columns>OriginType__c</columns>
+    <columns>OriginLocation__c</columns>
+    <columns>RecordDetailedLink__c</columns>
+    <columns>Timestamp__c</columns>
+    <filterScope>Everything</filterScope>
+    <label>All</label>
+</ListView>

--- a/nebula-logger/main/log-management/objects/Log__c/Log__c.object-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/Log__c.object-meta.xml
@@ -158,6 +158,7 @@
     <enableSearch>true</enableSearch>
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
+    <externalSharingModel>Private</externalSharingModel>
     <label>Log</label>
     <nameField>
         <displayFormat>Log-{000000}</displayFormat>
@@ -168,7 +169,6 @@
     </nameField>
     <pluralLabel>Logs</pluralLabel>
     <searchLayouts>
-        <customTabListAdditionalFields>NAME</customTabListAdditionalFields>
         <customTabListAdditionalFields>LoggedByUsernameLink__c</customTabListAdditionalFields>
         <customTabListAdditionalFields>StartTime__c</customTabListAdditionalFields>
         <customTabListAdditionalFields>OWNER.ALIAS</customTabListAdditionalFields>
@@ -179,10 +179,9 @@
         <customTabListAdditionalFields>TotalERRORLogEntries__c</customTabListAdditionalFields>
         <customTabListAdditionalFields>TotalWARNLogEntries__c</customTabListAdditionalFields>
         <excludedStandardButtons>New</excludedStandardButtons>
-        <excludedStandardButtons>OpenListInQuip</excludedStandardButtons>
-        <excludedStandardButtons>Accept</excludedStandardButtons>
         <excludedStandardButtons>PrintableListView</excludedStandardButtons>
-        <lookupDialogsAdditionalFields>NAME</lookupDialogsAdditionalFields>
+        <excludedStandardButtons>Accept</excludedStandardButtons>
+        <excludedStandardButtons>OpenListInQuip</excludedStandardButtons>
         <lookupDialogsAdditionalFields>LoggedByUsernameLink__c</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>StartTime__c</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>OWNER.ALIAS</lookupDialogsAdditionalFields>
@@ -192,7 +191,6 @@
         <lookupDialogsAdditionalFields>TotalLogEntries__c</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>TotalERRORLogEntries__c</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>TotalWARNLogEntries__c</lookupDialogsAdditionalFields>
-        <lookupPhoneDialogsAdditionalFields>NAME</lookupPhoneDialogsAdditionalFields>
         <lookupPhoneDialogsAdditionalFields>LoggedByUsernameLink__c</lookupPhoneDialogsAdditionalFields>
         <lookupPhoneDialogsAdditionalFields>StartTime__c</lookupPhoneDialogsAdditionalFields>
         <lookupPhoneDialogsAdditionalFields>OWNER.ALIAS</lookupPhoneDialogsAdditionalFields>
@@ -213,7 +211,6 @@
         <searchFilterFields>TotalLogEntries__c</searchFilterFields>
         <searchFilterFields>TotalERRORLogEntries__c</searchFilterFields>
         <searchFilterFields>TotalWARNLogEntries__c</searchFilterFields>
-        <searchResultsAdditionalFields>NAME</searchResultsAdditionalFields>
         <searchResultsAdditionalFields>LoggedByUsernameLink__c</searchResultsAdditionalFields>
         <searchResultsAdditionalFields>StartTime__c</searchResultsAdditionalFields>
         <searchResultsAdditionalFields>OWNER.ALIAS</searchResultsAdditionalFields>

--- a/nebula-logger/main/log-management/pathAssistants/LogStatus.pathAssistant-meta.xml
+++ b/nebula-logger/main/log-management/pathAssistants/LogStatus.pathAssistant-meta.xml
@@ -4,17 +4,5 @@
     <entityName>Log__c</entityName>
     <fieldName>Status__c</fieldName>
     <masterLabel>Log Status</masterLabel>
-    <pathAssistantSteps>
-        <picklistValueName>Done</picklistValueName>
-    </pathAssistantSteps>
-    <pathAssistantSteps>
-        <picklistValueName>Ignored</picklistValueName>
-    </pathAssistantSteps>
-    <pathAssistantSteps>
-        <picklistValueName>In Progress</picklistValueName>
-    </pathAssistantSteps>
-    <pathAssistantSteps>
-        <picklistValueName>New</picklistValueName>
-    </pathAssistantSteps>
     <recordTypeName>__MASTER__</recordTypeName>
 </PathAssistant>

--- a/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -835,6 +835,10 @@
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
     <tabSettings>
+        <tab>LogEntry__c</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+    <tabSettings>
         <tab>Log__c</tab>
         <visibility>Visible</visibility>
     </tabSettings>

--- a/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <applicationVisibilities>
+        <application>LoggerConsole</application>
+        <visible>true</visible>
+    </applicationVisibilities>
     <classAccesses>
         <apexClass>FlowLogEntry</apexClass>
         <enabled>true</enabled>

--- a/nebula-logger/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -25,6 +25,11 @@
   - View shared logs &amp; log entries</description>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.DatabaseResultJson__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.DatabaseResultType__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -35,8 +40,18 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.ExceptionStackTrace__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.ExceptionType__c</field>
         <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasDatabaseResult__c</field>
+        <readable>false</readable>
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
@@ -350,6 +365,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.RecordJson__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.RecordLink__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -372,6 +392,11 @@
         <editable>false</editable>
         <field>LogEntry__c.RecordSObjectType__c</field>
         <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.StackTrace__c</field>
+        <readable>false</readable>
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
@@ -415,8 +440,38 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.ClosedBy__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.ClosedDate__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.Comments__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.EndTime__c</field>
         <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.IsClosed__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.IsResolved__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.Issue__c</field>
+        <readable>false</readable>
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
@@ -427,6 +482,11 @@
         <editable>false</editable>
         <field>Log__c.LogEntriesSummary__c</field>
         <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.LogRetentionDate__c</field>
+        <readable>false</readable>
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
@@ -550,6 +610,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.Priority__c</field>
+        <readable>false</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.ProfileId__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -587,6 +652,11 @@
         <editable>false</editable>
         <field>Log__c.StartTime__c</field>
         <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.Status__c</field>
+        <readable>false</readable>
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>

--- a/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -795,6 +795,10 @@
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
     <tabSettings>
+        <tab>LogEntry__c</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+    <tabSettings>
         <tab>Log__c</tab>
         <visibility>Visible</visibility>
     </tabSettings>

--- a/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
-     <classAccesses>
+    <applicationVisibilities>
+        <application>LoggerConsole</application>
+        <visible>true</visible>
+    </applicationVisibilities>
+    <classAccesses>
         <apexClass>RelatedLogEntriesController</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -371,12 +371,12 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>LogEntry__c.RecordSObjectType__c</field>
+        <field>LogEntry__c.RecordSObjectTypeNamespace__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>LogEntry__c.RecordSObjectTypeNamespace__c</field>
+        <field>LogEntry__c.RecordSObjectType__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -561,17 +561,17 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.OrganizationEnvironmentType__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.OrganizationId__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
         <field>Log__c.OrganizationInstanceName__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
-        <field>Log__c.OrganizationEnvironmentType__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -778,7 +778,7 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>LogEntryEvent__e</object>
-        <viewAllRecords>true</viewAllRecords>
+        <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
     <objectPermissions>
         <allowCreate>false</allowCreate>

--- a/nebula-logger/main/log-management/profiles/Admin.profile-meta.xml
+++ b/nebula-logger/main/log-management/profiles/Admin.profile-meta.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Profile xmlns="http://soap.sforce.com/2006/04/metadata">
+    <applicationVisibilities>
+        <application>LoggerConsole</application>
+        <default>false</default>
+        <visible>true</visible>
+    </applicationVisibilities>
     <classAccesses>
         <apexClass>FlowLogEntry</apexClass>
         <enabled>true</enabled>

--- a/nebula-logger/main/log-management/profiles/Admin.profile-meta.xml
+++ b/nebula-logger/main/log-management/profiles/Admin.profile-meta.xml
@@ -997,6 +997,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.ApiReleaseNumber__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.ApiReleaseVersion__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.ApiVersion__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -1381,6 +1391,10 @@
         <object>Log__c</object>
         <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
+    <tabVisibilities>
+        <tab>LogEntry__c</tab>
+        <visibility>DefaultOn</visibility>
+    </tabVisibilities>
     <tabVisibilities>
         <tab>Log__c</tab>
         <visibility>DefaultOn</visibility>

--- a/nebula-logger/main/log-management/tabs/LogEntry__c.tab-meta.xml
+++ b/nebula-logger/main/log-management/tabs/LogEntry__c.tab-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customObject>true</customObject>
+    <motif>Custom83: Pencil</motif>
+</CustomTab>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/LoggedByUsername__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/LoggedByUsername__c.field-meta.xml
@@ -2,12 +2,12 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggedByUsername__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Username</label>
     <length>255</length>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
-    <trackHistory>false</trackHistory>
-    <trackTrending>false</trackTrending>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkLoginUrl__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkLoginUrl__c.field-meta.xml
@@ -2,6 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkLoginUrl__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Site Login URL</label>
     <length>255</length>
     <required>false</required>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkLogoutUrl__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkLogoutUrl__c.field-meta.xml
@@ -2,6 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkLogoutUrl__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Site Logout URL</label>
     <length>255</length>
     <required>false</required>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkName__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkName__c.field-meta.xml
@@ -3,12 +3,12 @@
     <fullName>NetworkName__c</fullName>
     <description>The name of the user&apos;s Community site (based on NetworkId).</description>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Site Name</label>
     <length>255</length>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
-    <trackHistory>false</trackHistory>
-    <trackTrending>false</trackTrending>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkSelfRegistrationUrl__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkSelfRegistrationUrl__c.field-meta.xml
@@ -2,6 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkSelfRegistrationUrl__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Site Self Registration URL</label>
     <length>255</length>
     <required>false</required>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkUrlPathPrefix__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkUrlPathPrefix__c.field-meta.xml
@@ -3,6 +3,9 @@
     <fullName>NetworkUrlPathPrefix__c</fullName>
     <description>The UrlPathPrefix is a unique string at the end of the URL for this community. For example, in the community URL CommunitiesSubdomainName.force.com/customers, customers is the UrlPathPrefix.</description>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Site URL Path Prefix</label>
     <length>255</length>
     <required>false</required>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationDomainUrl__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationDomainUrl__c.field-meta.xml
@@ -3,6 +3,9 @@
     <fullName>OrganizationDomainUrl__c</fullName>
     <description>The value returned from Url..getOrgDomainUrl()</description>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Organization Domain URL</label>
     <length>255</length>
     <required>false</required>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationEnvironmentType__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationEnvironmentType__c.field-meta.xml
@@ -2,6 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>OrganizationEnvironmentType__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Organization Environment Type</label>
     <length>255</length>
     <required>false</required>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationId__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationId__c.field-meta.xml
@@ -2,12 +2,12 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>OrganizationId__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Organization ID</label>
     <length>18</length>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
-    <trackHistory>false</trackHistory>
-    <trackTrending>false</trackTrending>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationInstanceName__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationInstanceName__c.field-meta.xml
@@ -2,12 +2,12 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>OrganizationInstanceName__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Organization Instance Name</label>
     <length>255</length>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
-    <trackHistory>false</trackHistory>
-    <trackTrending>false</trackTrending>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationName__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationName__c.field-meta.xml
@@ -2,12 +2,12 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>OrganizationName__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Organization Name</label>
     <length>255</length>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
-    <trackHistory>false</trackHistory>
-    <trackTrending>false</trackTrending>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationNamespacePrefix__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationNamespacePrefix__c.field-meta.xml
@@ -2,12 +2,12 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>OrganizationNamespacePrefix__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Organization Namespace Prefix</label>
     <length>255</length>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
-    <trackHistory>false</trackHistory>
-    <trackTrending>false</trackTrending>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationType__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/OrganizationType__c.field-meta.xml
@@ -2,6 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>OrganizationType__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Organization Type</label>
     <length>255</length>
     <required>false</required>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/ProfileName__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/ProfileName__c.field-meta.xml
@@ -2,12 +2,12 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ProfileName__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>Profile Name</label>
     <length>255</length>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
-    <trackHistory>false</trackHistory>
-    <trackTrending>false</trackTrending>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/UserLicenseDefinitionKey__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/UserLicenseDefinitionKey__c.field-meta.xml
@@ -3,6 +3,9 @@
     <fullName>UserLicenseDefinitionKey__c</fullName>
     <description>https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_userlicense.htm</description>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>User License Definition Key</label>
     <length>255</length>
     <required>false</required>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/UserLicenseId__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/UserLicenseId__c.field-meta.xml
@@ -2,12 +2,12 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserLicenseId__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>User License ID</label>
     <length>18</length>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
-    <trackHistory>false</trackHistory>
-    <trackTrending>false</trackTrending>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/UserLicenseName__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/UserLicenseName__c.field-meta.xml
@@ -2,6 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserLicenseName__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>User License Name</label>
     <length>255</length>
     <required>false</required>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/UserRoleName__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/UserRoleName__c.field-meta.xml
@@ -2,12 +2,12 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserRoleName__c</fullName>
     <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
     <label>User Role Name</label>
     <length>255</length>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
-    <trackHistory>false</trackHistory>
-    <trackTrending>false</trackTrending>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/main/logger-engine/permissionsets/LoggerLogCreator.permissionset-meta.xml
+++ b/nebula-logger/main/logger-engine/permissionsets/LoggerLogCreator.permissionset-meta.xml
@@ -9,11 +9,11 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
-        <apexClass>Logger</apexClass>
+        <apexClass>LogMessage</apexClass>
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
-        <apexClass>LogMessage</apexClass>
+        <apexClass>Logger</apexClass>
         <enabled>true</enabled>
     </classAccesses>
     <description>Provides access to generate log entries via Apex, Flow and Process Builder</description>


### PR DESCRIPTION
I decided to finally add a couple of small changes that help with viewing/managing logs

- New tab for `LogEntry__c` let's you use standard list view functionality for viewing all log entries, filtering, sorting, searching, etc.
- New 'Logger Console' app helps with viewing logs (primary tabs) and their related entries (subtabs)
  - Small drawback: lightning console apps are included in Sales Cloud & Service Cloud licenses, but Platform license require an extra Lightning Console permission set license ([source](https://help.salesforce.com/articleView?id=sf.console_lex_access.htm&type=5))