### PR TITLE
Added new save method 'SYNCHRONOUS_DML'

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Apex developers can use additional `Logger` methods to dynamically control how l
     -   `Logger.SaveMethod.EVENT_BUS` - The default save method, this uses the `EventBus` class to publish `LogEntryEvent__e` records. The default save method can also be controlled declaratively by updating the field `LoggerSettings__c.DefaultSaveMethod__c`
     -   `Logger.SaveMethod.QUEUEABLE` - This save method will trigger `Logger` to save any pending records asynchronously using a queueable job. This is useful when you need to defer some CPU usage and other limits consumed by Logger.
     -   `Logger.SaveMethod.REST` - This save method will use the current user’s session ID to make a synchronous callout to the org’s REST API. This is useful when you have other callouts being made and you need to avoid mixed DML operations.
+    -   `Logger.SaveMethod.SYNCHRONOUS_DML` - This save method will skip publishing the `LogEntryEvent__e` platform events, and instead immediately creates `Log__c` and `LogEntry__c` records. This is useful when you are logging from within the context of another platform event and/or you do not anticipate any exceptions to occur in the current transaction. **Note**: when using this save method, any exceptions will prevent your log entries from being saved - Salesforce will rollback any DML statements, including your log entries! Use this save method cautiously.
 
 ### Track Related Logs in Batchable and Queuable Jobs
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Designed for Salesforce admins, developers & architects. A robust logger for Apex, Flow, Process Builder & Integrations.
 
-[![Install Unlocked Package](./content/btn-install-unlocked-package.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000027FIVQA2)
+[![Install Unlocked Package](./content/btn-install-unlocked-package.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000027FJdQAM)
 [![Install Managed Package](./content/btn-install-managed-package.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000027FFgQAM)
 [![Deploy Unpackaged Metadata](./content/btn-deploy-unpackaged-metadata.png)](https://githubsfdeploy.herokuapp.com/?owner=jongpie&repo=NebulaLogger&ref=main)
 [![View Documentation](./content/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Batch class used to delete old logs, based on `Log__c.LogRetentionDate__c <= :Sy
 
 ### [LogEntryEventHandler](log-management/LogEntryEventHandler)
 
-Subscribes to `LogEntryEvent__e` platform events and normalizes the data into `Log__c` and `LogEntry__c` records
+Processes `LogEntryEvent__e` platform events and normalizes the data into `Log__c` and `LogEntry__c` records
 
 ### [LogEntryFieldSetPicklist](log-management/LogEntryFieldSetPicklist)
 

--- a/docs/log-management/LogEntryEventHandler.md
+++ b/docs/log-management/LogEntryEventHandler.md
@@ -4,13 +4,15 @@ layout: default
 
 ## LogEntryEventHandler class
 
-Subscribes to `LogEntryEvent__e` platform events and normalizes the data into `Log__c` and `LogEntry__c` records
+Processes `LogEntryEvent__e` platform events and normalizes the data into `Log__c` and `LogEntry__c` records
 
 ---
 
 ### Constructors
 
 #### `LogEntryEventHandler()`
+
+#### `LogEntryEventHandler(List<LogEntryEvent__e> logEntryEvents)`
 
 ---
 

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -37,13 +37,11 @@ public without sharing class LogEntryEventHandler {
      * @description Runs the trigger handler's logic for the `LogEntryEvent__e` platform event object
      */
     public void execute() {
-        if (this.logEntryEvents.isEmpty()) {
-            return;
+        if (this.logEntryEvents.isEmpty() == false) {
+            this.upsertLogs();
+            this.insertLogEntries();
+            this.insertTopics();
         }
-
-        this.upsertLogs();
-        this.insertLogEntries();
-        this.insertTopics();
     }
 
     private void upsertLogs() {

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -23,6 +23,12 @@ public without sharing class LogEntryEventHandler {
     private Map<LogEntry__c, List<String>> logEntryToTopics;
     private Set<String> topicNames;
 
+    public LogEntryEventHandler(List<LogEntryEvent__e> logEntryEvents) {
+        this();
+
+        this.logEntryEvents = logEntryEvents;
+    }
+
     public LogEntryEventHandler() {
         this.logEntryEvents = (List<LogEntryEvent__e>) Trigger.new;
         this.triggerOperationType = Trigger.operationType;
@@ -36,13 +42,13 @@ public without sharing class LogEntryEventHandler {
      * @description Runs the trigger handler's logic for the `LogEntryEvent__e` platform event object
      */
     public void execute() {
-        switch on this.triggerOperationType {
-            when AFTER_INSERT {
-                this.upsertLogs();
-                this.insertLogEntries();
-                this.insertTopics();
-            }
+        if (this.logEntryEvents.isEmpty()) {
+            return;
         }
+
+        this.upsertLogs();
+        this.insertLogEntries();
+        this.insertTopics();
     }
 
     private void upsertLogs() {

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -16,22 +16,17 @@ public without sharing class LogEntryEventHandler {
     // Trigger-based variables - tests can override these with mock objects
     @testVisible
     private List<LogEntryEvent__e> logEntryEvents;
-    @testVisible
-    private TriggerOperation triggerOperationType;
 
     private List<LogEntry__c> logEntries;
     private Map<LogEntry__c, List<String>> logEntryToTopics;
     private Set<String> topicNames;
 
-    public LogEntryEventHandler(List<LogEntryEvent__e> logEntryEvents) {
-        this();
-
-        this.logEntryEvents = logEntryEvents;
+    public LogEntryEventHandler() {
+        this((List<LogEntryEvent__e>) Trigger.new);
     }
 
-    public LogEntryEventHandler() {
-        this.logEntryEvents = (List<LogEntryEvent__e>) Trigger.new;
-        this.triggerOperationType = Trigger.operationType;
+    public LogEntryEventHandler(List<LogEntryEvent__e> logEntryEvents) {
+        this.logEntryEvents = logEntryEvents;
 
         this.logEntries = new List<LogEntry__c>();
         this.logEntryToTopics = new Map<LogEntry__c, List<String>>();
@@ -276,7 +271,7 @@ public without sharing class LogEntryEventHandler {
             SELECT Id, ApiReleaseNumber__c, ApiReleaseVersion__c
             FROM Log__c
             WHERE CreatedDate >= :fourHoursAgo AND CreatedDate = TODAY AND ApiReleaseNumber__c != NULL
-            ORDER BY CreatedDate DESC
+            ORDER BY StartTime__c DESC
             LIMIT 1
         ];
 

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -5,7 +5,7 @@
 
 /**
  * @group Log Management
- * @description Subscribes to `LogEntryEvent__e` platform events and normalizes the data into `Log__c` and `LogEntry__c` records
+ * @description Processes `LogEntryEvent__e` platform events and normalizes the data into `Log__c` and `LogEntry__c` records
  */
 public without sharing class LogEntryEventHandler {
     private static final Map<String, Log__c> TRANSACTION_ID_TO_LOG = new Map<String, Log__c>();

--- a/nebula-logger/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/main/logger-engine/classes/Logger.cls
@@ -2510,9 +2510,7 @@ global with sharing class Logger {
                 }
             }
             when SYNCHRONOUS_DML {
-                System.debug('saving with LogEntryEventHandler');
                 new LogEntryEventHandler(logEntryEvents).execute();
-                System.debug('saved with LogEntryEventHandler');
             }
         }
 

--- a/nebula-logger/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/main/logger-engine/classes/Logger.cls
@@ -57,7 +57,8 @@ global with sharing class Logger {
     global enum SaveMethod {
         EVENT_BUS,
         QUEUEABLE,
-        REST
+        REST,
+        SYNCHRONOUS_DML
     }
 
     // Settings management methods
@@ -2508,6 +2509,11 @@ global with sharing class Logger {
                     new RestApiSaver().insertRecords(logEntryEvents);
                 }
             }
+            when SYNCHRONOUS_DML {
+                System.debug('saving with LogEntryEventHandler');
+                new LogEntryEventHandler(logEntryEvents).execute();
+                System.debug('saved with LogEntryEventHandler');
+            }
         }
 
         flushBuffer();
@@ -2642,6 +2648,9 @@ global with sharing class Logger {
             }
             when 'REST' {
                 defaultSaveMethod = SaveMethod.REST;
+            }
+            when 'SYNCHRONOUS_DML' {
+                defaultSaveMethod = SaveMethod.SYNCHRONOUS_DML;
             }
             when else {
                 defaultSaveMethod = SaveMethod.EVENT_BUS;

--- a/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -262,6 +262,16 @@ private class LogEntryEventHandler_Tests {
     }
 
     @isTest
+    static void it_should_gracefully_skip_execution_when_logEntryEvents_list_is_empty() {
+        List<LogEntryEvent__e> logEntryEvents = new List<LogEntryEvent__e>();
+        System.assert(logEntryEvents.isEmpty());
+
+        Test.startTest();
+        new LogEntryEventHandler(logEntryEvents).execute();
+        Test.stopTest();
+    }
+
+    @isTest
     static void it_should_normalize_simple_event_data_into_log_and_log_entry() {
         String transactionId = '123-456-789-0';
 
@@ -489,12 +499,69 @@ private class LogEntryEventHandler_Tests {
 
         System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
 
+        System.assertEquals(1, Limits.getCallouts());
+
         Log__c log = getLog();
         System.assertEquals(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
 
         System.assertEquals(MOCK_RELEASE_NUMBER, log.ApiReleaseNumber__c);
         System.assertEquals(MOCK_RELEASE_VERSION, log.ApiReleaseVersion__c);
+        validateLogFields(logEntryEvent, log);
+        validateLogEntryFields(logEntryEvent, logEntry);
+    }
+
+    @isTest
+    static void it_should_set_api_release_number_and_api_release_version_from_recent_record() {
+        Log__c recentLog = new Log__c(
+            ApiReleaseNumber__c = 'QWERTY',
+            ApiReleaseVersion__c = 'ASDF',
+            TransactionId__c = 'ABC-XYZ'
+        );
+        insert recentLog;
+
+        insert new LogEntry__c(
+            Log__c = recentLog.Id,
+            Timestamp__c = System.now().addHours(-1)
+        );
+
+        LogEntryEventHandler.shouldCallStatusApi = true;
+
+        LoggerSettings__c orgDefaults = LoggerSettings__c.getOrgDefaults();
+        orgDefaults.EnableStatusApiCallout__c = true;
+        upsert orgDefaults;
+
+        String transactionId = '123-456-789-0';
+        LogEntryEvent__e logEntryEvent = new LogEntryEvent__e(
+            EpochTimestamp__c = System.now().getTime(),
+            Message__c = 'my message',
+            Timestamp__c = System.now(),
+            TransactionEntryNumber__c = 1,
+            TransactionId__c = transactionId
+        );
+
+        Database.SaveResult saveResult;
+
+        Test.startTest();
+
+        saveResult = EventBus.publish(logEntryEvent);
+        // Normally, you don't have to call Test.getEventBus().deliver() if you're also using Test.stopTest()
+        // But, in this case, there are 3 transactions happening (original test, async platform event, and async future method)
+        // So, call Test.getEventBus().deliver() and Test.stopTest() to make sure all transactions are completed before running asserts
+        Test.getEventBus().deliver();
+
+        Test.stopTest();
+
+        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
+
+        System.assertEquals(0, Limits.getCallouts());
+
+        Log__c log = getLog();
+        System.assertEquals(1, log.LogEntries__r.size());
+        LogEntry__c logEntry = log.LogEntries__r.get(0);
+
+        System.assertEquals(recentLog.ApiReleaseNumber__c, log.ApiReleaseNumber__c);
+        System.assertEquals(recentLog.ApiReleaseVersion__c, log.ApiReleaseVersion__c);
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
     }

--- a/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -54,6 +54,7 @@ private class LogEntryEventHandler_Tests {
                 SessionSecurityLevel__c,
                 SessionType__c,
                 SourceIp__c,
+                StartTime__c,
                 SystemMode__c,
                 ThemeDisplayed__c,
                 TimeZoneId__c,
@@ -125,7 +126,7 @@ private class LogEntryEventHandler_Tests {
                     FROM LogEntries__r
                 )
             FROM Log__c
-            ORDER BY CreatedDate
+            ORDER BY StartTime__c DESC
             LIMIT 1
         ];
     }
@@ -557,6 +558,7 @@ private class LogEntryEventHandler_Tests {
         System.assertEquals(0, Limits.getCallouts());
 
         Log__c log = getLog();
+        System.assertNotEquals(recentLog.Id, log.Id, log.StartTime__c);
         System.assertEquals(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
 

--- a/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -500,8 +500,6 @@ private class LogEntryEventHandler_Tests {
 
         System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
 
-        System.assertEquals(1, Limits.getCallouts());
-
         Log__c log = getLog();
         System.assertEquals(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);

--- a/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
@@ -771,8 +771,6 @@ private class Logger_Tests {
 
         setUserLoggingLevel(LoggingLevel.DEBUG);
 
-        Logger.getUserSettings().DefaultSaveMethod__c = 'SYNCHRONOUS_DML';
-
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
 

--- a/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
@@ -595,10 +595,11 @@ private class Logger_Tests {
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.assertEquals(0, countOfLogEntries);
 
-        Test.startTest();
-
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.DEBUG.name();
         Logger.getUserSettings().DefaultSaveMethod__c = 'QUEUEABLE';
+        upsert Logger.getUserSettings();
+
+        Test.startTest();
 
         System.assertEquals(Logger.SaveMethod.QUEUEABLE, Logger.transactionSaveMethod);
 

--- a/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
@@ -556,6 +556,7 @@ private class Logger_Tests {
         System.assertEquals(1, Limits.getPublishImmediateDml());
         System.assertEquals(0, Limits.getQueueableJobs());
         System.assertEquals(0, Limits.getCallouts());
+        System.assertEquals(0, Limits.getDmlStatements());
 
         Test.stopTest();
 
@@ -581,6 +582,7 @@ private class Logger_Tests {
         System.assertEquals(1, Limits.getPublishImmediateDml());
         System.assertEquals(0, Limits.getQueueableJobs());
         System.assertEquals(0, Limits.getCallouts());
+        System.assertEquals(0, Limits.getDmlStatements());
 
         Test.stopTest();
 
@@ -611,6 +613,7 @@ private class Logger_Tests {
         System.assertEquals(0, Limits.getPublishImmediateDml());
         System.assertEquals(1, Limits.getQueueableJobs());
         System.assertEquals(0, Limits.getCallouts());
+        System.assertEquals(0, Limits.getDmlStatements());
 
         Test.stopTest();
 
@@ -636,6 +639,7 @@ private class Logger_Tests {
         System.assertEquals(0, Limits.getPublishImmediateDml());
         System.assertEquals(1, Limits.getQueueableJobs());
         System.assertEquals(0, Limits.getCallouts());
+        System.assertEquals(0, Limits.getDmlStatements());
 
         Test.getEventBus().deliver();
 
@@ -669,6 +673,7 @@ private class Logger_Tests {
         System.assertEquals(0, Limits.getPublishImmediateDml());
         System.assertEquals(0, Limits.getQueueableJobs());
         System.assertEquals(1, Limits.getCallouts());
+        System.assertEquals(0, Limits.getDmlStatements());
 
         Test.stopTest();
     }
@@ -693,6 +698,7 @@ private class Logger_Tests {
         System.assertEquals(0, Limits.getPublishImmediateDml());
         System.assertEquals(0, Limits.getQueueableJobs());
         System.assertEquals(1, Limits.getCallouts());
+        System.assertEquals(0, Limits.getDmlStatements());
 
         Test.stopTest();
     }
@@ -721,6 +727,67 @@ private class Logger_Tests {
         System.assertEquals(0, Limits.getPublishImmediateDml());
         System.assertEquals(0, Limits.getQueueableJobs());
         System.assertEquals(1, Limits.getCallouts());
+        System.assertEquals(0, Limits.getDmlStatements());
+
+        Test.stopTest();
+    }
+
+    @isTest
+    static void it_should_save_via_synchronous_dml_when_defaulted() {
+        Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
+        System.assertEquals(0, countOfLogEntries);
+
+        setUserLoggingLevel(LoggingLevel.DEBUG);
+
+        Logger.getUserSettings().DefaultSaveMethod__c = 'SYNCHRONOUS_DML';
+
+        System.assertEquals(Logger.SaveMethod.SYNCHRONOUS_DML, Logger.transactionSaveMethod);
+
+        Logger.debug('test log entry');
+        Logger.debug('another test log entry');
+
+        System.assertEquals(0, Limits.getCallouts());
+
+        Test.startTest();
+
+        Logger.saveLog();
+        System.assertEquals(0, Limits.getPublishImmediateDml());
+        System.assertEquals(0, Limits.getQueueableJobs());
+        System.assertEquals(0, Limits.getCallouts());
+        System.assertNotEquals(0, Limits.getDmlStatements());
+
+        // Requery & assert before Test.stopTest() since this is supposed to save synchronously
+        countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
+        System.assertEquals(2, countOfLogEntries);
+
+        Test.stopTest();
+    }
+
+    @isTest
+    static void it_should_save_via_synchronous_dml_when_specified() {
+        Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
+        System.assertEquals(0, countOfLogEntries);
+
+        setUserLoggingLevel(LoggingLevel.DEBUG);
+
+        Logger.getUserSettings().DefaultSaveMethod__c = 'SYNCHRONOUS_DML';
+
+        Logger.debug('test log entry');
+        Logger.debug('another test log entry');
+
+        System.assertEquals(0, Limits.getCallouts());
+
+        Test.startTest();
+
+        Logger.saveLog(Logger.SaveMethod.SYNCHRONOUS_DML);
+        System.assertEquals(0, Limits.getPublishImmediateDml());
+        System.assertEquals(0, Limits.getQueueableJobs());
+        System.assertEquals(0, Limits.getCallouts());
+        System.assertNotEquals(0, Limits.getDmlStatements());
+
+        // Requery & assert before Test.stopTest() since this is supposed to save synchronously
+        countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
+        System.assertEquals(2, countOfLogEntries);
 
         Test.stopTest();
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.4.5",
+    "version": "4.4.6",
     "description": "Designed for Salesforce admins, developers & architects. A robust logger for Apex, Flow, Process Builder & Integrations.",
     "scripts": {
         "deploy": "npm run deploy:logger && npm run deploy:managedpackage && npm run deploy:extratests",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -8,9 +8,9 @@
             "path": "nebula-logger",
             "default": true,
             "definitionFile": "config/project-scratch-def-with-experience-cloud.json",
-            "versionName": "LogBatchPurger Bugfixes",
-            "versionNumber": "4.4.5.0",
-            "versionDescription": "Fixes 2 issues in LogBatchPurger that could cause errors due to record chunking and query limits",
+            "versionName": "New save method SYNCHRONOUS_DML",
+            "versionNumber": "4.4.6.0",
+            "versionDescription": "The new save method skips publishing platform events and instead immediately creates Log__c and LogEntry__c records. Use cautiously!",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases"
         }
     ],
@@ -20,6 +20,7 @@
         "Nebula Logger - Unlocked Package@4.4.2-0-topics-overloads-cleanup": "04t5Y0000027FGeQAM",
         "Nebula Logger - Unlocked Package@4.4.3-0-guest-user-bugfix": "04t5Y0000027FI1QAM",
         "Nebula Logger - Unlocked Package@4.4.4-0-timestamp-bugfix": "04t5Y0000027FIQQA2",
-        "Nebula Logger - Unlocked Package@4.4.5-0-log-batch-purger-bugfixes": "04t5Y0000027FIVQA2"
+        "Nebula Logger - Unlocked Package@4.4.5-0-log-batch-purger-bugfixes": "04t5Y0000027FIVQA2",
+        "Nebula Logger - Unlocked Package@4.4.6-0-new-save-method-synchronous_dml": "04t5Y0000027FJdQAM"
     }
 }


### PR DESCRIPTION
This skips publishing platform events and instead immediately creates Log__c and LogEntry__c records