### PR TITLE
New 'anonymous mode' setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Designed for Salesforce admins, developers & architects. A robust logger for Apex, Flow, Process Builder & Integrations.
 
-[![Install Unlocked Package](./content/btn-install-unlocked-package.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015kfMQAQ)
+[![Install Unlocked Package](./content/btn-install-unlocked-package.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015kgPQAQ)
 [![Install Managed Package](./content/btn-install-managed-package.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015keOQAQ)
 [![View Documentation](./content/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
@@ -90,9 +90,6 @@ After deploying Nebula Logger to your org, there are a few additional configurat
     -   `LoggerAdmin` provides view-all and modify-all access to all log records.
 -   Customize the default settings in `LoggerSettings__c`
     -   You can customize settings at the org, profile and user levels
--   Unlocked Package Only: Enable Salesforce Topics for the `Log__c` and `LogEntry__c` objects for tagging/labeling. See [Salesforce Help](https://help.salesforce.com/articleView?id=sf.collab_topics_records_admin.htm) for more details.
-    -   Currently, enabling Topics for objects must still be done using the Salesforce Classic UI. Once enabled, Topics can then be used from withing Lightning Experience.
-    -   Once enabled, Topics can be added via Apex and Flow and then used as list view filters (and more) for the object `Log__c`.
 
 ---
 

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -98,7 +98,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
 
             log.ApiVersion__c = logEntryEvent.ApiVersion__c;
             log.Locale__c = logEntryEvent.Locale__c;
-            log.LoggedBy__c = logEntryEvent.CreatedById;
+            log.LoggedBy__c = logEntryEvent.LoggedById__c;
             log.LoggedByUsername__c = logEntryEvent.LoggedByUsername__c;
             log.LoginDomain__c = logEntryEvent.LoginDomain__c;
             log.LoginHistoryId__c = logEntryEvent.LoginHistoryId__c;

--- a/nebula-logger/main/log-management/objects/Log__c/fields/LoggedByUsernameLink__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/LoggedByUsernameLink__c.field-meta.xml
@@ -2,10 +2,14 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggedByUsernameLink__c</fullName>
     <externalId>false</externalId>
-    <formula>HYPERLINK(
-    LoggedBy__c, 
-    IF(ISBLANK(LoggedByUsername__c), LoggedBy__r.Username, LoggedByUsername__c), 
-    &apos;_top&apos;
+    <formula>IF(
+    ISBLANK(LoggedBy__c),
+    &apos;Anonymous&apos;,
+    HYPERLINK(
+        LoggedBy__c,
+        IF(ISBLANK(LoggedByUsername__c), LoggedBy__r.Username, LoggedByUsername__c),
+        &apos;_top&apos;
+    )
 )</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Username</label>

--- a/nebula-logger/main/log-management/objects/Log__c/listViews/AllLogs.listView-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/listViews/AllLogs.listView-meta.xml
@@ -3,15 +3,15 @@
     <fullName>AllLogs</fullName>
     <columns>NAME</columns>
     <columns>LoggedByUsernameLink__c</columns>
-    <columns>StartTime__c</columns>
-    <columns>OWNER.ALIAS</columns>
-    <columns>Priority__c</columns>
-    <columns>Status__c</columns>
     <columns>TransactionId__c</columns>
     <columns>TotalLimitsCpuTimeUsed__c</columns>
     <columns>TotalLogEntries__c</columns>
     <columns>TotalERRORLogEntries__c</columns>
     <columns>TotalWARNLogEntries__c</columns>
+    <columns>OWNER.ALIAS</columns>
+    <columns>Priority__c</columns>
+    <columns>Status__c</columns>
+    <columns>StartTime__c</columns>
     <filterScope>Everything</filterScope>
     <label>All Logs</label>
 </ListView>

--- a/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -41,25 +41,56 @@ global with sharing class LogEntryEventBuilder {
             return;
         }
 
+        String orgEnvironmentType;
+        if (ORGANIZATION.IsSandbox == true && ORGANIZATION.TrialExpirationDate != null) {
+            orgEnvironmentType = 'Scratch Org';
+        } else if (ORGANIZATION.IsSandbox == true) {
+            orgEnvironmentType = 'Sandbox';
+        } else {
+            orgEnvironmentType = 'Production';
+        }
+
         this.logEntryEvent = new LogEntryEvent__e(
             ApiVersion__c = API_VERSION,
+            LimitsAggregateQueriesMax__c = Limits.getLimitAggregateQueries(),
             LimitsAggregateQueriesUsed__c = Limits.getAggregateQueries(),
+            LimitsAsyncCallsMax__c = Limits.getLimitAsyncCalls(),
             LimitsAsyncCallsUsed__c = Limits.getAsyncCalls(),
+            LimitsCalloutsMax__c = Limits.getLimitCallouts(),
             LimitsCalloutsUsed__c = Limits.getCallouts(),
+            LimitsCpuTimeMax__c = Limits.getLimitCpuTime(),
             LimitsCpuTimeUsed__c = Limits.getCpuTime(),
+            LimitsDmlRowsMax__c = Limits.getLimitDmlRows(),
             LimitsDmlRowsUsed__c = Limits.getDmlRows(),
+            LimitsDmlStatementsMax__c = Limits.getLimitDmlStatements(),
             LimitsDmlStatementsUsed__c = Limits.getDmlStatements(),
+            LimitsEmailInvocationsMax__c = Limits.getLimitEmailInvocations(),
             LimitsEmailInvocationsUsed__c = Limits.getEmailInvocations(),
+            LimitsFutureCallsMax__c = Limits.getLimitFutureCalls(),
             LimitsFutureCallsUsed__c = Limits.getFutureCalls(),
+            LimitsHeapSizeMax__c = Limits.getLimitHeapSize(),
             LimitsHeapSizeUsed__c = Limits.getHeapSize(),
+            LimitsMobilePushApexCallsMax__c = Limits.getLimitMobilePushApexCalls(),
             LimitsMobilePushApexCallsUsed__c = Limits.getMobilePushApexCalls(),
+            LimitsQueueableJobsMax__c = Limits.getLimitQueueableJobs(),
             LimitsQueueableJobsUsed__c = Limits.getQueueableJobs(),
+            LimitsSoqlQueriesMax__c = Limits.getLimitQueries(),
             LimitsSoqlQueriesUsed__c = Limits.getQueries(),
+            LimitsSoqlQueryLocatorRowsMax__c = Limits.getLimitQueryLocatorRows(),
             LimitsSoqlQueryLocatorRowsUsed__c = Limits.getQueryLocatorRows(),
+            LimitsSoqlQueryRowsMax__c = Limits.getLimitQueryRows(),
             LimitsSoqlQueryRowsUsed__c = Limits.getQueryRows(),
+            LimitsSoslSearchesMax__c = Limits.getLimitSoslQueries(),
             LimitsSoslSearchesUsed__c = Limits.getSoslQueries(),
             LoggingLevel__c = entryLoggingLevel.NAME(),
             LoggingLevelOrdinal__c = entryLoggingLevel.ORDINAL(),
+            OrganizationDomainUrl__c = Url.getOrgDomainUrl()?.toExternalForm(),
+            OrganizationEnvironmentType__c = orgEnvironmentType,
+            OrganizationId__c = ORGANIZATION.Id,
+            OrganizationInstanceName__c = ORGANIZATION.InstanceName,
+            OrganizationName__c = ORGANIZATION.Name,
+            OrganizationNamespacePrefix__c = ORGANIZATION.NamespacePrefix,
+            OrganizationType__c = ORGANIZATION.OrganizationType,
             OriginType__c = ORIGIN_TYPE_APEX,
             Timestamp__c = System.now(),
             EpochTimestamp__c = System.now().getTime(),
@@ -482,8 +513,7 @@ global with sharing class LogEntryEventBuilder {
         }
 
         // Lazy-loading of some details to help minimize Apex heap size usage until needed
-        if (this.detailsAreSet == false) {
-            this.setOrganizationDetails();
+        if (this.detailsAreSet == false && Logger.getUserSettings().AnonymousMode__c == false) {
             this.setNetworkDetails();
             this.setUserDetails();
             this.setUserSessionDetails();
@@ -503,25 +533,6 @@ global with sharing class LogEntryEventBuilder {
         return this.logEntryEvent;
     }
 
-    private void setOrganizationDetails() {
-        String orgEnvironmentType;
-        if (ORGANIZATION.IsSandbox == true && ORGANIZATION.TrialExpirationDate != null) {
-            orgEnvironmentType = 'Scratch Org';
-        } else if (ORGANIZATION.IsSandbox == true) {
-            orgEnvironmentType = 'Sandbox';
-        } else {
-            orgEnvironmentType = 'Production';
-        }
-
-        this.logEntryEvent.OrganizationDomainUrl__c = Url.getOrgDomainUrl()?.toExternalForm();
-        this.logEntryEvent.OrganizationEnvironmentType__c = orgEnvironmentType;
-        this.logEntryEvent.OrganizationId__c = ORGANIZATION.Id;
-        this.logEntryEvent.OrganizationInstanceName__c = ORGANIZATION.InstanceName;
-        this.logEntryEvent.OrganizationName__c = ORGANIZATION.Name;
-        this.logEntryEvent.OrganizationNamespacePrefix__c = ORGANIZATION.NamespacePrefix;
-        this.logEntryEvent.OrganizationType__c = ORGANIZATION.OrganizationType;
-    }
-
     private void setNetworkDetails() {
         if (NETWORK_SITE == null) {
             return;
@@ -535,12 +546,41 @@ global with sharing class LogEntryEventBuilder {
     }
 
     private void setUserDetails() {
+        this.logEntryEvent.LoggedById__c = USER.Id;
         this.logEntryEvent.LoggedByUsername__c = USER.Username;
         this.logEntryEvent.ProfileName__c = USER.Profile.Name;
         this.logEntryEvent.UserLicenseDefinitionKey__c = USER.Profile.UserLicense.LicenseDefinitionKey;
         this.logEntryEvent.UserLicenseId__c = USER.Profile.UserLicenseId;
         this.logEntryEvent.UserLicenseName__c = USER.Profile.UserLicense.Name;
         this.logEntryEvent.UserRoleName__c = USER.UserRole?.Name;
+    }
+
+    private void setUserSessionDetails() {
+        LoggingLevel userLoggingLevel = Logger.getUserLoggingLevel();
+
+        this.logEntryEvent.Locale__c = UserInfo.getLocale();
+        this.logEntryEvent.NetworkId__c = Network.getNetworkId();
+        this.logEntryEvent.LoginHistoryId__c = AUTH_SESSION?.LoginHistoryId;
+        this.logEntryEvent.LoginApplication__c = AUTH_SESSION?.LoginHistory.Application;
+        this.logEntryEvent.LoginBrowser__c = AUTH_SESSION?.LoginHistory.Browser;
+        this.logEntryEvent.LoginPlatform__c = AUTH_SESSION?.LoginHistory.Platform;
+        this.logEntryEvent.LoginType__c = AUTH_SESSION?.LoginType;
+        this.logEntryEvent.LogoutUrl__c = AUTH_SESSION?.LogoutUrl;
+        this.logEntryEvent.ProfileId__c = UserInfo.getProfileId();
+        this.logEntryEvent.SessionId__c = AUTH_SESSION?.Id;
+        this.logEntryEvent.SessionSecurityLevel__c = AUTH_SESSION?.SessionSecurityLevel;
+        this.logEntryEvent.SessionType__c = AUTH_SESSION?.SessionType;
+        this.logEntryEvent.SourceIp__c = AUTH_SESSION?.SourceIp;
+        this.logEntryEvent.TimeZoneId__c = UserInfo.getTimeZone().getId();
+        this.logEntryEvent.TimeZoneName__c = UserInfo.getTimeZone().getDisplayName();
+        this.logEntryEvent.UserLoggingLevel__c = userLoggingLevel.name();
+        this.logEntryEvent.UserLoggingLevelOrdinal__c = userLoggingLevel.ordinal();
+        this.logEntryEvent.UserRoleId__c = UserInfo.getUserRoleId();
+        this.logEntryEvent.UserType__c = UserInfo.getUserType();
+
+        if (this.logEntryEvent.SessionType__c != 'Oauth2') {
+            this.logEntryEvent.ThemeDisplayed__c = UserInfo.getUiThemeDisplayed();
+        }
     }
 
     private String getSObjectClassification(Schema.SObjectType sobjectType) {
@@ -586,49 +626,6 @@ global with sharing class LogEntryEventBuilder {
             namespace = null;
         }
         return namespace;
-    }
-
-    private void setUserSessionDetails() {
-        LoggingLevel userLoggingLevel = Logger.getUserLoggingLevel();
-
-        this.logEntryEvent.LimitsAggregateQueriesMax__c = Limits.getLimitAggregateQueries();
-        this.logEntryEvent.LimitsAsyncCallsMax__c = Limits.getLimitAsyncCalls();
-        this.logEntryEvent.LimitsCalloutsMax__c = Limits.getLimitCallouts();
-        this.logEntryEvent.LimitsCpuTimeMax__c = Limits.getLimitCpuTime();
-        this.logEntryEvent.LimitsDmlRowsMax__c = Limits.getLimitDmlRows();
-        this.logEntryEvent.LimitsDmlStatementsMax__c = Limits.getLimitDmlStatements();
-        this.logEntryEvent.LimitsEmailInvocationsMax__c = Limits.getLimitEmailInvocations();
-        this.logEntryEvent.LimitsFutureCallsMax__c = Limits.getLimitFutureCalls();
-        this.logEntryEvent.LimitsHeapSizeMax__c = Limits.getLimitHeapSize();
-        this.logEntryEvent.LimitsMobilePushApexCallsMax__c = Limits.getLimitMobilePushApexCalls();
-        this.logEntryEvent.LimitsQueueableJobsMax__c = Limits.getLimitQueueableJobs();
-        this.logEntryEvent.LimitsSoqlQueriesMax__c = Limits.getLimitQueries();
-        this.logEntryEvent.LimitsSoqlQueryLocatorRowsMax__c = Limits.getLimitQueryLocatorRows();
-        this.logEntryEvent.LimitsSoqlQueryRowsMax__c = Limits.getLimitQueryRows();
-        this.logEntryEvent.LimitsSoslSearchesMax__c = Limits.getLimitSoslQueries();
-        this.logEntryEvent.Locale__c = UserInfo.getLocale();
-        this.logEntryEvent.NetworkId__c = Network.getNetworkId();
-        this.logEntryEvent.LoginHistoryId__c = AUTH_SESSION?.LoginHistoryId;
-        this.logEntryEvent.LoginApplication__c = AUTH_SESSION?.LoginHistory.Application;
-        this.logEntryEvent.LoginBrowser__c = AUTH_SESSION?.LoginHistory.Browser;
-        this.logEntryEvent.LoginPlatform__c = AUTH_SESSION?.LoginHistory.Platform;
-        this.logEntryEvent.LoginType__c = AUTH_SESSION?.LoginType;
-        this.logEntryEvent.LogoutUrl__c = AUTH_SESSION?.LogoutUrl;
-        this.logEntryEvent.ProfileId__c = UserInfo.getProfileId();
-        this.logEntryEvent.SessionId__c = AUTH_SESSION?.Id;
-        this.logEntryEvent.SessionSecurityLevel__c = AUTH_SESSION?.SessionSecurityLevel;
-        this.logEntryEvent.SessionType__c = AUTH_SESSION?.SessionType;
-        this.logEntryEvent.SourceIp__c = AUTH_SESSION?.SourceIp;
-        this.logEntryEvent.TimeZoneId__c = UserInfo.getTimeZone().getId();
-        this.logEntryEvent.TimeZoneName__c = UserInfo.getTimeZone().getDisplayName();
-        this.logEntryEvent.UserLoggingLevel__c = userLoggingLevel.name();
-        this.logEntryEvent.UserLoggingLevelOrdinal__c = userLoggingLevel.ordinal();
-        this.logEntryEvent.UserRoleId__c = UserInfo.getUserRoleId();
-        this.logEntryEvent.UserType__c = UserInfo.getUserType();
-
-        if (this.logEntryEvent.SessionType__c != 'Oauth2') {
-            this.logEntryEvent.ThemeDisplayed__c = UserInfo.getUiThemeDisplayed();
-        }
     }
 
     // Private static methods

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/LoggedById__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/LoggedById__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>LoggedById__c</fullName>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Logged By ID</label>
+    <length>18</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/main/logger-engine/objects/LoggerSettings__c/fields/AnonymousMode__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LoggerSettings__c/fields/AnonymousMode__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AnonymousMode__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <inlineHelpText
+    >When enabled, any logs generated will not have any user-specific details set - any fields related to the User, Profile, etc. will be null.</inlineHelpText>
+    <label>Anonymous Mode</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/nebula-logger/main/logger-engine/objects/LoggerSettings__c/listViews/All.listView-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LoggerSettings__c/listViews/All.listView-meta.xml
@@ -5,6 +5,7 @@
     <columns>SETUP_TYPE</columns>
     <columns>IsEnabled__c</columns>
     <columns>LoggingLevel__c</columns>
+    <columns>AnonymousMode__c</columns>
     <columns>EnableSystemMessages__c</columns>
     <columns>DefaultLogShareAccessLevel__c</columns>
     <columns>DefaultNumberOfDaysToRetainLogs__c</columns>

--- a/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -837,16 +837,18 @@ private class LogEntryEventHandler_Tests {
             orgEnvironmentType = 'Production';
         }
 
+        Id logOwnerId = logEntryEvent.LoggedById__c == null ? UserInfo.getUserId() : logEntryEvent.LoggedById__c;
+
         System.assertEquals(logEntryEvent.ApiVersion__c, log.ApiVersion__c);
         System.assertEquals(logEntryEvent.Locale__c, log.Locale__c);
-        System.assertEquals(UserInfo.getUserId(), log.LoggedBy__c);
+        System.assertEquals(logEntryEvent.LoggedById__c, log.LoggedBy__c);
         System.assertEquals(logEntryEvent.LoggedByUsername__c, log.LoggedByUsername__c);
         System.assertEquals(logEntryEvent.LoginDomain__c, log.LoginDomain__c);
         System.assertEquals(logEntryEvent.LoginHistoryId__c, log.LoginHistoryId__c);
         System.assertEquals(logEntryEvent.LoginType__c, log.LoginType__c);
         System.assertEquals(logEntryEvent.LogoutUrl__c, log.LogoutUrl__c);
         System.assertEquals(logEntryEvent.NetworkId__c, log.NetworkId__c);
-        System.assertEquals(UserInfo.getUserId(), log.OwnerId);
+        System.assertEquals(logOwnerId, log.OwnerId);
         System.assertEquals(logEntryEvent.ProfileId__c, log.ProfileId__c);
         System.assertEquals(logEntryEvent.SessionId__c, log.SessionId__c);
         System.assertEquals(logEntryEvent.SessionId__c, log.SessionId__c);

--- a/nebula-logger/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -132,43 +132,43 @@ private class LogEntryEventBuilder_Tests {
         System.assertEquals(false, builder.getLogEntryEvent().MessageTruncated__c);
         System.assertEquals(message, builder.getLogEntryEvent().Message__c);
     }
-    
+
     @IsTest
     static void it_should_truncate_message_for_long_logMessage() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(LoggingLevel.INFO, true);
         System.assertEquals(false, builder.getLogEntryEvent().MessageTruncated__c);
         System.assertEquals(null, builder.getLogEntryEvent().Message__c);
-        
+
         Test.startTest();
-        
+
         Integer maxMessageLength = Schema.LogEntry__c.Message__c.getDescribe().getLength();
         String baseMessage = 'z'.repeat(LogEntryEvent__e.Message__c.getDescribe().getLength() + 1);
         LogMessage logMessage = new LogMessage(baseMessage, 'something else');
         builder.setMessage(logMessage);
         System.assert(logMessage.getMessage().length() > maxMessageLength, 'Test message length should exceed the field length');
         builder.setMessage(logMessage);
-        
+
         Test.stopTest();
-        
+
         System.assertEquals(true, builder.getLogEntryEvent().MessageTruncated__c, 'Message should have been truncated');
         System.assertEquals(logMessage.getMessage().left(maxMessageLength), builder.getLogEntryEvent().Message__c);
     }
-    
+
     @IsTest
     static void it_should_truncate_message_for_long_string() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(LoggingLevel.INFO, true);
         System.assertEquals(false, builder.getLogEntryEvent().MessageTruncated__c);
         System.assertEquals(null, builder.getLogEntryEvent().Message__c);
-        
+
         Test.startTest();
-        
+
         Integer maxMessageLength = Schema.LogEntry__c.Message__c.getDescribe().getLength();
         String message = 'z'.repeat(LogEntryEvent__e.Message__c.getDescribe().getLength() + 1);
         System.assert(message.length() > maxMessageLength, 'Test message length should exceed the field length');
         builder.setMessage(message);
-        
+
         Test.stopTest();
-        
+
         System.assertEquals(true, builder.getLogEntryEvent().MessageTruncated__c, 'Message should have been truncated');
         System.assertEquals(message.left(maxMessageLength), builder.getLogEntryEvent().Message__c);
     }
@@ -939,6 +939,7 @@ private class LogEntryEventBuilder_Tests {
         System.assertEquals(organization.OrganizationType, builder.getLogEntryEvent().OrganizationType__c);
 
         // Verify user fields
+        System.assertEquals(USER.Id, builder.getLogEntryEvent().LoggedById__c);
         System.assertEquals(USER.Username, builder.getLogEntryEvent().LoggedByUsername__c);
         System.assertEquals(USER.Profile.Name, builder.getLogEntryEvent().ProfileName__c);
         System.assertEquals(USER.Profile.UserLicense.LicenseDefinitionKey, builder.getLogEntryEvent().UserLicenseDefinitionKey__c);

--- a/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
@@ -807,6 +807,100 @@ private class Logger_Tests {
     }
 
     @IsTest
+    static void it_should_not_set_user_fields_when_anonymous_mode_enabled() {
+        Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
+        System.assertEquals(0, countOfLogEntries);
+
+        Logger.getUserSettings().AnonymousMode__c = true;
+        Logger.debug('test log entry');
+        Logger.debug('another test log entry');
+
+        Test.startTest();
+        Logger.saveLog();
+        Test.stopTest();
+
+        Log__c log = [
+            SELECT
+                Id,
+                Locale__c,
+                LoggedBy__c,
+                LoggedByUsername__c,
+                LoggedByUsernameLink__c,
+                LoginApplication__c,
+                LoginBrowser__c,
+                LoginHistoryId__c,
+                LoginPlatform__c,
+                LoginType__c,
+                LogoutUrl__c,
+                NetworkId__c,
+                NetworkLoginUrl__c,
+                NetworkLogoutUrl__c,
+                NetworkName__c,
+                NetworkSelfRegistrationUrl__c,
+                NetworkUrlPathPrefix__c,
+                OrganizationDomainUrl__c,
+                OrganizationEnvironmentType__c,
+                OrganizationId__c,
+                OrganizationInstanceName__c,
+                OrganizationName__c,
+                OrganizationNamespacePrefix__c,
+                OrganizationType__c,
+                ProfileId__c,
+                ProfileName__c,
+                SessionId__c,
+                SessionSecurityLevel__c,
+                SessionType__c,
+                SourceIp__c,
+                ThemeDisplayed__c,
+                TimeZoneId__c,
+                TimeZoneName__c,
+                UserLicenseDefinitionKey__c,
+                UserLicenseId__c,
+                UserLicenseName__c,
+                UserLoggingLevel__c,
+                UserLoggingLevelOrdinal__c,
+                UserRoleId__c,
+                UserRoleName__c,
+                UserType__c
+            FROM Log__c
+        ];
+
+        System.assertEquals('Anonymous', log.LoggedByUsernameLink__c);
+        System.assertEquals(null, log.NetworkName__c);
+        System.assertEquals(null, log.NetworkLoginUrl__c);
+        System.assertEquals(null, log.NetworkLogoutUrl__c);
+        System.assertEquals(null, log.NetworkSelfRegistrationUrl__c);
+        System.assertEquals(null, log.NetworkUrlPathPrefix__c);
+        System.assertEquals(null, log.LoggedBy__c);
+        System.assertEquals(null, log.LoggedByUsername__c);
+        System.assertEquals(null, log.ProfileName__c);
+        System.assertEquals(null, log.UserLicenseDefinitionKey__c);
+        System.assertEquals(null, log.UserLicenseId__c);
+        System.assertEquals(null, log.UserLicenseName__c);
+        System.assertEquals(null, log.UserRoleName__c);
+        System.assertEquals(null, log.Locale__c);
+        System.assertEquals(null, log.NetworkId__c);
+        System.assertEquals(null, log.LoginHistoryId__c);
+        System.assertEquals(null, log.LoginApplication__c);
+        System.assertEquals(null, log.LoginBrowser__c);
+        System.assertEquals(null, log.LoginPlatform__c);
+        System.assertEquals(null, log.LoginType__c);
+        System.assertEquals(null, log.LogoutUrl__c);
+        System.assertEquals(null, log.ProfileId__c);
+        System.assertEquals(null, log.SessionId__c);
+        System.assertEquals(null, log.SessionSecurityLevel__c);
+        System.assertEquals(null, log.SessionType__c);
+        System.assertEquals(null, log.SourceIp__c);
+        System.assertEquals(null, log.TimeZoneId__c);
+        System.assertEquals(null, log.TimeZoneName__c);
+        System.assertEquals(null, log.UserLoggingLevel__c);
+        System.assertEquals(null, log.UserLoggingLevelOrdinal__c);
+        System.assertEquals(null, log.UserRoleId__c);
+        System.assertEquals(null, log.UserType__c);
+        System.assertEquals(null, log.ThemeDisplayed__c);
+    }
+
+    @IsTest
     static void it_should_flush_buffer() {
         System.assertEquals(0, Logger.getBufferSize());
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.6.0",
+    "version": "4.6.2",
     "description": "Designed for Salesforce admins, developers & architects. A robust logger for Apex, Flow, Process Builder & Integrations.",
     "scripts": {
         "deploy": "npm run deploy:logger && npm run deploy:managedpackage && npm run deploy:extratests",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -44,6 +44,7 @@
         "Nebula Logger - Unlocked Package@4.5.2-0-plugin-framework-enhancements": "04t5Y0000027FNaQAM",
         "Nebula Logger - Unlocked Package@4.6.0-0-tagging-system-overhaul": "04t5Y0000015keTQAQ",
         "Nebula Logger - Unlocked Package@4.6.1-0-summer-21-upgrade": "04t5Y0000015kfMQAQ",
+        "Nebula Logger - Unlocked Package@4.6.2-0-anonymous-logs": "04t5Y0000015kgPQAQ",
         "Nebula Logger Plugin - Slack": "0Ho5e000000oM3pCAE",
         "Nebula Logger Plugin - Slack@0.9.0-0-beta-release": "04t5e00000061lHAAQ",
         "Nebula Logger Plugin - Slack@0.9.1-0-beta-release-round-2": "04t5e00000065xiAAA"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -8,9 +8,9 @@
             "path": "nebula-logger",
             "default": false,
             "definitionFile": "config/project-scratch-def-with-experience-cloud.json",
-            "versionNumber": "4.6.1.0",
-            "versionName": "Summer '21 Upgrade",
-            "versionDescription": "Upgraded metadata to API v52.0 + added LogEntry__c.EventUuid__c",
+            "versionNumber": "4.6.2.0",
+            "versionName": "Anonymous Logs",
+            "versionDescription": "Logs can now be anonymous - user-specific data is not stored",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases"
         },
         {


### PR DESCRIPTION
Logs can now be stored anonymously using the new 'anonymous mode' setting. 

### New Anonymous Mode setting

This feature can be enabled by checking the checkbox `LoggerSetting__c.AnonymousMode__c`. 

- Since `LoggerSettings__c` is a custom hierarchy setting, this feature can be configured at the org, profile or user level, allowing you to enable anonymous mode for just certain user(s) or profile(s), while still logging user-level details for other users.
- When enabled, data stored in the custom objects `Log__c` and `LogEntry__c` will not contain any user-identifying info. The audit fields `CreatedById` and `LastModifiedById` will (continue to be) the 'Automated Process' system-user.
- The platform event records in `LogEntryEvent__e` cannot be made fully anonymous - Salesforce automatically sets the field `LogEntryEvent__e.CreatedById` to the current user. All other user-related fields on `LogEntryEvent__e` will be set to null (just like on `Log__c` and `LogEntry__c`).

![image](https://user-images.githubusercontent.com/1267157/129317761-ed047b15-57dc-4dd8-9458-04551eb58654.png)

### Anonymous `Log__c` records in a list view

![image](https://user-images.githubusercontent.com/1267157/129316785-b34c8c54-901d-4d4d-a08f-e56ce3f61868.png)

### Detailed view of an anonymous `Log__c` record
All of the user-specific fields (including fields that come from `User`, `Profile`, `UserRole` and `Network`) are set to null. `Organization` details are still populated.

![image](https://user-images.githubusercontent.com/1267157/129317483-9c99811a-ff4b-4638-8d5d-76bd3bb90f79.png)

