### PR TITLE
New 'Scenario' field on Log__c

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Deployment
 
 on:
     push:
-        branches:
-            - main
         paths-ignore:
             - 'content/**'
             - 'docs/**'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Deployment
 
 on:
     push:
+        branches:
+            - main
         paths-ignore:
             - 'content/**'
             - 'docs/**'

--- a/docs/logger-engine/ComponentLogger.md
+++ b/docs/logger-engine/ComponentLogger.md
@@ -104,6 +104,10 @@ The value to use as the log entry&apos;s message
 
 (Optional) The record ID to relate to the log entry
 
+###### `scenario` → `String`
+
+Optionally specify the name to use for the current transaction&apos;s scenario
+
 ###### `stack` → `String`
 
 The JavaScript stack trace from when the log entry was created

--- a/docs/logger-engine/FlowCollectionLogEntry.md
+++ b/docs/logger-engine/FlowCollectionLogEntry.md
@@ -46,6 +46,10 @@ The records to relate to this log entry - the records&apos; JSON is automaticall
 
 Optionally choose to save any pending log entries
 
+#### `scenario` → `String`
+
+Optionally specify the name to use for the current transaction&apos;s scenario
+
 #### `tagsString` → `String`
 
 Optionally provide a comma-separated String of tags to dynamically assign to the log entry

--- a/docs/logger-engine/FlowLogEntry.md
+++ b/docs/logger-engine/FlowLogEntry.md
@@ -46,6 +46,10 @@ Optionally relate the log entry to a particular record ID
 
 Optionally choose to save any pending log entries.
 
+#### `scenario` → `String`
+
+Optionally specify the name to use for the current transaction&apos;s scenario
+
 #### `tagsString` → `String`
 
 Optionally provide a comma-separated String of tags to dynamically assign to the log entry

--- a/docs/logger-engine/FlowLogger.md
+++ b/docs/logger-engine/FlowLogger.md
@@ -74,6 +74,10 @@ General message to log.
 
 boolean used to determine if logs are saved to Salesforce.
 
+###### `scenario` → `String`
+
+Optionally specify the name to use for the current transaction&apos;s scenario
+
 ###### `tagsString` → `String`
 
 String of tags / topics.

--- a/docs/logger-engine/FlowRecordLogEntry.md
+++ b/docs/logger-engine/FlowRecordLogEntry.md
@@ -46,6 +46,10 @@ The record to relate to this log entry - the record&apos;s JSON is automatically
 
 Optionally choose to save any pending log entries
 
+#### `scenario` → `String`
+
+Optionally specify the name to use for the current transaction&apos;s scenario
+
 #### `tagsString` → `String`
 
 Optionally provide a comma-separated String of tags to dynamically assign to the log entry

--- a/docs/logger-engine/Logger.md
+++ b/docs/logger-engine/Logger.md
@@ -4188,9 +4188,19 @@ Sets the default save method used when calling saveLog() - any subsequent calls 
 
 ##### Parameters
 
-| Param        | Description                                                                                              |
-| ------------ | -------------------------------------------------------------------------------------------------------- |
-| `saveMethod` | - The enum value of Logger.SaveMethod to use for any other calls to saveLog() in the current transaction |
+| Param        | Description                                                                                            |
+| ------------ | ------------------------------------------------------------------------------------------------------ |
+| `saveMethod` | The enum value of Logger.SaveMethod to use for any other calls to saveLog() in the current transaction |
+
+#### `setScenario(String scenario)` → `void`
+
+Sets the scenario name for the current transaction - this is stored in `LogEntryEvent__e.Scenario__c` and `Log__c.Scenario__c`, and can be used to filter &amp; group logs
+
+##### Parameters
+
+| Param      | Description                                                 |
+| ---------- | ----------------------------------------------------------- |
+| `scenario` | The name to use for the current transaction&apos;s scenario |
 
 #### `suspendSaving()` → `void`
 

--- a/docs/plugin-framework/LoggerSObjectHandlerPlugin.md
+++ b/docs/plugin-framework/LoggerSObjectHandlerPlugin.md
@@ -12,7 +12,7 @@ Abstract class used to create custom Apex plugins to execute for all trigger ope
 
 #### `LoggerSObjectHandlerPlugin()`
 
-## All instances of `LoggerSObjectHandlerPlugin` are dynamically created, which requires aparameterless constructor
+## All instances of `LoggerSObjectHandlerPlugin` are dynamically created, which requires a parameterless constructor
 
 ### Methods
 

--- a/nebula-logger-recipes/main/default/lwc/loggerLWCDemo/loggerLWCDemo.html
+++ b/nebula-logger-recipes/main/default/lwc/loggerLWCDemo/loggerLWCDemo.html
@@ -11,6 +11,7 @@
     <lightning-card title="Nebula Logger for Lightning Components" icon-name="custom:custom19">
         <div class="slds-var-m-around_medium">
             <lightning-input label="Example Log Message" value={message} onchange={messageChange}></lightning-input>
+            <lightning-input label="Scenario" value={scenario} onchange={scenarioChange}></lightning-input>
             <lightning-input label="Comma-Separated Tags" value={tagsString} onchange={tagsStringChange}></lightning-input>
             <div class="slds-button-group" role="group">
                 <lightning-button label="Log ERROR" onclick={logErrorExample}></lightning-button>

--- a/nebula-logger-recipes/main/default/lwc/loggerLWCDemo/loggerLWCDemo.js
+++ b/nebula-logger-recipes/main/default/lwc/loggerLWCDemo/loggerLWCDemo.js
@@ -9,10 +9,15 @@ const LOGGER_NAME = 'c-logger';
 
 export default class LoggerLWCDemo extends LightningElement {
     message = 'Hello, world!';
+    scenario = 'Some demo scenario';
     tagsString = 'Tag-one, Another tag here';
 
     messageChange(event) {
         this.message = event.target.value;
+    }
+
+    scenarioChange(event) {
+        this.scenario = event.target.value;
     }
 
     tagsStringChange(event) {
@@ -73,6 +78,7 @@ export default class LoggerLWCDemo extends LightningElement {
     saveLogExample() {
         console.log('running saveLog for btn');
         const logger = this.template.querySelector(LOGGER_NAME);
+        logger.setScenario(this.scenario);
         console.log(logger);
         logger.saveLog();
     }

--- a/nebula-logger-recipes/main/default/profiles/Admin.profile-meta.xml
+++ b/nebula-logger-recipes/main/default/profiles/Admin.profile-meta.xml
@@ -1594,6 +1594,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.Scenario__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.SendSlackNotification__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/configuration/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/main/configuration/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -878,6 +878,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.Scenario__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.SessionId__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/configuration/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/main/configuration/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -726,6 +726,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.Scenario__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.SessionId__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/configuration/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/main/configuration/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -810,6 +810,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.Scenario__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.SessionId__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/main/log-management/classes/LogEntryEventHandler.cls
@@ -106,6 +106,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
             log.ParentLog__r = logEntryEvent.ParentLogTransactionId__c == null ? null : parentLog;
             log.ProfileId__c = logEntryEvent.ProfileId__c;
             log.ProfileName__c = logEntryEvent.ProfileName__c;
+            log.Scenario__c = logEntryEvent.Scenario__c;
             log.SessionId__c = logEntryEvent.SessionId__c;
             log.SessionSecurityLevel__c = logEntryEvent.SessionSecurityLevel__c;
             log.SessionType__c = logEntryEvent.SessionType__c;

--- a/nebula-logger/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
+++ b/nebula-logger/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
@@ -207,6 +207,15 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
+                <fieldItem>Record.Scenario__c</fieldItem>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.Issue__c</fieldItem>
             </fieldInstance>
         </itemInstances>

--- a/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
+++ b/nebula-logger/main/log-management/layouts/Log__c-Log Layout.layout-meta.xml
@@ -68,6 +68,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
+                <field>Scenario__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
                 <field>Issue__c</field>
             </layoutItems>
             <layoutItems>

--- a/nebula-logger/main/log-management/objects/Log__c/fields/Scenario__c.field-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/fields/Scenario__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Scenario__c</fullName>
+    <caseSensitive>false</caseSensitive>
+    <externalId>true</externalId>
+    <label>Scenario</label>
+    <length>255</length>
+    <required>false</required>
+    <trackFeedHistory>true</trackFeedHistory>
+    <trackHistory>true</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/main/log-management/objects/Log__c/listViews/AllLogs.listView-meta.xml
+++ b/nebula-logger/main/log-management/objects/Log__c/listViews/AllLogs.listView-meta.xml
@@ -11,6 +11,7 @@
     <columns>OWNER.ALIAS</columns>
     <columns>Priority__c</columns>
     <columns>Status__c</columns>
+    <columns>Scenario__c</columns>
     <columns>StartTime__c</columns>
     <filterScope>Everything</filterScope>
     <label>All Logs</label>

--- a/nebula-logger/main/log-management/quickActions/Log__c.Manage.quickAction-meta.xml
+++ b/nebula-logger/main/log-management/quickActions/Log__c.Manage.quickAction-meta.xml
@@ -17,6 +17,11 @@
             </quickActionLayoutItems>
             <quickActionLayoutItems>
                 <emptySpace>false</emptySpace>
+                <field>Scenario__c</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
                 <field>Issue__c</field>
                 <uiBehavior>Edit</uiBehavior>
             </quickActionLayoutItems>

--- a/nebula-logger/main/logger-engine/classes/ComponentLogger.cls
+++ b/nebula-logger/main/logger-engine/classes/ComponentLogger.cls
@@ -32,8 +32,9 @@ public inherited sharing class ComponentLogger {
     public static String saveComponentLogEntries(List<ComponentLogEntry> componentLogEntries) {
         try {
             for (ComponentLogEntry componentLogEntry : componentLogEntries) {
-                LoggingLevel loggingLevel = Logger.getLoggingLevel(componentLogEntry.loggingLevel);
-                LogEntryEventBuilder logEntryEventBuilder = Logger.newEntry(loggingLevel, componentLogEntry.message)
+                Logger.setScenario(componentLogEntry.scenario);
+                LoggingLevel entryLoggingLevel = Logger.getLoggingLevel(componentLogEntry.loggingLevel);
+                LogEntryEventBuilder logEntryEventBuilder = Logger.newEntry(entryLoggingLevel, componentLogEntry.message)
                     .setRecord(componentLogEntry.recordId)
                     .setRecord(componentLogEntry.record)
                     .addTags(componentLogEntry.tags);
@@ -213,6 +214,12 @@ public inherited sharing class ComponentLogger {
          */
         @AuraEnabled
         public SObject record { get; set; }
+
+        /**
+         * @description Optionally specify the name to use for the current transaction's scenario
+         */
+        @AuraEnabled
+        public String scenario { get; set; }
 
         /**
          * @description The JavaScript stack trace from when the log entry was created

--- a/nebula-logger/main/logger-engine/classes/FlowCollectionLogEntry.cls
+++ b/nebula-logger/main/logger-engine/classes/FlowCollectionLogEntry.cls
@@ -52,6 +52,12 @@ global inherited sharing class FlowCollectionLogEntry {
     global String loggingLevelName;
 
     /**
+     * @description Optionally specify the name to use for the current transaction's scenario
+     */
+    @InvocableVariable(required=false label='(Optional) Scenario')
+    global String scenario;
+
+    /**
      * @description Optionally provide a comma-separated String of tags to dynamically assign to the log entry
      */
     @InvocableVariable(required=false label='(Optional) Tags (comma-separated)')

--- a/nebula-logger/main/logger-engine/classes/FlowLogEntry.cls
+++ b/nebula-logger/main/logger-engine/classes/FlowLogEntry.cls
@@ -52,6 +52,12 @@ global inherited sharing class FlowLogEntry {
     global String loggingLevelName;
 
     /**
+     * @description Optionally specify the name to use for the current transaction's scenario
+     */
+    @InvocableVariable(required=false label='(Optional) Scenario')
+    global String scenario;
+
+    /**
      * @description Optionally provide a comma-separated String of tags to dynamically assign to the log entry
      */
     @InvocableVariable(required=false label='(Optional) Tags (comma-separated)')

--- a/nebula-logger/main/logger-engine/classes/FlowLogger.cls
+++ b/nebula-logger/main/logger-engine/classes/FlowLogger.cls
@@ -46,6 +46,12 @@ public inherited sharing class FlowLogger {
         public String loggingLevelName;
 
         /**
+         * @description Optionally specify the name to use for the current transaction's scenario
+         */
+        @InvocableVariable(required=false label='(Optional) Scenario')
+        public String scenario;
+
+        /**
          * @description String of tags / topics.
          */
         public String tagsString;
@@ -92,14 +98,15 @@ public inherited sharing class FlowLogger {
             // but LogEntryEventBuilder.addTags() uses List<String>, so FlowLogger handles the conversion work
             List<String> parsedTags = this.tagsString?.replaceAll('( ,)|(,)|(, )', ',').split(',');
 
+            Logger.setScenario(this.scenario);
             this.entryLoggingLevel = Logger.getLoggingLevel(this.loggingLevelName);
             this.logEntryEventBuilder = Logger.newEntry(this.entryLoggingLevel, this.message).addTags(this.topics).addTags(parsedTags);
-            this.logEntryEvent = logEntryEventBuilder.getLogEntryEvent();
 
             if (this.logEntryEventBuilder.shouldSave() == false) {
                 return this.logEntryEventBuilder;
             }
 
+            this.logEntryEvent = logEntryEventBuilder.getLogEntryEvent();
             this.logEntryEvent.OriginLocation__c = this.flowName;
             this.logEntryEvent.OriginType__c = 'Flow';
             this.logEntryEvent.StackTrace__c = null;

--- a/nebula-logger/main/logger-engine/classes/FlowRecordLogEntry.cls
+++ b/nebula-logger/main/logger-engine/classes/FlowRecordLogEntry.cls
@@ -51,6 +51,12 @@ global inherited sharing class FlowRecordLogEntry {
     global String loggingLevelName;
 
     /**
+     * @description Optionally specify the name to use for the current transaction's scenario
+     */
+    @InvocableVariable(required=false label='(Optional) Scenario')
+    global String scenario;
+
+    /**
      * @description Optionally provide a comma-separated String of tags to dynamically assign to the log entry
      */
     @InvocableVariable(required=false label='(Optional) Tags (comma-separated)')

--- a/nebula-logger/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/main/logger-engine/classes/Logger.cls
@@ -18,6 +18,7 @@ global with sharing class Logger {
 
     private static Integer currentTransactionEntryNumber = 1;
     private static String parentLogTransactionId;
+    private static String transactionScenario;
     private static Boolean suspendSaving = false;
     private static LoggerSettings__c userSettings;
 
@@ -2442,8 +2443,17 @@ global with sharing class Logger {
 
     // Save control methods
     /**
+     * @description Sets the scenario name for the current transaction - this is stored in `LogEntryEvent__e.Scenario__c`
+     *              and `Log__c.Scenario__c`, and can be used to filter & group logs
+     * @param  scenario The name to use for the current transaction's scenario
+     */
+    public static void setScenario(String scenario) {
+        transactionScenario = scenario;
+    }
+
+    /**
      * @description Sets the default save method used when calling saveLog() - any subsequent calls to saveLog() will use the specified save method
-     * @param  saveMethod - The enum value of Logger.SaveMethod to use for any other calls to saveLog() in the current transaction
+     * @param  saveMethod The enum value of Logger.SaveMethod to use for any other calls to saveLog() in the current transaction
      */
     global static void setSaveMethod(SaveMethod saveMethod) {
         transactionSaveMethod = saveMethod;
@@ -2485,6 +2495,7 @@ global with sharing class Logger {
             if (logEntryEventBuilder.shouldSave()) {
                 LogEntryEvent__e logEntryEvent = logEntryEventBuilder.getLogEntryEvent();
                 logEntryEvent.ParentLogTransactionId__c = getParentLogTransactionId();
+                logEntryEvent.Scenario__c = transactionScenario;
                 logEntryEvent.SystemMode__c = getCurrentQuiddity().name();
                 logEntryEvent.TransactionId__c = getTransactionId();
 

--- a/nebula-logger/main/logger-engine/lwc/logger/__tests__/logger.test.js
+++ b/nebula-logger/main/logger-engine/lwc/logger/__tests__/logger.test.js
@@ -129,6 +129,29 @@ describe('Logger lwc tests', () => {
             expect(logEntry.message).toEqual(message);
         });
     });
+    it('sets a log scenario on all entries', async () => {
+        const logger = createElement('c-logger', { is: Logger });
+        document.body.appendChild(logger);
+
+        getSettingsAdapter.emit(mockGetSettings);
+
+        return Promise.resolve().then(() => {
+            const scenario = 'some scenario';
+            const message = 'some message';
+            const firstLogEntry = logger.finest(message);
+            expect(firstLogEntry.scenario).toBeUndefined();
+            expect(logger.getBufferSize()).toEqual(1);
+
+            const secondLogEntry = logger.info(message);
+            expect(secondLogEntry.scenario).toBeUndefined();
+            expect(logger.getBufferSize()).toEqual(2);
+
+            logger.setScenario(scenario);
+
+            expect(firstLogEntry.scenario).toEqual(scenario);
+            expect(secondLogEntry.scenario).toEqual(scenario);
+        });
+    });
     it('flushes buffer', async () => {
         const logger = createElement('c-logger', { is: Logger });
         document.body.appendChild(logger);

--- a/nebula-logger/main/logger-engine/lwc/logger/logger.js
+++ b/nebula-logger/main/logger-engine/lwc/logger/logger.js
@@ -12,6 +12,8 @@ export default class Logger extends LightningElement {
     componentLogEntries = [];
     settings;
 
+    _scenario;
+
     @wire(getSettings)
     wiredSettings({ error, data }) {
         if (data) {
@@ -57,6 +59,14 @@ export default class Logger extends LightningElement {
     }
 
     @api
+    setScenario(scenario) {
+        this._scenario = scenario;
+        this.componentLogEntries.forEach(logEntry => {
+            logEntry.scenario = this._scenario;
+        });
+    }
+
+    @api
     getBufferSize() {
         return this.componentLogEntries.length;
     }
@@ -88,6 +98,9 @@ export default class Logger extends LightningElement {
         const shouldSave = this._meetsUserLoggingLevel(loggingLevel);
 
         const logEntryBuilder = newLogEntry(loggingLevel, shouldSave).setMessage(message);
+        if (this._scenario) {
+            logEntryBuilder.scenario = this._scenario;
+        }
         if (this._meetsUserLoggingLevel(loggingLevel) == true) {
             this.componentLogEntries.push(logEntryBuilder);
         }

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/Scenario__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/Scenario__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Scenario__c</fullName>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Scenario</label>
+    <length>255</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/Scenario__c.field-meta.xml
+++ b/nebula-logger/main/logger-engine/objects/LogEntryEvent__e/fields/Scenario__c.field-meta.xml
@@ -7,7 +7,7 @@
     <isSortingDisabled>false</isSortingDisabled>
     <label>Scenario</label>
     <length>255</length>
-    <required>true</required>
+    <required>false</required>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/main/plugin-framework/classes/LoggerSObjectHandlerPlugin.cls
+++ b/nebula-logger/main/plugin-framework/classes/LoggerSObjectHandlerPlugin.cls
@@ -12,7 +12,7 @@
 //       which could lead to a lot of problems, so for now/indefinitely, plugins will only work in the unlocked package
 public abstract class LoggerSObjectHandlerPlugin {
     /**
-     * @description All instances of `LoggerSObjectHandlerPlugin` are dynamically created, which requires aparameterless constructor
+     * @description All instances of `LoggerSObjectHandlerPlugin` are dynamically created, which requires a parameterless constructor
      */
     @SuppressWarnings('PMD.EmptyStatementBlock')
     public LoggerSObjectHandlerPlugin() {

--- a/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -113,6 +113,7 @@ private class LogEntryEventHandler_Tests {
             RecordJson__c = JSON.serializePretty(currentUser),
             RecordSObjectClassification__c = 'Standard Object',
             RecordSObjectType__c = 'User',
+            Scenario__c = 'Apex test execution',
             SessionId__c = null,
             SessionSecurityLevel__c = null,
             SessionType__c = null,
@@ -702,6 +703,7 @@ private class LogEntryEventHandler_Tests {
                 ParentLog__c,
                 ProfileId__c,
                 ProfileName__c,
+                Scenario__c,
                 SessionId__c,
                 SessionSecurityLevel__c,
                 SessionType__c,
@@ -809,6 +811,8 @@ private class LogEntryEventHandler_Tests {
         System.assertEquals(logEntryEvent.NetworkId__c, log.NetworkId__c);
         System.assertEquals(logOwnerId, log.OwnerId);
         System.assertEquals(logEntryEvent.ProfileId__c, log.ProfileId__c);
+        System.assertEquals(logEntryEvent.ProfileName__c, log.ProfileName__c);
+        System.assertEquals(logEntryEvent.Scenario__c, log.Scenario__c);
         System.assertEquals(logEntryEvent.SessionId__c, log.SessionId__c);
         System.assertEquals(logEntryEvent.SessionId__c, log.SessionId__c);
         System.assertEquals(logEntryEvent.SessionSecurityLevel__c, log.SessionSecurityLevel__c);

--- a/nebula-logger/tests/logger-engine/classes/ComponentLogger_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/ComponentLogger_Tests.cls
@@ -132,6 +132,27 @@ private class ComponentLogger_Tests {
     }
 
     @IsTest
+    static void it_should_set_log_scenario() {
+        System.assertEquals(0, [SELECT COUNT() FROM Log__c]);
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.FINEST.name();
+
+        List<ComponentLogger.ComponentLogEntry> componentLogEntries = new List<ComponentLogger.ComponentLogEntry>();
+        ComponentLogger.ComponentLogEntry componentLogEntry = new ComponentLogger.ComponentLogEntry();
+        componentLogEntry.loggingLevel = LoggingLevel.INFO.name();
+        componentLogEntry.message = 'hello, world';
+        componentLogEntry.scenario = 'Some scenario';
+        componentLogEntry.timestamp = System.now();
+        componentLogEntries.add(componentLogEntry);
+
+        Test.startTest();
+        ComponentLogger.saveComponentLogEntries(componentLogEntries);
+        Test.stopTest();
+
+        Log__c log = [SELECT Id, Scenario__c FROM Log__c];
+        System.assertEquals(componentLogEntry.scenario, log.Scenario__c);
+    }
+
+    @IsTest
     static void it_should_parse_aura_component_stack_trace() {
         String expectedComponentType = 'Aura';
         String expectedComponentApiName = 'c/loggerAuraDemo';

--- a/nebula-logger/tests/logger-engine/classes/FlowCollectionLogEntry_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/FlowCollectionLogEntry_Tests.cls
@@ -213,6 +213,29 @@ private class FlowCollectionLogEntry_Tests {
         System.assertEquals(flowEntry.message, logEntry.Message__c);
         System.assertEquals('Flow', logEntry.OriginType__c);
     }
+
+    @IsTest
+    static void it_should_set_log_scenario() {
+        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
+
+        Test.startTest();
+
+        Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
+        FlowCollectionLogEntry flowEntry = createFlowCollectionLogEntry();
+        flowEntry.loggingLevelName = userLoggingLevel.name();
+        flowEntry.scenario = 'Some scenario';
+        FlowCollectionLogEntry.addFlowCollectionEntries(new List<FlowCollectionLogEntry>{ flowEntry });
+        System.assertEquals(1, Logger.getBufferSize());
+
+        Logger.saveLog();
+        String transactionId = Logger.getTransactionId();
+
+        Test.stopTest();
+
+        Log__c log = [SELECT Id, Scenario__c FROM Log__c WHERE TransactionId__c = :transactionId];
+        System.assertEquals(flowEntry.scenario, log.Scenario__c);
+    }
+
     @IsTest
     static void it_should_add_tags_to_log_entry() {
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;

--- a/nebula-logger/tests/logger-engine/classes/FlowLogEntry_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/FlowLogEntry_Tests.cls
@@ -154,6 +154,28 @@ private class FlowLogEntry_Tests {
     }
 
     @IsTest
+    static void it_should_set_log_scenario() {
+        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
+
+        Test.startTest();
+
+        Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
+        FlowLogEntry flowEntry = createFlowLogEntry();
+        flowEntry.loggingLevelName = userLoggingLevel.name();
+        flowEntry.scenario = 'Some scenario';
+        FlowLogEntry.addFlowEntries(new List<FlowLogEntry>{ flowEntry });
+        System.assertEquals(1, Logger.getBufferSize());
+
+        Logger.saveLog();
+        String transactionId = Logger.getTransactionId();
+
+        Test.stopTest();
+
+        Log__c log = [SELECT Id, Scenario__c FROM Log__c WHERE TransactionId__c = :transactionId];
+        System.assertEquals(flowEntry.scenario, log.Scenario__c);
+    }
+
+    @IsTest
     static void it_should_add_tags_to_log_entry() {
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowEntryLoggingLevel = LoggingLevel.DEBUG;

--- a/nebula-logger/tests/logger-engine/classes/FlowRecordLogEntry_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/FlowRecordLogEntry_Tests.cls
@@ -191,6 +191,28 @@ private class FlowRecordLogEntry_Tests {
     }
 
     @IsTest
+    static void it_should_set_log_scenario() {
+        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
+
+        Test.startTest();
+
+        Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
+        FlowRecordLogEntry flowEntry = createFlowRecordLogEntry();
+        flowEntry.loggingLevelName = userLoggingLevel.name();
+        flowEntry.scenario = 'Some scenario';
+        FlowRecordLogEntry.addFlowRecordEntries(new List<FlowRecordLogEntry>{ flowEntry });
+        System.assertEquals(1, Logger.getBufferSize());
+
+        Logger.saveLog();
+        String transactionId = Logger.getTransactionId();
+
+        Test.stopTest();
+
+        Log__c log = [SELECT Id, Scenario__c FROM Log__c WHERE TransactionId__c = :transactionId];
+        System.assertEquals(flowEntry.scenario, log.Scenario__c);
+    }
+
+    @IsTest
     static void it_should_add_tags_to_log_entry() {
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;

--- a/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/tests/logger-engine/classes/Logger_Tests.cls
@@ -315,6 +315,40 @@ private class Logger_Tests {
     }
 
     @IsTest
+    static void it_should_set_scenario() {
+        String transactionId = Logger.getTransactionId();
+        String transactionScenarioName = 'some test scenario for this transaction';
+
+        Logger.setScenario(transactionScenarioName);
+        for (Integer i = 0; i < 5; i++) {
+            Logger.info('my log entry');
+        }
+        Logger.saveLog();
+        Test.getEventBus().deliver();
+
+        Log__c log = [SELECT Id, Scenario__c FROM Log__c WHERE TransactionId__c = :transactionId];
+        System.assertEquals(transactionScenarioName, log.Scenario__c, 'Scenario__c was not properly set on the Log__c record');
+    }
+
+    @IsTest
+    static void it_should_use_last_scenario_when_multiple_scenarios_specified() {
+        String transactionId = Logger.getTransactionId();
+        String initialTransactionScenarioName = 'some test scenario for this transaction';
+        String lastTransactionScenarioName = 'some test scenario for this transaction';
+
+        Logger.setScenario(initialTransactionScenarioName);
+        for (Integer i = 0; i < 5; i++) {
+            Logger.info('my log entry');
+        }
+        Logger.setScenario(lastTransactionScenarioName);
+        Logger.saveLog();
+        Test.getEventBus().deliver();
+
+        Log__c log = [SELECT Id, Scenario__c FROM Log__c WHERE TransactionId__c = :transactionId];
+        System.assertEquals(lastTransactionScenarioName, log.Scenario__c, 'Scenario__c was not properly set on the Log__c record');
+    }
+
+    @IsTest
     static void it_should_set_parent_transaction_id() {
         String expectedParentTransactionId = 'imagineThisWereAGuid';
         Logger.setParentLogTransactionId(expectedParentTransactionId);

--- a/scripts/apex/create-sample-log-entries.apex
+++ b/scripts/apex/create-sample-log-entries.apex
@@ -1,3 +1,4 @@
+Logger.setScenario('an example transaction scenario name');
 Logger.getUserSettings().LoggingLevel__c = LoggingLevel.INFO.name();
 Logger.getUserSettings().ApplyDataMaskRules__c = true;
 


### PR DESCRIPTION
Closes #217 by adding a new field, `Log__c.Scenario__c`, that can be set via Apex, Flow and lightning components. The scenario field provides a way to identify the context (or.... dare I say, the scenario) of the current transaction. This field is provided as a way for org's to self-identify the context of the current transaction. It fully relies on the org's metadata to handle setting this - nothing within Nebula Logger automatically sets this field. In the event that the scenario is set multiple times in a single transaction, then the last scenario specified will be the value used for `Log__c.Scenario__c`.

|        | Scenario Field                                  | Tagging System                                                      |
| ------ | ----------------------------------------------- | ------------------------------------------------------------------- |
| Object | `Log__c` object - stored in `Log__.Scenario__c` | `LogEntry__c` object - related via `LogEntryTag__c` junction object |
| Usage  | Only 1 scenario can be stored per transaction   | Supports adding multiple tags to each `LogEntry__c` record          |

## Specifying Scenario in Apex
When logging from within Apex, simply call the method `Logger.setScenario(String scenario)` at some point within your code to specify the current transaction's scenario.

```java
Logger.info('some log entry created BEFORE specifying a scenario'); // This log entry will still have the scenario set, even though it's logged before `setScenario(String)` is called
Logger.setScenario('an example transaction scenario name');
Logger.info('some log entry created AFTER specifying a scenario'); 
Logger.saveLog();
```

## Specifying Scenario in Lightning Components
When logging from within lightning web components and aura components, you can specify the scenario by calling the `logger` function `setScenario(scenario)` - this function expects a String to be passed as the parameter. This example shows a basic example of how you can specify the log's scenario and save any pending log entries.

```javascript
saveLogExample() {
    const logger = this.template.querySelector(LOGGER_NAME);
    logger.setScenario(this.scenario);
    console.log(logger);
    logger.saveLog();
}
```

## Specifying Scenario in Flow
With adding a log entry from Flow, you can now optionally set the transaction's scenario, using the provided property `Scenario` - this property is available in all 3 Flow classes (`FlowLogEntry`, `FlowRecordLogEntry`, and `FlowCollectionLogEntry`).

![image](https://user-images.githubusercontent.com/1267157/136153854-825b90d3-8cf2-4ece-99fb-3f67c09778b2.png)

## Scenario Field in `Log__c` List Views
The new `Scenario__c` field is now included in the "All Logs" list view - you can also add the new field to any of your own list views.

![image](https://user-images.githubusercontent.com/1267157/136157418-53da2880-d3ef-4cb2-8ec5-277a40cd1417.png)

## Scenario Field on `Log__c` Detail Page
The new `Scenario__c` field is also included on the `Log__c` record's detail page, under the section "Log Management"

![image](https://user-images.githubusercontent.com/1267157/136157724-e71178b4-eed0-4075-8301-5e2b379f16b3.png)

## Manually Updating the Scenario Field via Log's "Manage" Quick Action
In some situations, you may want to manually change the value of the field `Log__c.Scenario__c` - this can now be done using the "Manage" quick action. Simply click the "Manage" button on a `Log__c` record (or select multiple logs from a list view and click "Manage"), and you can then update the field's value.

![image](https://user-images.githubusercontent.com/1267157/136158096-517554f6-9650-407f-ad1e-e8e6d631d762.png)


