### PR TITLE
Added example batch & queueable classes

### DIFF
--- a/examples/classes/Account_Batch_Logger_Example.cls
+++ b/examples/classes/Account_Batch_Logger_Example.cls
@@ -1,0 +1,44 @@
+// An example trigger to demo logging Account records, using all trigger operations
+// This , you should use a trigger handler framework, but this trigger is just for demo purposes
+public with sharing class Account_Batch_Logger_Example implements Database.Batchable<SObject>, Database.Stateful {
+    private String originalTransactionId;
+
+    public Database.QueryLocator start(Database.BatchableContext batchableContext) {
+        // Each batchable method runs in a separate transaction
+        // ...so store the first transaction ID to later relate the other transactions
+        this.originalTransactionId = Logger.getTransactionId();
+
+        Logger.info('Starting Account_Batch_Logger_Example');
+        Logger.saveLog();
+
+        // Just as an example, query 100 accounts
+        return Database.getQueryLocator([SELECT Id, Name, OwnerId, Owner.Name, Type FROM Account LIMIT 100]);
+    }
+
+    public void execute(Database.BatchableContext batchableContext, List<Account> scope) {
+        // One-time call (per transaction) to set the parent log
+        Logger.fine('this.originalTransactionId==' + this.originalTransactionId);
+        Logger.setParentLogTransactionId(this.originalTransactionId);
+
+        for (Account account : scope) {
+            // TODO add your batch job's logic
+
+            // Then log the result
+            Logger.info('Processed an account record', account);
+        }
+
+        Logger.debug('Saving account records', scope);
+        update scope;
+
+        Logger.saveLog();
+    }
+
+    public void finish(Database.BatchableContext batchableContext) {
+        // The finish method runs in yet-another transaction, so set the parent log again
+        Logger.fine('this.originalTransactionId==' + this.originalTransactionId);
+        Logger.setParentLogTransactionId(this.originalTransactionId);
+
+        Logger.info('Finishing running Account_Batch_Logger_Example');
+        Logger.saveLog();
+    }
+}

--- a/examples/classes/Account_Batch_Logger_Example.cls-meta.xml
+++ b/examples/classes/Account_Batch_Logger_Example.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/examples/classes/Account_Queueable_Logger_Example.cls
+++ b/examples/classes/Account_Queueable_Logger_Example.cls
@@ -1,0 +1,38 @@
+//------------------------------------------------------------------------------------------------//
+// This file is part of the Nebula Logger project, released under the MIT License.                //
+// See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    //
+//------------------------------------------------------------------------------------------------//
+
+// An example queueable job that will run several chained instances
+// Each instance uses the parentLogTransactionId to relate its log back to the original instance's log
+public with sharing class Account_Queueable_Logger_Example implements Queueable {
+    private Integer numberOfJobsToChain;
+    private String parentLogTransactionId;
+
+    private List<LogEntryEvent__e> logEntryEvents = new List<LogEntryEvent__e>();
+
+    public Account_Queueable_Logger_Example(Integer numberOfJobsToChain) {
+        this(numberOfJobsToChain, null);
+    }
+
+    public Account_Queueable_Logger_Example(Integer numberOfJobsToChain, String parentLogTransactionId) {
+        this.numberOfJobsToChain = numberOfJobsToChain;
+        this.parentLogTransactionId = parentLogTransactionId;
+    }
+
+    public void execute(System.QueueableContext queueableContext) {
+        Logger.setParentLogTransactionId(this.parentLogTransactionId);
+
+        Logger.fine('queueableContext==' + queueableContext);
+        Logger.info('this.numberOfJobsToChain==' + this.numberOfJobsToChain);
+        Logger.info('this.parentLogTransactionId==' + this.parentLogTransactionId);
+
+        Logger.saveLog();
+
+        --this.numberOfJobsToChain;
+        if (this.numberOfJobsToChain > 0) {
+            String parentLogTransactionId = this.parentLogTransactionId != null ? this.parentLogTransactionId : Logger.getTransactionId();
+            System.enqueueJob(new Account_Queueable_Logger_Example(this.numberOfJobsToChain, parentLogTransactionId));
+        }
+    }
+}

--- a/examples/classes/Account_Queueable_Logger_Example.cls-meta.xml
+++ b/examples/classes/Account_Queueable_Logger_Example.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
I realized I didn't include examples for batch or queueable Apex, so I've added basic examples of each. Both show how you can use `Logger.setParentLogTransactionId(String transactionId)` to relate async transactions back to the original transaction.