### PR TITLE
Refactored trigger handler to manage more shared logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Designed for Salesforce admins, developers & architects. A robust logger for Apex, Lightning Components, Flow, Process Builder & Integrations.
 
-[![Install Unlocked Package](./content/btn-install-unlocked-package.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015kgjQAA)
+[![Install Unlocked Package](./content/btn-install-unlocked-package.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015kh3QAA)
 [![Install Managed Package](./content/btn-install-managed-package.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015keOQAQ)
 [![View Documentation](./content/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -16,27 +16,13 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
     @TestVisible
     private static final List<LogEntryTagRule__mdt> TAG_ASSIGNMENT_RULES = getTagAssignmentRules();
 
-    // Trigger-based variables - tests can override these with mock objects
     @TestVisible
-    private List<LogEntryEvent__e> logEntryEvents {
-        get {
-            return (List<LogEntryEvent__e>) this.triggerNew;
-        }
-    }
+    private List<LogEntryEvent__e> logEntryEvents;
 
     private Boolean shouldCallStatusApi = LoggerParameter.Handler.getBoolean('LogEntryEventHandler_CallStatusApi', false);
     private List<LogEntry__c> logEntries = new List<LogEntry__c>();
     private Map<String, List<String>> logEntryEventUuidToTagNames = new Map<String, List<String>>();
     private Set<String> tagNames = new Set<String>();
-
-    public LogEntryEventHandler() {
-    }
-
-    public LogEntryEventHandler(TriggerOperation triggerOperationType, List<LogEntryEvent__e> logEntryEvents) {
-        // Override the variables provided by LoggerSObjectHandler
-        this.triggerOperationType = triggerOperationType;
-        this.triggerNew = logEntryEvents;
-    }
 
     /**
      * @description Returns SObject Type that the handler is responsible for processing
@@ -46,24 +32,19 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
         return Schema.LogEntryEvent__e.SObjectType;
     }
 
-    /**
-     * @description Runs the trigger handler's logic for the `LogEntryEvent__e` platform event object
-     */
-    public override void execute() {
-        if (this.isEnabled() == false) {
-            return;
-        }
+    // Public method so it can be called from Logger - this is unique to LogEntryEventHandler
+    public override void executeBeforeInsert(List<SObject> triggerNew) {
+        this.logEntryEvents = (List<LogEntryEvent__e>) triggerNew;
+    }
 
-        switch on this.triggerOperationType {
-            when AFTER_INSERT {
-                this.upsertLogs();
-                this.insertLogEntries();
-                this.appendRuleBasedTags();
-                this.insertLogEntryTags();
-            }
-        }
+    // Public method so it can be called from Logger - this is unique to LogEntryEventHandler
+    public override void executeAfterInsert(List<SObject> triggerNew) {
+        this.logEntryEvents = (List<LogEntryEvent__e>) triggerNew;
 
-        this.executePlugins();
+        this.upsertLogs();
+        this.insertLogEntries();
+        this.appendRuleBasedTags();
+        this.insertLogEntryTags();
     }
 
     private void upsertLogs() {
@@ -71,10 +52,9 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
         // ...try to query recent logs first to see if there is a recent log with the details already populated
         Log__c recentLogWithApiReleaseDetails = getRecentLogWithApiReleaseDetails();
 
-        // The LogEntryEvent__e object stores a denormalized version of Log__c & LogEntry__c data
-        // In case the list contains entries tied to multiple transactions, use the TRANSACTION_ID_TO_LOG map to create 1 Log__c per transaction ID
-
         for (LogEntryEvent__e logEntryEvent : this.logEntryEvents) {
+            // The LogEntryEvent__e object stores a denormalized version of Log__c & LogEntry__c data
+            // In case the list contains entries tied to multiple transactions, use the TRANSACTION_ID_TO_LOG map to create 1 Log__c per transaction ID
             if (TRANSACTION_ID_TO_LOG.containsKey(logEntryEvent.TransactionId__c) == true) {
                 continue;
             }

--- a/nebula-logger/main/log-management/classes/LogEntryHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryHandler.cls
@@ -8,16 +8,8 @@
  * @description Manages setting fields on `LogEntry__c` before insert & before update
  */
 public without sharing class LogEntryHandler extends LoggerSObjectHandler {
-    // Trigger-based variables - tests can override these with mock objects
     @TestVisible
-    private List<LogEntry__c> logEntries {
-        get {
-            return (List<LogEntry__c>) this.triggerNew;
-        }
-    }
-
-    public LogEntryHandler() {
-    }
+    private List<LogEntry__c> logEntries;
 
     /**
      * @description Returns SObject Type that the handler is responsible for processing
@@ -27,34 +19,25 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
         return Schema.LogEntry__c.SObjectType;
     }
 
-    /**
-     * @description Runs the trigger handler's logic for the `LogEntry__c` custom object
-     */
-    public override void execute() {
-        if (this.isEnabled() == false) {
-            return;
-        }
+    protected override void executeBeforeInsert(List<SObject> triggerNew) {
+        this.logEntries = (List<LogEntry__c>) triggerNew;
 
-        switch on this.triggerOperationType {
-            when BEFORE_INSERT {
-                this.setCheckboxFields();
-                this.setApexClassFields();
-                this.setComponentFields();
-                this.setFlowDefinitionFields();
-                this.setFlowVersionFields();
-                this.setRecordNames();
-            }
-            when BEFORE_UPDATE {
-                // Realistically, these checkbox fields probably only need to be set on insert
-                // but some admins & devs might decide to update/append data in some of the related fields
-                // and it conceptually feels weird for there to be scenarios where these fields could be inaccurate,
-                // so keep them up to date just to be safe
-                this.setCheckboxFields();
-            }
-        }
+        this.setCheckboxFields();
+        this.setApexClassFields();
+        this.setComponentFields();
+        this.setFlowDefinitionFields();
+        this.setFlowVersionFields();
+        this.setRecordNames();
+    }
 
-        // Run any plugins configured in the LoggerSObjectHandlerPlugin__mdt custom metadata type
-        this.executePlugins();
+    protected override void executeBeforeUpdate(Map<Id, SObject> triggerNewMap, Map<Id, SObject> triggerOldMap) {
+        this.logEntries = (List<LogEntry__c>) triggerNewMap.values();
+
+        // Realistically, these checkbox fields probably only need to be set on insert
+        // but some admins & devs might decide to update/append data in some of the related fields
+        // and it conceptually feels weird for there to be scenarios where these fields could be inaccurate,
+        // so keep them up to date just to be safe
+        this.setCheckboxFields();
     }
 
     private void setCheckboxFields() {

--- a/nebula-logger/main/log-management/classes/LogEntryTagHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryTagHandler.cls
@@ -10,13 +10,8 @@
 public without sharing class LogEntryTagHandler extends LoggerSObjectHandler {
     private static final Map<String, Log__c> TRANSACTION_ID_TO_LOG = new Map<String, Log__c>();
 
-    // Trigger-based variables - tests can override these with mock objects
     @TestVisible
-    private List<LogEntryTag__c> logEntryTags {
-        get {
-            return (List<LogEntryTag__c>) this.triggerNew;
-        }
-    }
+    private List<LogEntryTag__c> logEntryTags;
 
     /**
      * @description Returns SObject Type that the handler is responsible for processing
@@ -26,21 +21,16 @@ public without sharing class LogEntryTagHandler extends LoggerSObjectHandler {
         return Schema.LogEntryTag__c.SObjectType;
     }
 
-    /**
-     * @description Runs the trigger handler's logic for the `LogEntryTag__c` custom object
-     */
-    public override void execute() {
-        if (this.isEnabled() == false) {
-            return;
-        }
+    protected override void executeBeforeInsert(List<SObject> triggerNew) {
+        this.logEntryTags = (List<LogEntryTag__c>) triggerNew;
 
-        switch on this.triggerOperationType {
-            when BEFORE_INSERT, BEFORE_UPDATE {
-                this.setUniqueIdField();
-            }
-        }
+        this.setUniqueIdField();
+    }
 
-        this.executePlugins();
+    protected override void executeBeforeUpdate(Map<Id, SObject> triggerNewMap, Map<Id, SObject> triggerOldMap) {
+        this.logEntryTags = (List<LogEntryTag__c>) triggerNewMap.values();
+
+        this.setUniqueIdField();
     }
 
     private void setUniqueIdField() {

--- a/nebula-logger/main/log-management/classes/LogHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogHandler.cls
@@ -22,23 +22,11 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
         return logStatusByName;
     }
 
-    // Trigger-based variables - tests can override these with mock objects
     @TestVisible
-    private List<Log__c> logs {
-        get {
-            return (List<Log__c>) this.triggerNew;
-        }
-    }
+    private List<Log__c> logs;
 
     @TestVisible
-    private Map<Id, Log__c> oldLogsById {
-        get {
-            return (Map<Id, Log__c>) this.triggerOldMap;
-        }
-    }
-
-    public LogHandler() {
-    }
+    private Map<Id, Log__c> oldLogsById;
 
     /**
      * @description Returns SObject Type that the handler is responsible for processing
@@ -48,33 +36,28 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
         return Schema.Log__c.SObjectType;
     }
 
-    /**
-     * @description Runs the trigger handler's logic for the `Log__c` custom object
-     */
-    public override void execute() {
-        if (this.isEnabled() == false) {
-            return;
-        }
+    protected override void executeBeforeInsert(List<SObject> triggerNew) {
+        this.logs = (List<Log__c>) triggerNew;
 
-        switch on this.triggerOperationType {
-            when BEFORE_INSERT {
-                this.setOrgReleaseCycle();
-                this.setClosedStatusFields();
-                // The log retention date field should support being manually changed, so only auto-set it on insert
-                this.setLogRetentionDate();
-            }
-            when BEFORE_UPDATE {
-                this.setClosedStatusFields();
-                // Priority logic relies on roll-up fields, so only run on update (after log entries are inserted)
-                this.setPriority();
-            }
-            when AFTER_INSERT {
-                this.shareLogsWithLoggingUsers();
-            }
-        }
+        this.setOrgReleaseCycle();
+        this.setClosedStatusFields();
+        // The log retention date field should support being manually changed, so only auto-set it on insert
+        this.setLogRetentionDate();
+    }
 
-        // Run any plugins configured in the LoggerSObjectHandlerPlugin__mdt custom metadata type
-        this.executePlugins();
+    protected override void executeBeforeUpdate(Map<Id, SObject> triggerNewMap, Map<Id, SObject> triggerOldMap) {
+        this.logs = (List<Log__c>) triggerNewMap.values();
+        this.oldLogsById = (Map<Id, Log__c>) triggerOldMap;
+
+        this.setClosedStatusFields();
+        // Priority logic relies on roll-up fields, so only run on update (after log entries are inserted)
+        this.setPriority();
+    }
+
+    protected override void executeAfterInsert(Map<Id, SObject> triggerNewMap) {
+        this.logs = (List<Log__c>) triggerNewMap.values();
+
+        this.shareLogsWithLoggingUsers();
     }
 
     private void setOrgReleaseCycle() {

--- a/nebula-logger/main/log-management/classes/LoggerSObjectHandler.cls
+++ b/nebula-logger/main/log-management/classes/LoggerSObjectHandler.cls
@@ -48,7 +48,7 @@ public abstract class LoggerSObjectHandler {
         }
     }
 
-    // Private static testVisible methods
+    // Private static TestVisible methods
     @TestVisible
     private static void setMockConfiguration(Schema.SObjectType sobjectType, LoggerSObjectHandler__mdt configuration) {
         configurationBySObjectType.put(sobjectType, configuration);
@@ -65,15 +65,15 @@ public abstract class LoggerSObjectHandler {
     }
 
     @TestVisible
-    protected TriggerOperation triggerOperationType;
+    private TriggerOperation triggerOperationType;
     @TestVisible
-    protected List<SObject> triggerNew;
+    private List<SObject> triggerNew;
     @TestVisible
-    protected Map<Id, SObject> triggerNewMap;
+    private Map<Id, SObject> triggerNewMap;
     @TestVisible
-    protected List<SObject> triggerOld;
+    private List<SObject> triggerOld;
     @TestVisible
-    protected Map<Id, SObject> triggerOldMap;
+    private Map<Id, SObject> triggerOldMap;
 
     private LoggerSObjectHandler__mdt handlerConfiguration;
     private List<LoggerSObjectHandlerPlugin__mdt> plugins;
@@ -81,7 +81,7 @@ public abstract class LoggerSObjectHandler {
     public LoggerSObjectHandler() {
         this.setConfigurations();
 
-        if (this.handlerConfiguration.IsEnabled__c == true) {
+        if (this.isEnabled() == true) {
             this.triggerOperationType = Trigger.operationType;
             this.triggerNew = Trigger.new;
             this.triggerNewMap = Trigger.newMap;
@@ -99,17 +99,72 @@ public abstract class LoggerSObjectHandler {
     /**
      * @description Runs the handler class's logic
      */
-    public abstract void execute();
+    public void execute() {
+        if (this.isEnabled() == false) {
+            return;
+        }
 
-    /**
-     * @description Indicates if the current SObject Handler is enabled, based on `LoggerSObjectHandler__mdt.IsEnabled__c`
-     * @return   The `Boolean` value (`true` == enabled, `false` == disabled)
-     */
-    protected Boolean isEnabled() {
+        switch on this.triggerOperationType {
+            when BEFORE_INSERT {
+                this.executeBeforeInsert(this.triggerNew);
+            }
+            when BEFORE_UPDATE {
+                this.executeBeforeUpdate(this.triggerNewMap, this.triggerOldMap);
+            }
+            when BEFORE_DELETE {
+                this.executeBeforeDelete(this.triggerNewMap);
+            }
+            when AFTER_INSERT {
+                // Platform Events don't have an ID field, thus Trigger.newMap doesn't work for LogEntryEvent__e
+                // For custom objects, Map<Id, SObject> is more convenient since it provides both the keys & values
+                // 2 AFTER_INSERT methods are used here in the framework, with the expectation that only 1 will be implemented per handler class
+                this.executeAfterInsert(this.triggerNew);
+                this.executeAfterInsert(this.triggerNewMap);
+            }
+            when AFTER_UPDATE {
+                this.executeAfterUpdate(this.triggerNewMap, this.triggerOldMap);
+            }
+            when AFTER_DELETE {
+                this.executeAfterDelete(this.triggerNewMap);
+            }
+            when AFTER_UNDELETE {
+                this.executeAfterUndelete(this.triggerNewMap);
+            }
+        }
+
+        this.executePlugins();
+    }
+
+    protected virtual void executeBeforeInsert(List<SObject> triggerNew) {
+    }
+
+    protected virtual void executeBeforeUpdate(Map<Id, SObject> triggerNewMap, Map<Id, SObject> triggerOldMap) {
+    }
+
+    protected virtual void executeBeforeDelete(Map<Id, SObject> triggerNewMap) {
+    }
+
+    // executeAfterInsert(List<SObject triggerNew) is used for LogEntryEvent__e, which does not have an ID field
+    protected virtual void executeAfterInsert(List<SObject> triggerNew) {
+    }
+
+    protected virtual void executeAfterInsert(Map<Id, SObject> triggerNewMap) {
+    }
+
+    protected virtual void executeAfterUpdate(Map<Id, SObject> triggerNewMap, Map<Id, SObject> triggerOldMap) {
+    }
+
+    protected virtual void executeAfterDelete(Map<Id, SObject> triggerNewMap) {
+    }
+
+    protected virtual void executeAfterUndelete(Map<Id, SObject> triggerNewMap) {
+    }
+
+    private Boolean isEnabled() {
         return this.handlerConfiguration.IsEnabled__c;
     }
 
-    protected void executePlugins() {
+    private void executePlugins() {
         if (this.plugins == null || this.plugins.isEmpty() == true) {
             return;
         }

--- a/nebula-logger/main/log-management/classes/LoggerTagHandler.cls
+++ b/nebula-logger/main/log-management/classes/LoggerTagHandler.cls
@@ -10,13 +10,8 @@
 public without sharing class LoggerTagHandler extends LoggerSObjectHandler {
     private static final Map<String, Log__c> TRANSACTION_ID_TO_LOG = new Map<String, Log__c>();
 
-    // Trigger-based variables - tests can override these with mock objects
     @TestVisible
-    private List<LoggerTag__c> loggerTags {
-        get {
-            return (List<LoggerTag__c>) this.triggerNew;
-        }
-    }
+    private List<LoggerTag__c> loggerTags;
 
     /**
      * @description Returns SObject Type that the handler is responsible for processing
@@ -26,21 +21,16 @@ public without sharing class LoggerTagHandler extends LoggerSObjectHandler {
         return Schema.LoggerTag__c.SObjectType;
     }
 
-    /**
-     * @description Runs the trigger handler's logic for the `LoggerTag__c` custom object
-     */
-    public override void execute() {
-        if (this.isEnabled() == false) {
-            return;
-        }
+    protected override void executeBeforeInsert(List<SObject> triggerNew) {
+        this.loggerTags = (List<LoggerTag__c>) triggerNew;
 
-        switch on this.triggerOperationType {
-            when BEFORE_INSERT, BEFORE_UPDATE {
-                this.setUniqueIdField();
-            }
-        }
+        this.setUniqueIdField();
+    }
 
-        this.executePlugins();
+    protected override void executeBeforeUpdate(Map<Id, SObject> triggerNewMap, Map<Id, SObject> triggerOldMap) {
+        this.loggerTags = (List<LoggerTag__c>) triggerNewMap.values();
+
+        this.setUniqueIdField();
     }
 
     private void setUniqueIdField() {

--- a/nebula-logger/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/main/logger-engine/classes/Logger.cls
@@ -2499,7 +2499,7 @@ global with sharing class Logger {
         // This gives us a chance to run the handler class & handler plugins before insert,
         // allowing the plugins to make further changes to the `LogEntryEvent__e` records
         // So, execute the handler, which internally then executes any plugins
-        new LogEntryEventHandler(TriggerOperation.BEFORE_INSERT, logEntryEvents).execute();
+        new LogEntryEventHandler().executeBeforeInsert(logEntryEvents);
 
         // Now that the plugins have run, double check to make sure that saving should still happen
         if (getBufferSize() == 0) {
@@ -2525,7 +2525,7 @@ global with sharing class Logger {
                 }
             }
             when SYNCHRONOUS_DML {
-                new LogEntryEventHandler(TriggerOperation.AFTER_INSERT, logEntryEvents).execute();
+                new LogEntryEventHandler().executeAfterInsert(logEntryEvents);
             }
         }
 

--- a/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -50,7 +50,8 @@ private class LogEntryEventHandler_Tests {
         System.assert(logEntryEvents.isEmpty());
 
         Test.startTest();
-        new LogEntryEventHandler(TriggerOperation.BEFORE_INSERT, logEntryEvents).execute();
+        new LogEntryEventHandler().executeBeforeInsert(logEntryEvents);
+        new LogEntryEventHandler().executeAfterInsert(logEntryEvents);
         Test.stopTest();
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.6.4",
+    "version": "4.6.5",
     "description": "Designed for Salesforce admins, developers & architects. A robust logger for Apex, Flow, Process Builder & Integrations.",
     "scripts": {
         "deploy": "npm run deploy:logger && npm run deploy:managedpackage && npm run deploy:extratests",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -8,9 +8,9 @@
             "path": "nebula-logger",
             "default": false,
             "definitionFile": "config/project-scratch-def-with-experience-cloud.json",
-            "versionNumber": "4.6.4.0",
-            "versionName": "Logger for lwc and aura",
-            "versionDescription": "Re-introduced a lightning component for frontend logging",
+            "versionNumber": "4.6.5.0",
+            "versionName": "Internal trigger handler optimizations",
+            "versionDescription": "Refactored trigger handler to manage more shared logic",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases"
         },
         {
@@ -47,6 +47,7 @@
         "Nebula Logger - Unlocked Package@4.6.2-0-anonymous-logs": "04t5Y0000015kgPQAQ",
         "Nebula Logger - Unlocked Package@4.6.3-0-more-metadata-data": "04t5Y0000015kgeQAA",
         "Nebula Logger - Unlocked Package@4.6.4-0-logger-for-lwc-and-aura": "04t5Y0000015kgjQAA",
+        "Nebula Logger - Unlocked Package@4.6.5-0-internal-trigger-handler-optimizations": "04t5Y0000015kh3QAA",
         "Nebula Logger Plugin - Slack": "0Ho5e000000oM3pCAE",
         "Nebula Logger Plugin - Slack@0.9.0-0-beta-release": "04t5e00000061lHAAQ",
         "Nebula Logger Plugin - Slack@0.9.1-0-beta-release-round-2": "04t5e00000065xiAAA"


### PR DESCRIPTION
Previously, each handler class was using `switch` statements around `Trigger.operationType` - the handler framework now manages it and calls protected methods as needed.