### PR TITLE
Fixed upsert logic for Log__c so it doesn't assume that there is only 1 transaction ID involved

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,19 +14,6 @@ on:
             - '.gitignore'
             - '.prettierignore'
             - '.prettierrc'
-    pull_request:
-        types: [opened, edited, synchronize, reopened]
-        paths-ignore:
-            - 'sfdx-project.json'
-            - 'README.md'
-            - 'Contributing.md'
-            - 'CODE_OF_CONDUCT.md'
-            - 'package.json'
-            - 'LICENSE'
-            - 'content/**'
-            - '.gitignore'
-            - '.prettierignore'
-            - '.prettierrc'
 
 jobs:
     validation-deployment-test:

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -37,14 +37,12 @@ public without sharing class LogEntryEventHandler {
     }
 
     private void upsertLogs(List<LogEntryEvent__e> logEntryEvents) {
-        if (logsUpserted == true) {
-            return;
-        }
-
         Log__c recentLogWithDetails = getRecentLogWithDetails();
 
         // The LogEntryEvent__e object stores a denormalized version of Log__c & LogEntry__c data
         // In case the list contains entries tied to multiple transactions, use the TRANSACTION_ID_TO_LOG map to create 1 Log__c per transaction ID
+
+        List<Log__c> logsToUpsert = new List<Log__c>();
         for (LogEntryEvent__e logEntryEvent : logEntryEvents) {
             if (TRANSACTION_ID_TO_LOG.containsKey(logEntryEvent.TransactionId__c) == true) {
                 continue;
@@ -106,11 +104,11 @@ public without sharing class LogEntryEventHandler {
             log.UserRoleName__c = logEntryEvent.UserRoleName__c;
             log.UserType__c = logEntryEvent.UserType__c;
 
+            logsToUpsert.add(log);
             TRANSACTION_ID_TO_LOG.put(log.TransactionId__c, log);
         }
 
-        upsert TRANSACTION_ID_TO_LOG.values() TransactionId__c;
-        logsUpserted = true;
+        upsert logsToUpsert TransactionId__c;
 
         // If no recent logs have the details, and there is not another instance of the job in progress, then start a new one
         if (shouldCallStatusApi == true && LoggerSettings__c.getOrgDefaults().EnableStatusApiCallout__c && recentLogWithDetails == null && getCountOfOpenJobs() == 0) {

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -8,8 +8,9 @@
  * @description Subscribes to `LogEntryEvent__e` platform events and normalizes the data into `Log__c` and `LogEntry__c` records
  */
 public without sharing class LogEntryEventHandler {
-    private static final Log__c LOG = new Log__c();
+    private static final Map<String, Log__c> TRANSACTION_ID_TO_LOG = new Map<String, Log__c>();
 
+    private static Boolean logsUpserted = false;
     @TestVisible
     private static Boolean shouldCallStatusApi = Test.isRunningTest() == false;
 
@@ -28,79 +29,88 @@ public without sharing class LogEntryEventHandler {
 
         switch on Trigger.operationType {
             when AFTER_INSERT {
-                this.upsertLog(logEntryEvents);
+                this.upsertLogs(logEntryEvents);
                 this.insertLogEntries(logEntryEvents);
                 this.insertTopics();
             }
         }
     }
 
-    private void upsertLog(List<LogEntryEvent__e> logEntryEvents) {
-        if (LOG.Id != null) {
+    private void upsertLogs(List<LogEntryEvent__e> logEntryEvents) {
+        if (logsUpserted == true) {
             return;
         }
 
-        // The LogEntryEvent__e object stores a denormalized version of Log__c & LogEntry__c data
-        // The first LogEntryEvent__e record is used to normalize the data
-        LogEntryEvent__e logEntryEvent = logEntryEvents.get(0);
-        Log__c parentLog = new Log__c(TransactionId__c = logEntryEvent.ParentLogTransactionId__c);
-
-        LOG.ApiVersion__c = logEntryEvent.ApiVersion__c;
-        LOG.Locale__c = logEntryEvent.Locale__c;
-        LOG.LoggedBy__c = logEntryEvent.CreatedById;
-        LOG.LoggedByUsername__c = logEntryEvent.LoggedByUsername__c;
-        LOG.LoginDomain__c = logEntryEvent.LoginDomain__c;
-        LOG.LoginHistoryId__c = logEntryEvent.LoginHistoryId__c;
-        LOG.LoginApplication__c = logEntryEvent.LoginApplication__c;
-        LOG.LoginBrowser__c = logEntryEvent.LoginBrowser__c;
-        LOG.LoginPlatform__c = logEntryEvent.LoginPlatform__c;
-        LOG.LoginType__c = logEntryEvent.LoginType__c;
-        LOG.LogoutUrl__c = logEntryEvent.LogoutUrl__c;
-        LOG.NetworkId__c = logEntryEvent.NetworkId__c;
-        LOG.NetworkLoginUrl__c = logEntryEvent.NetworkLoginUrl__c;
-        LOG.NetworkLogoutUrl__c = logEntryEvent.NetworkLogoutUrl__c;
-        LOG.NetworkName__c = logEntryEvent.NetworkName__c;
-        LOG.NetworkSelfRegistrationUrl__c = logEntryEvent.NetworkSelfRegistrationUrl__c;
-        LOG.NetworkUrlPathPrefix__c = logEntryEvent.NetworkUrlPathPrefix__c;
-        LOG.OrganizationDomainUrl__c = logEntryEvent.OrganizationDomainUrl__c;
-        LOG.OrganizationEnvironmentType__c = logEntryEvent.OrganizationEnvironmentType__c;
-        LOG.OrganizationId__c = logEntryEvent.OrganizationId__c;
-        LOG.OrganizationInstanceName__c = logEntryEvent.OrganizationInstanceName__c;
-        LOG.OrganizationName__c = logEntryEvent.OrganizationName__c;
-        LOG.OrganizationNamespacePrefix__c = logEntryEvent.OrganizationNamespacePrefix__c;
-        LOG.OrganizationType__c = logEntryEvent.OrganizationType__c;
-        LOG.OwnerId = logEntryEvent.CreatedById;
-        LOG.ParentLog__r = logEntryEvent.ParentLogTransactionId__c == null ? null : parentLog;
-        LOG.ProfileId__c = logEntryEvent.ProfileId__c;
-        LOG.ProfileName__c = logEntryEvent.ProfileName__c;
-        LOG.SessionId__c = logEntryEvent.SessionId__c;
-        LOG.SessionId__c = logEntryEvent.SessionId__c;
-        LOG.SessionSecurityLevel__c = logEntryEvent.SessionSecurityLevel__c;
-        LOG.SessionType__c = logEntryEvent.SessionType__c;
-        LOG.SourceIp__c = logEntryEvent.SourceIp__c;
-        LOG.SystemMode__c = logEntryEvent.SystemMode__c;
-        LOG.ThemeDisplayed__c = logEntryEvent.ThemeDisplayed__c;
-        LOG.TimeZoneId__c = logEntryEvent.TimeZoneId__c;
-        LOG.TimeZoneName__c = logEntryEvent.TimeZoneName__c;
-        LOG.TransactionId__c = logEntryEvent.TransactionId__c;
-        LOG.UserLicenseDefinitionKey__c = logEntryEvent.UserLicenseDefinitionKey__c;
-        LOG.UserLicenseId__c = logEntryEvent.UserLicenseId__c;
-        LOG.UserLicenseName__c = logEntryEvent.UserLicenseName__c;
-        LOG.UserLoggingLevel__c = logEntryEvent.UserLoggingLevel__c;
-        LOG.UserLoggingLevelOrdinal__c = logEntryEvent.UserLoggingLevelOrdinal__c;
-        LOG.UserRoleId__c = logEntryEvent.UserRoleId__c;
-        LOG.UserRoleName__c = logEntryEvent.UserRoleName__c;
-        LOG.UserType__c = logEntryEvent.UserType__c;
-
-        // To avoid making a callout for every log, try to query recent logs first
-        // If there is a recent log with the details already populated, copy the field values before upserting the log
         Log__c recentLogWithDetails = getRecentLogWithDetails();
-        if (recentLogWithDetails != null) {
-            LOG.ApiReleaseNumber__c = recentLogWithDetails.ApiReleaseNumber__c;
-            LOG.ApiReleaseVersion__c = recentLogWithDetails.ApiReleaseVersion__c;
+
+        // The LogEntryEvent__e object stores a denormalized version of Log__c & LogEntry__c data
+        // In case the list contains entries tied to multiple transactions, use the TRANSACTION_ID_TO_LOG map to create 1 Log__c per transaction ID
+        for (LogEntryEvent__e logEntryEvent : logEntryEvents) {
+            if (TRANSACTION_ID_TO_LOG.containsKey(logEntryEvent.TransactionId__c) == true) {
+                continue;
+            }
+
+            Log__c parentLog = new Log__c(TransactionId__c = logEntryEvent.ParentLogTransactionId__c);
+            Log__c log = new Log__c();
+            // To avoid making a callout for every log for details retrieved from api.status.salesforce.com,
+            // ...try to query recent logs first to see if there is a recent log with the details already populated
+            if (recentLogWithDetails != null) {
+                log.ApiReleaseNumber__c = recentLogWithDetails.ApiReleaseNumber__c;
+                log.ApiReleaseVersion__c = recentLogWithDetails.ApiReleaseVersion__c;
+            }
+
+            log.ApiVersion__c = logEntryEvent.ApiVersion__c;
+            log.Locale__c = logEntryEvent.Locale__c;
+            log.LoggedBy__c = logEntryEvent.CreatedById;
+            log.LoggedByUsername__c = logEntryEvent.LoggedByUsername__c;
+            log.LoginDomain__c = logEntryEvent.LoginDomain__c;
+            log.LoginHistoryId__c = logEntryEvent.LoginHistoryId__c;
+            log.LoginApplication__c = logEntryEvent.LoginApplication__c;
+            log.LoginBrowser__c = logEntryEvent.LoginBrowser__c;
+            log.LoginPlatform__c = logEntryEvent.LoginPlatform__c;
+            log.LoginType__c = logEntryEvent.LoginType__c;
+            log.LogoutUrl__c = logEntryEvent.LogoutUrl__c;
+            log.NetworkId__c = logEntryEvent.NetworkId__c;
+            log.NetworkLoginUrl__c = logEntryEvent.NetworkLoginUrl__c;
+            log.NetworkLogoutUrl__c = logEntryEvent.NetworkLogoutUrl__c;
+            log.NetworkName__c = logEntryEvent.NetworkName__c;
+            log.NetworkSelfRegistrationUrl__c = logEntryEvent.NetworkSelfRegistrationUrl__c;
+            log.NetworkUrlPathPrefix__c = logEntryEvent.NetworkUrlPathPrefix__c;
+            log.OrganizationDomainUrl__c = logEntryEvent.OrganizationDomainUrl__c;
+            log.OrganizationEnvironmentType__c = logEntryEvent.OrganizationEnvironmentType__c;
+            log.OrganizationId__c = logEntryEvent.OrganizationId__c;
+            log.OrganizationInstanceName__c = logEntryEvent.OrganizationInstanceName__c;
+            log.OrganizationName__c = logEntryEvent.OrganizationName__c;
+            log.OrganizationNamespacePrefix__c = logEntryEvent.OrganizationNamespacePrefix__c;
+            log.OrganizationType__c = logEntryEvent.OrganizationType__c;
+            log.OwnerId = logEntryEvent.CreatedById;
+            log.ParentLog__r = logEntryEvent.ParentLogTransactionId__c == null ? null : parentLog;
+            log.ProfileId__c = logEntryEvent.ProfileId__c;
+            log.ProfileName__c = logEntryEvent.ProfileName__c;
+            log.SessionId__c = logEntryEvent.SessionId__c;
+            log.SessionId__c = logEntryEvent.SessionId__c;
+            log.SessionSecurityLevel__c = logEntryEvent.SessionSecurityLevel__c;
+            log.SessionType__c = logEntryEvent.SessionType__c;
+            log.SourceIp__c = logEntryEvent.SourceIp__c;
+            log.SystemMode__c = logEntryEvent.SystemMode__c;
+            log.ThemeDisplayed__c = logEntryEvent.ThemeDisplayed__c;
+            log.TimeZoneId__c = logEntryEvent.TimeZoneId__c;
+            log.TimeZoneName__c = logEntryEvent.TimeZoneName__c;
+            log.TransactionId__c = logEntryEvent.TransactionId__c;
+            log.UserLicenseDefinitionKey__c = logEntryEvent.UserLicenseDefinitionKey__c;
+            log.UserLicenseId__c = logEntryEvent.UserLicenseId__c;
+            log.UserLicenseName__c = logEntryEvent.UserLicenseName__c;
+            log.UserLoggingLevel__c = logEntryEvent.UserLoggingLevel__c;
+            log.UserLoggingLevelOrdinal__c = logEntryEvent.UserLoggingLevelOrdinal__c;
+            log.UserRoleId__c = logEntryEvent.UserRoleId__c;
+            log.UserRoleName__c = logEntryEvent.UserRoleName__c;
+            log.UserType__c = logEntryEvent.UserType__c;
+
+            TRANSACTION_ID_TO_LOG.put(log.TransactionId__c, log);
         }
 
-        upsert LOG TransactionId__c;
+        upsert TRANSACTION_ID_TO_LOG.values() TransactionId__c;
+        logsUpserted = true;
 
         // If no recent logs have the details, and there is not another instance of the job in progress, then start a new one
         if (shouldCallStatusApi == true && LoggerSettings__c.getOrgDefaults().EnableStatusApiCallout__c && recentLogWithDetails == null && getCountOfOpenJobs() == 0) {
@@ -109,7 +119,7 @@ public without sharing class LogEntryEventHandler {
     }
 
     private void insertLogEntries(List<LogEntryEvent__e> logEntryEvents) {
-        if (LOG.Id == null) {
+        if (logsUpserted == false) {
             return; // Avoid an exception - if there is no log, we can't save log entries
         }
 
@@ -155,7 +165,7 @@ public without sharing class LogEntryEventHandler {
                 LimitsSoqlQueryRowsUsed__c = logEntryEvent.LimitsSoqlQueryRowsUsed__c,
                 LimitsSoslSearchesUsed__c = logEntryEvent.LimitsSoslSearchesUsed__c,
                 LimitsSoslSearchesMax__c = logEntryEvent.LimitsSoslSearchesMax__c,
-                Log__c = LOG.Id,
+                Log__c = TRANSACTION_ID_TO_LOG.get(logEntryEvent.TransactionId__c).Id,
                 LoggingLevel__c = logEntryEvent.LoggingLevel__c,
                 LoggingLevelOrdinal__c = logEntryEvent.LoggingLevelOrdinal__c,
                 Message__c = logEntryEvent.Message__c,
@@ -220,7 +230,7 @@ public without sharing class LogEntryEventHandler {
                 topicAssignments.add(new TopicAssignment(EntityId = logEntry.Id, TopicId = topicNameToTopics.get(topicName).Id));
 
                 // Add all topics to the parent log when enabled
-                topicAssignments.add(new TopicAssignment(EntityId = LOG.Id, TopicId = topicNameToTopics.get(topicName).Id));
+                topicAssignments.add(new TopicAssignment(EntityId = logEntry.Log__c, TopicId = topicNameToTopics.get(topicName).Id));
             }
         }
         insert new List<TopicAssignment>(topicAssignments);

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -10,7 +10,6 @@
 public without sharing class LogEntryEventHandler {
     private static final Map<String, Log__c> TRANSACTION_ID_TO_LOG = new Map<String, Log__c>();
 
-    private static Boolean logsUpserted = false;
     @TestVisible
     private static Boolean shouldCallStatusApi = Test.isRunningTest() == false;
 
@@ -37,12 +36,11 @@ public without sharing class LogEntryEventHandler {
     }
 
     private void upsertLogs(List<LogEntryEvent__e> logEntryEvents) {
-        Log__c recentLogWithDetails = getRecentLogWithDetails();
+        Log__c recentLogWithApiReleaseDetails = getRecentLogWithApiReleaseDetails();
 
         // The LogEntryEvent__e object stores a denormalized version of Log__c & LogEntry__c data
         // In case the list contains entries tied to multiple transactions, use the TRANSACTION_ID_TO_LOG map to create 1 Log__c per transaction ID
 
-        List<Log__c> logsToUpsert = new List<Log__c>();
         for (LogEntryEvent__e logEntryEvent : logEntryEvents) {
             if (TRANSACTION_ID_TO_LOG.containsKey(logEntryEvent.TransactionId__c) == true) {
                 continue;
@@ -52,9 +50,9 @@ public without sharing class LogEntryEventHandler {
             Log__c log = new Log__c();
             // To avoid making a callout for every log for details retrieved from api.status.salesforce.com,
             // ...try to query recent logs first to see if there is a recent log with the details already populated
-            if (recentLogWithDetails != null) {
-                log.ApiReleaseNumber__c = recentLogWithDetails.ApiReleaseNumber__c;
-                log.ApiReleaseVersion__c = recentLogWithDetails.ApiReleaseVersion__c;
+            if (recentLogWithApiReleaseDetails != null) {
+                log.ApiReleaseNumber__c = recentLogWithApiReleaseDetails.ApiReleaseNumber__c;
+                log.ApiReleaseVersion__c = recentLogWithApiReleaseDetails.ApiReleaseVersion__c;
             }
 
             log.ApiVersion__c = logEntryEvent.ApiVersion__c;
@@ -104,23 +102,18 @@ public without sharing class LogEntryEventHandler {
             log.UserRoleName__c = logEntryEvent.UserRoleName__c;
             log.UserType__c = logEntryEvent.UserType__c;
 
-            logsToUpsert.add(log);
             TRANSACTION_ID_TO_LOG.put(log.TransactionId__c, log);
         }
 
-        upsert logsToUpsert TransactionId__c;
+        upsert TRANSACTION_ID_TO_LOG.values() TransactionId__c;
 
         // If no recent logs have the details, and there is not another instance of the job in progress, then start a new one
-        if (shouldCallStatusApi == true && LoggerSettings__c.getOrgDefaults().EnableStatusApiCallout__c && recentLogWithDetails == null && getCountOfOpenJobs() == 0) {
+        if (shouldCallStatusApi == true && LoggerSettings__c.getOrgDefaults().EnableStatusApiCallout__c && recentLogWithApiReleaseDetails == null && getCountOfOpenJobs() == 0) {
             setStatusApiDetails();
         }
     }
 
     private void insertLogEntries(List<LogEntryEvent__e> logEntryEvents) {
-        if (logsUpserted == false) {
-            return; // Avoid an exception - if there is no log, we can't save log entries
-        }
-
         for (LogEntryEvent__e logEntryEvent : logEntryEvents) {
             // Workaround field for platform issue w/ accurate datetimes
             Datetime timestamp = String.isNotBlank(logEntryEvent.TimestampString__c)
@@ -235,7 +228,7 @@ public without sharing class LogEntryEventHandler {
     }
 
     // Private static methods
-    private static Log__c getRecentLogWithDetails() {
+    private static Log__c getRecentLogWithApiReleaseDetails() {
         // Query for recent logs created only today - the status API should be called...
         // ...at least once per day to make sure that status details are still accurate.
         // This query should make a callout approximately every 4 hours.

--- a/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -123,6 +123,8 @@ private class LogEntryEventHandler_Tests {
                     FROM LogEntries__r
                 )
             FROM Log__c
+            ORDER BY CreatedDate
+            LIMIT 1
         ];
     }
 
@@ -365,6 +367,45 @@ private class LogEntryEventHandler_Tests {
 
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
+    }
+
+    @isTest
+    static void it_should_normalize_event_data_for_multiple_transactions_into_multiple_logs() {
+        List<String> transactionIds = new List<String>{ '123-456', '789-0' };
+        System.assertEquals(2, transactionIds.size());
+
+        List<LogEntryEvent__e> logEntryEvents = new List<LogEntryEvent__e>();
+        for (Integer i = 0; i < transactionIds.size(); i++) {
+            LogEntryEvent__e logEntryEvent = new LogEntryEvent__e(
+                Message__c = 'my message',
+                Timestamp__c = System.now(),
+                TransactionId__c = transactionIds.get(i)
+            );
+
+            logEntryEvents.add(logEntryEvent);
+        }
+        System.assertEquals(transactionIds.size(), logEntryEvents.size());
+
+        Test.startTest();
+        List<Database.SaveResult> saveResults = EventBus.publish(logEntryEvents);
+        Test.getEventBus().deliver();
+        System.assertEquals(transactionIds.size(), saveResults.size());
+        Test.stopTest();
+
+        for (Database.SaveResult saveResult : saveResults) {
+            System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
+        }
+
+        List<Log__c> logs = [SELECT Id, TransactionId__c, (SELECT Id FROM LogEntries__r) FROM Log__c];
+
+        System.assertEquals(2, logs.size(), logs);
+
+        // Convert the list of txn IDs to a set so we can use `contains()`
+        Set<String> uniqueTransactionIds = new Set<String>(transactionIds);
+        for (Log__c log : logs) {
+            System.assert(uniqueTransactionIds.contains(log.TransactionId__c), log.TransactionId__c);
+            System.assertEquals(1, log.LogEntries__r.size());
+        }
     }
 
     @isTest


### PR DESCRIPTION
It's hard to reproduce the scenario consistently, but it seems like in practice, 1 transaction of AFTER_INSERT on LogEntryEvent__e can sometimes have records with different transaction IDs. This seems to happen with some logging in batch jobs, but the existing code has an incorrect assumption that all of the `LogEntryEvent__e` records are tied to the same transaction ID.

I've updated the logic in `LogEntryEventHandler` to upsert a `List<Log__c>` (1 record per transaction ID) instead of just a single `Log__c` record.