### PR TITLE
Logger.setParentLogTransactionId() ignores self-referencing transaction IDs

### DIFF
--- a/nebula-logger/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/main/logger-engine/classes/Logger.cls
@@ -85,7 +85,9 @@ global with sharing class Logger {
      * @param  parentTransactionId - The transaction ID of the original parent transaction
      */
     global static void setParentLogTransactionId(String parentTransactionId) {
-        parentLogTransactionId = parentTransactionId;
+        if (parentTransactionId != getTransactionId()) {
+            parentLogTransactionId = parentTransactionId;
+        }
     }
 
     /**

--- a/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
@@ -249,10 +249,17 @@ private class Logger_Tests {
     }
 
     @isTest
-    static void it_should_return_set_parent_transaction_id() {
+    static void it_should_set_parent_transaction_id() {
         String expectedParentTransactionId = 'imagineThisWereAGuid';
         Logger.setParentLogTransactionId(expectedParentTransactionId);
         System.assertEquals(expectedParentTransactionId, Logger.getParentLogTransactionId());
+    }
+
+    @isTest
+    static void it_should_ignore_parent_transaction_id_when_set_to_current_transaction_id() {
+        String currentTransactionId = Logger.getTransactionId();
+        Logger.setParentLogTransactionId(currentTransactionId);
+        System.assertEquals(null, Logger.getParentLogTransactionId());
     }
 
     @isTest


### PR DESCRIPTION
Closes #174 by adding an extra check in `Logger.setParentLogTransactionId(String parentTransactionId)` - it now ignores the value provided when it's the current transaction ID.