### PR TITLE
Removed refs to Account object in Admin.profile

### DIFF
--- a/nebula-logger/main/log-management/profiles/Admin.profile-meta.xml
+++ b/nebula-logger/main/log-management/profiles/Admin.profile-meta.xml
@@ -1387,9 +1387,6 @@
         <readable>true</readable>
     </fieldPermissions>
     <layoutAssignments>
-        <layout>Account-Account Layout</layout>
-    </layoutAssignments>
-    <layoutAssignments>
         <layout>LogEntry__c-Log Entry Layout</layout>
     </layoutAssignments>
     <layoutAssignments>
@@ -1398,15 +1395,6 @@
     <layoutAssignments>
         <layout>Log__c-Log Layout</layout>
     </layoutAssignments>
-    <objectPermissions>
-        <allowCreate>true</allowCreate>
-        <allowDelete>true</allowDelete>
-        <allowEdit>true</allowEdit>
-        <allowRead>true</allowRead>
-        <modifyAllRecords>true</modifyAllRecords>
-        <object>Account</object>
-        <viewAllRecords>true</viewAllRecords>
-    </objectPermissions>
     <objectPermissions>
         <allowCreate>true</allowCreate>
         <allowDelete>true</allowDelete>


### PR DESCRIPTION
Fixes #138 by removing references to the `Account` object in the Admin profile - these references should not have been added to the repo