### PR TITLE
Split sfdx-project.json into 2 versions

### DIFF
--- a/managed-package/sfdx-project.json
+++ b/managed-package/sfdx-project.json
@@ -1,0 +1,25 @@
+{
+    "namespace": "Nebula",
+    "sfdcLoginUrl": "https://login.salesforce.com",
+    "sourceApiVersion": "51.0",
+    "packageDirectories": [
+        {
+            "package": "Nebula Logger",
+            "path": "nebula-logger",
+            "default": true,
+            "definitionFile": "config/project-scratch-def.json",
+            "postInstallScript": "LoggerInstallHandler",
+            "versionName": "New Logger Console app, expanded Apex & Flow logging",
+            "versionNumber": "4.3.0.3",
+            "ancestorVersion": "4.2.0.0",
+            "versionDescription": "Includes new Logger Console app & reports for admins, automatic log sharing, and expanded logging for Apex & Flow",
+            "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases"
+        }
+    ],
+    "packageAliases": {
+        "Nebula Logger": "0Ho5Y000000XZCDSA4",
+        "Nebula Logger@4.0.0-9-managed-package-release": "04t5Y000000XJZ7QAO",
+        "Nebula Logger@4.2.0-0-more-fields-and-methods": "04t5Y000000Xg4wQAC",
+        "Nebula Logger@4.3.0-3-logger-console-app": "04t5Y000000YLDLQA4"
+    }
+}

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,25 +1,10 @@
 {
-    "namespace": "Nebula",
     "sfdcLoginUrl": "https://login.salesforce.com",
     "sourceApiVersion": "51.0",
     "packageDirectories": [
         {
-            "package": "Nebula Logger",
             "path": "nebula-logger",
-            "default": true,
-            "definitionFile": "config/project-scratch-def.json",
-            "postInstallScript": "LoggerInstallHandler",
-            "versionName": "New Logger Console app, expanded Apex & Flow logging",
-            "versionNumber": "4.3.0.3",
-            "ancestorVersion": "4.2.0.0",
-            "versionDescription": "Includes new Logger Console app & reports for admins, automatic log sharing, and expanded logging for Apex & Flow",
-            "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases"
+            "default": true
         }
-    ],
-    "packageAliases": {
-        "Nebula Logger": "0Ho5Y000000XZCDSA4",
-        "Nebula Logger@4.0.0-9-managed-package-release": "04t5Y000000XJZ7QAO",
-        "Nebula Logger@4.2.0-0-more-fields-and-methods": "04t5Y000000Xg4wQAC",
-        "Nebula Logger@4.3.0-3-logger-console-app": "04t5Y000000YLDLQA4"
-    }
+    ]
 }


### PR DESCRIPTION
Initially done by @jamessimone as part of the BigObject branch (WIP), this PR adds 2 versions of `sfdx-project.json`

- `./sfdx-project.json` - this version no longer references anything for the managed package or namespace. This makes it much easier for others to create scratch orgs and work on changes (since no one else has access to the `Nebula` namespace or packaging org
- `./managed-package/sfdx-project.json` - this version contains all of the additional details needed for the managed package. This version is really only needed when publishing new versions of the package, so it can be tucked away in the managed package directory.