### PR TITLE
Added Log__c field for instance release cycle

### DIFF
--- a/nebula-logger/main/log-management/classes/LogHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogHandler.cls
@@ -8,6 +8,8 @@
  * @description Manages setting fields on `Log__c` before insert & before update
  */
 public without sharing class LogHandler {
+    private static final Organization ORGANIZATION = [SELECT Id, InstanceName, IsSandbox FROM Organization];
+
     @testVisible
     private static Map<String, LogStatus__mdt> logStatusByName;
 
@@ -71,9 +73,9 @@ public without sharing class LogHandler {
         };
 
         String releaseCycle;
-        if (logs.get(0).OrganizationEnvironmentType__c == 'Production' || nonPreviewInstances.contains(logs.get(0).OrganizationInstanceName__c)) {
+        if (ORGANIZATION.IsSandbox == false || nonPreviewInstances.contains(ORGANIZATION.InstanceName)) {
             releaseCycle = 'Non-Preview Instance';
-        } else if (previewInstances.contains(logs.get(0).OrganizationInstanceName__c)) {
+        } else if (previewInstances.contains(ORGANIZATION.InstanceName)) {
             releaseCycle = 'Preview Instance';
         } else {
             // Use 'Unknown' as the default for private instances and situations where the hardcoded sets above are missing some values

--- a/nebula-logger/main/log-management/classes/LogHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogHandler.cls
@@ -71,10 +71,10 @@ public without sharing class LogHandler {
         };
 
         String releaseCycle;
-        if (previewInstances.contains(logs.get(0).OrganizationInstanceName__c)) {
-            releaseCycle = 'Preview Instance';
-        } else if (nonPreviewInstances.contains(logs.get(0).OrganizationInstanceName__c)) {
+        if (logs.get(0).OrganizationEnvironmentType__c == 'Production' || nonPreviewInstances.contains(logs.get(0).OrganizationInstanceName__c)) {
             releaseCycle = 'Non-Preview Instance';
+        } else if (previewInstances.contains(logs.get(0).OrganizationInstanceName__c)) {
+            releaseCycle = 'Preview Instance';
         } else {
             // Use 'Unknown' as the default for private instances and situations where the hardcoded sets above are missing some values
             releaseCycle = 'Unknown';

--- a/nebula-logger/main/log-management/classes/LogHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogHandler.cls
@@ -62,9 +62,25 @@ public without sharing class LogHandler {
             'AUS8S', 'IND3S', 'USA3S'
         };
 
-        Boolean isPreviewInstance = previewInstances.contains(logs.get(0).OrganizationInstanceName__c);
+        Set<String> nonPreviewInstances = new Set<String>{
+            'CS1', 'CS6', 'CS8', 'CS10', 'CS16', 'CS18', 'CS22', 'CS24', 'CS29', 'CS33', 'CS40', 'CS43',
+            'CS50', 'CS52', 'CS58', 'CS60', 'CS62', 'CS64', 'CS65', 'CS66', 'CS68', 'CS70', 'CS73', 'CS86',
+            'CS89', 'CS90', 'CS92', 'CS94', 'CS98', 'CS100', 'CS101', 'CS102', 'CS110', 'CS114', 'CS115', 'CS117',
+            'CS119', 'CS121', 'CS132', 'CS148', 'CS151', 'CS162', 'CS165', 'CS173', 'AUS4S', 'IND2S', 'USA2S'
+        };
+
+        String releaseCycle;
+        if (previewInstances.contains(logs.get(0).OrganizationInstanceName__c)) {
+            releaseCycle = 'Preview Instance';
+        } else if (nonPreviewInstances.contains(logs.get(0).OrganizationInstanceName__c)) {
+            releaseCycle = 'Non-Preview Instance';
+        } else {
+            // Use 'Unknown' as the default for private instances and situations where the hardcoded sets above are missing some values
+            releaseCycle = 'Unknown';
+        }
+
         for (Log__c log : logs) {
-            log.OrganizationInstanceReleaseCycle__c = isPreviewInstance ? 'Preview Instance' : 'Non-Preview Instance';
+            log.OrganizationInstanceReleaseCycle__c = releaseCycle;
         }
     }
 

--- a/nebula-logger/main/log-management/classes/LogHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogHandler.cls
@@ -29,6 +29,7 @@ public without sharing class LogHandler {
 
         switch on Trigger.operationType {
             when BEFORE_INSERT {
+                this.setOrgReleaseCycle(logs);
                 this.setClosedStatusFields(logs);
                 // The log retention date field should support being manually changed, so only auto-set it on insert
                 this.setLogRetentionDate(logs);
@@ -41,6 +42,29 @@ public without sharing class LogHandler {
             when AFTER_INSERT {
                 this.shareLogsWithLoggingUsers(logs);
             }
+        }
+    }
+
+    private void setOrgReleaseCycle(List<Log__c> logs) {
+        // Currently, there doesn't seem to be a way within Apex or api.status.salesforce.com...
+        // ...to know if your org is on a preview instance or non-preview instance
+        // So, that unfortunately leaves hardcoding the instances for now
+        // And no need for this to be static since it's only used internally for BEFORE_INSERT context
+        Set<String> previewInstances = new Set<String>{
+            'CS2', 'CS4', 'CS5', 'CS7', 'CS9', 'CS11', 'CS14', 'CS15', 'CS17', 'CS19', 'CS20', 'CS21',
+            'CS23', 'CS25', 'CS26', 'CS27', 'CS28', 'CS31', 'CS32', 'CS34', 'CS35', 'CS36', 'CS37', 'CS41',
+            'CS42', 'CS44', 'CS45', 'CS47', 'CS53', 'CS57', 'CS59', 'CS61', 'CS63', 'CS67', 'CS69', 'CS72',
+            'CS74', 'CS75', 'CS76', 'CS77', 'CS78', 'CS79', 'CS80', 'CS81', 'CS84', 'CS87', 'CS88', 'CS91',
+            'CS95', 'CS96', 'CS97', 'CS99', 'CS105', 'CS106', 'CS107', 'CS108', 'CS109', 'CS111', 'CS112',
+            'CS113', 'CS116', 'CS122', 'CS123', 'CS124', 'CS125', 'CS126', 'CS127', 'CS128', 'CS129', 'CS133',
+            'CS137', 'CS138', 'CS142', 'CS152', 'CS159', 'CS160', 'CS169', 'CS174', 'CS189', 'CS190', 'CS191',
+            'CS192', 'CS193', 'CS194', 'CS195', 'CS196', 'CS197', 'CS198', 'CS199', 'CS201', 'CS203', 'AUS2S',
+            'AUS8S', 'IND3S', 'USA3S'
+        };
+
+        Boolean isPreviewInstance = previewInstances.contains(logs.get(0).OrganizationInstanceName__c);
+        for (Log__c log : logs) {
+            log.OrganizationInstanceReleaseCycle__c = isPreviewInstance ? 'Preview Instance' : 'Non-Preview Instance';
         }
     }
 

--- a/nebula-logger/main/log-management/classes/LogHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogHandler.cls
@@ -49,6 +49,7 @@ public without sharing class LogHandler {
         // Currently, there doesn't seem to be a way within Apex or api.status.salesforce.com...
         // ...to know if your org is on a preview instance or non-preview instance
         // So, that unfortunately leaves hardcoding the instances for now
+        // Source: https://www.salesforce.com/blog/spring-21-sandbox-preview/
         // And no need for this to be static since it's only used internally for BEFORE_INSERT context
         Set<String> previewInstances = new Set<String>{
             'CS2', 'CS4', 'CS5', 'CS7', 'CS9', 'CS11', 'CS14', 'CS15', 'CS17', 'CS19', 'CS20', 'CS21',

--- a/nebula-logger/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
+++ b/nebula-logger/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
@@ -660,7 +660,7 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.OrganizationDomainUrl__c</fieldItem>
+                <fieldItem>Record.OrganizationNamespacePrefix__c</fieldItem>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -669,7 +669,7 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.OrganizationNamespacePrefix__c</fieldItem>
+                <fieldItem>Record.OrganizationDomainUrl__c</fieldItem>
             </fieldInstance>
         </itemInstances>
         <name>Facet-c4a1f400-d677-4197-9c0c-60bb1e5b426d</name>

--- a/nebula-logger/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
+++ b/nebula-logger/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
@@ -660,7 +660,7 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.OrganizationEnvironmentType__c</fieldItem>
+                <fieldItem>Record.OrganizationDomainUrl__c</fieldItem>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -682,7 +682,25 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
+                <fieldItem>Record.OrganizationEnvironmentType__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.OrganizationInstanceName__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.OrganizationInstanceReleaseCycle__c</fieldItem>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -710,15 +728,6 @@
                     <value>readonly</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.ApiReleaseNumber__c</fieldItem>
-            </fieldInstance>
-        </itemInstances>
-        <itemInstances>
-            <fieldInstance>
-                <fieldInstanceProperties>
-                    <name>uiBehavior</name>
-                    <value>readonly</value>
-                </fieldInstanceProperties>
-                <fieldItem>Record.OrganizationDomainUrl__c</fieldItem>
             </fieldInstance>
         </itemInstances>
         <name>Facet-7a49dd50-62e1-43c4-a95b-81a04f2e4a8e</name>

--- a/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
+++ b/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
@@ -260,11 +260,11 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OrganizationDomainUrl__c</field>
+                <field>OrganizationNamespacePrefix__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OrganizationNamespacePrefix__c</field>
+                <field>OrganizationDomainUrl__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>

--- a/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
+++ b/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
@@ -260,7 +260,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
-                <field>OrganizationEnvironmentType__c</field>
+                <field>OrganizationDomainUrl__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
@@ -270,7 +270,15 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Readonly</behavior>
+                <field>OrganizationEnvironmentType__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
                 <field>OrganizationInstanceName__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>OrganizationInstanceReleaseCycle__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
@@ -283,10 +291,6 @@
             <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>ApiReleaseNumber__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Readonly</behavior>
-                <field>OrganizationDomainUrl__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
@@ -372,7 +376,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h1g000002BBzo</masterLabel>
+        <masterLabel>00hJ0000003PpYD</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/nebula-logger/main/log-management/objects/Log__c/fields/ApiVersion__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/ApiVersion__c.field-meta.xml
@@ -14,17 +14,17 @@
         <valueSetDefinition>
             <sorted>false</sorted>
             <value>
-                <fullName>v53</fullName>
+                <fullName>v53.0</fullName>
                 <default>false</default>
                 <label>v53.0 - Winter &apos;22</label>
             </value>
             <value>
-                <fullName>v52</fullName>
+                <fullName>v52.0</fullName>
                 <default>false</default>
                 <label>v52.0 - Summer &apos;21</label>
             </value>
             <value>
-                <fullName>v51</fullName>
+                <fullName>v51.0</fullName>
                 <default>false</default>
                 <label>v51.0 - Spring &apos;21</label>
             </value>

--- a/nebula-logger/main/log-management/objects/Log__c/fields/ApiVersion__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/ApiVersion__c.field-meta.xml
@@ -16,17 +16,17 @@
             <value>
                 <fullName>v53.0</fullName>
                 <default>false</default>
-                <label>v53.0 - Winter &apos;22</label>
+                <label>v53.0 - Winter &apos;22 Release</label>
             </value>
             <value>
                 <fullName>v52.0</fullName>
                 <default>false</default>
-                <label>v52.0 - Summer &apos;21</label>
+                <label>v52.0 - Summer &apos;21 Release</label>
             </value>
             <value>
                 <fullName>v51.0</fullName>
                 <default>false</default>
-                <label>v51.0 - Spring &apos;21</label>
+                <label>v51.0 - Spring &apos;21 Release</label>
             </value>
         </valueSetDefinition>
     </valueSet>

--- a/nebula-logger/main/log-management/objects/Log__c/fields/OrganizationEnvironmentType__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/OrganizationEnvironmentType__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>OrganizationEnvironmentType__c</fullName>
     <externalId>false</externalId>
-    <label>Organization Environment Type</label>
+    <label>Environment Type</label>
     <required>false</required>
     <trackFeedHistory>false</trackFeedHistory>
     <trackHistory>false</trackHistory>

--- a/nebula-logger/main/log-management/objects/Log__c/fields/OrganizationInstanceName__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/OrganizationInstanceName__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>OrganizationInstanceName__c</fullName>
     <externalId>false</externalId>
-    <label>Organization Instance Name</label>
+    <label>Instance Name</label>
     <length>255</length>
     <required>false</required>
     <trackFeedHistory>false</trackFeedHistory>

--- a/nebula-logger/main/log-management/objects/Log__c/fields/OrganizationInstanceReleaseCycle__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/OrganizationInstanceReleaseCycle__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>OrganizationInstanceReleaseCycle__c</fullName>
     <externalId>false</externalId>
-    <label>Organization Instance Release Cycle</label>
+    <label>Instance Release Cycle</label>
     <required>false</required>
     <trackFeedHistory>false</trackFeedHistory>
     <trackHistory>false</trackHistory>

--- a/nebula-logger/main/log-management/objects/Log__c/fields/OrganizationInstanceReleaseCycle__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/OrganizationInstanceReleaseCycle__c.field-meta.xml
@@ -21,6 +21,11 @@
                 <default>false</default>
                 <label>Non-Preview Instance</label>
             </value>
+            <value>
+                <fullName>Unknown</fullName>
+                <default>false</default>
+                <label>Unknown</label>
+            </value>
         </valueSetDefinition>
     </valueSet>
 </CustomField>

--- a/nebula-logger/main/log-management/objects/Log__c/fields/OrganizationInstanceReleaseCycle__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/OrganizationInstanceReleaseCycle__c.field-meta.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>OrganizationInstanceReleaseCycle__c</fullName>
+    <externalId>false</externalId>
+    <label>Organization Instance Release Cycle</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Preview Instance</fullName>
+                <default>false</default>
+                <label>Preview Instance</label>
+            </value>
+            <value>
+                <fullName>Non-Preview Instance</fullName>
+                <default>false</default>
+                <label>Non-Preview Instance</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -626,6 +626,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.OrganizationInstanceReleaseCycle__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.OrganizationType__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -600,6 +600,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.OrganizationInstanceReleaseCycle__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.OrganizationType__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -586,6 +586,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.OrganizationInstanceReleaseCycle__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.OrganizationType__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/log-management/profiles/Admin.profile-meta.xml
+++ b/nebula-logger/main/log-management/profiles/Admin.profile-meta.xml
@@ -1177,6 +1177,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.OrganizationInstanceReleaseCycle__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.OrganizationType__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -548,8 +548,12 @@ global with sharing class LogEntryEventBuilder {
 
     // Private static methods
     private static String getApiVersion() {
+        // Small hack to determine the org's current API version (since Apex doesn't natively provide it)
+        // Serializing any SObject with an ID will include the API version in the JSON
+        // So, use UserInfo.getUserId() to create an instance of User and parse the JSOn to get the API version
+        // Expected JSON: {"attributes":{"type":"User","url":"/services/data/v51.0/sobjects/User/005J000000AugnYIAR"}
         String userJson = JSON.serialize(new User(Id = UserInfo.getUserId()));
-        return userJson.substringAfter('/data/').substringBefore('.0/sobjects/');
+        return userJson.substringAfter('/data/').substringBefore('/sobjects/User');
     }
 
     private static List<String> getIgnoredClasses() {

--- a/nebula-logger/tests/log-management/classes/LogHandler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogHandler_Tests.cls
@@ -24,6 +24,51 @@ private class LogHandler_Tests {
     }
 
     @isTest
+    static void it_should_set_org_release_cycle_on_insert() {
+        Set<String> previewInstances = new Set<String>{
+            'CS2', 'CS4', 'CS5', 'CS7', 'CS9', 'CS11', 'CS14', 'CS15', 'CS17', 'CS19', 'CS20', 'CS21',
+            'CS23', 'CS25', 'CS26', 'CS27', 'CS28', 'CS31', 'CS32', 'CS34', 'CS35', 'CS36', 'CS37', 'CS41',
+            'CS42', 'CS44', 'CS45', 'CS47', 'CS53', 'CS57', 'CS59', 'CS61', 'CS63', 'CS67', 'CS69', 'CS72',
+            'CS74', 'CS75', 'CS76', 'CS77', 'CS78', 'CS79', 'CS80', 'CS81', 'CS84', 'CS87', 'CS88', 'CS91',
+            'CS95', 'CS96', 'CS97', 'CS99', 'CS105', 'CS106', 'CS107', 'CS108', 'CS109', 'CS111', 'CS112',
+            'CS113', 'CS116', 'CS122', 'CS123', 'CS124', 'CS125', 'CS126', 'CS127', 'CS128', 'CS129', 'CS133',
+            'CS137', 'CS138', 'CS142', 'CS152', 'CS159', 'CS160', 'CS169', 'CS174', 'CS189', 'CS190', 'CS191',
+            'CS192', 'CS193', 'CS194', 'CS195', 'CS196', 'CS197', 'CS198', 'CS199', 'CS201', 'CS203', 'AUS2S',
+            'AUS8S', 'IND3S', 'USA3S'
+        };
+
+        Set<String> nonPreviewInstances = new Set<String>{
+            'CS1', 'CS6', 'CS8', 'CS10', 'CS16', 'CS18', 'CS22', 'CS24', 'CS29', 'CS33', 'CS40', 'CS43',
+            'CS50', 'CS52', 'CS58', 'CS60', 'CS62', 'CS64', 'CS65', 'CS66', 'CS68', 'CS70', 'CS73', 'CS86',
+            'CS89', 'CS90', 'CS92', 'CS94', 'CS98', 'CS100', 'CS101', 'CS102', 'CS110', 'CS114', 'CS115', 'CS117',
+            'CS119', 'CS121', 'CS132', 'CS148', 'CS151', 'CS162', 'CS165', 'CS173', 'AUS4S', 'IND2S', 'USA2S'
+        };
+
+        Organization organization = [SELECT Id, InstanceName, IsSandbox FROM Organization];
+
+        String expectedReleaseCycle;
+        if (organization.IsSandbox == false || nonPreviewInstances.contains(organization.InstanceName)) {
+            expectedReleaseCycle = 'Non-Preview Instance';
+        } else if (previewInstances.contains(organization.InstanceName)) {
+            expectedReleaseCycle = 'Preview Instance';
+        } else {
+            // Use 'Unknown' as the default for private instances and situations where the hardcoded sets above are missing some values
+            expectedReleaseCycle = 'Unknown';
+        }
+
+        Log__c log = new Log__c(
+            TransactionId__c = '1234'
+        );
+
+        Test.startTest();
+        insert log;
+        Test.stopTest();
+
+        log = [SELECT Id, OrganizationInstanceReleaseCycle__c FROM Log__c WHERE Id = :log.Id];
+        System.assertEquals(expectedReleaseCycle, log.OrganizationInstanceReleaseCycle__c);
+    }
+
+    @isTest
     static void it_should_clear_closed_status_fields_when_open() {
         Log__c log = new Log__c(
             ClosedBy__c = UserInfo.getUserId(),


### PR DESCRIPTION
Closes #104 by adding a new field, `Log__c.OrganizationInstanceReleaseCycle__c` that's populated by `LogHandler`

Currently, there doesn't seem to be a way within Apex or `api.status.salesforce.com` to know if your org is on a preview instance or non-preview instance. But each instance does should have the same consistent release cycle (i.e., I don't think an instance would ever change from being a 'preview instance' to a non-preview instance', or vice versa), so I'm using a hardcoded list of instances for now.

![image](https://user-images.githubusercontent.com/1267157/111734469-71dfc000-8837-11eb-8a48-8caf36d3b1d7.png)

