### PR TITLE
Added new method Logger.logDatabaseErrors() (plus overloads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Designed for Salesforce admins, developers & architects. A robust logger for Ape
 
 ## Unlocked Package - v4.7.4
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015liHQAQ)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015liHQAQ)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015ligQAA)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015ligQAA)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
 ## Managed Package - v4.7.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Designed for Salesforce admins, developers & architects. A robust logger for Apex, Lightning Components, Flow, Process Builder & Integrations.
 
-## Unlocked Package - v4.7.3
+## Unlocked Package - v4.7.4
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015liHQAQ)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015liHQAQ)

--- a/docs/apex/Logger-Engine/Logger.md
+++ b/docs/apex/Logger-Engine/Logger.md
@@ -4086,7 +4086,7 @@ Boolean
 
 #### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a log entry for any results within the provided List DeleteResult&gt; where isSuccess() == true
+Creates a log entry for any results within the provided `List&lt;DeleteResult&gt;` where `isSuccess() != true`
 
 ##### Parameters
 
@@ -4108,7 +4108,7 @@ The instance of `LogEntryBuilder` was generated to log any errors, or `null` if 
 
 #### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a log entry for any results within the provided List DeleteResult&gt; where isSuccess() == true
+Creates a log entry for any results within the provided `List&lt;DeleteResult&gt;` where `isSuccess() != true`
 
 ##### Parameters
 
@@ -4130,7 +4130,7 @@ The instance of `LogEntryBuilder` was generated to log any errors, or `null` if 
 
 #### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a log entry for any results within the provided List MergeResult&gt; where isSuccess() == true
+Creates a log entry for any results within the provided `List&lt;MergeResult&gt;` where `isSuccess() != true`
 
 ##### Parameters
 
@@ -4152,7 +4152,7 @@ The instance of `LogEntryBuilder` was generated to log any errors, or `null` if 
 
 #### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a log entry for any results within the provided List MergeResult&gt; where isSuccess() == true
+Creates a log entry for any results within the provided `List&lt;MergeResult&gt;` where `isSuccess() != true`
 
 ##### Parameters
 
@@ -4174,7 +4174,7 @@ The instance of `LogEntryBuilder` was generated to log any errors, or `null` if 
 
 #### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a log entry for any results within the provided List SaveResult&gt; where isSuccess() == true
+Creates a log entry for any results within the provided `List&lt;SaveResult&gt;` where `isSuccess() != true`
 
 ##### Parameters
 
@@ -4196,7 +4196,7 @@ The instance of `LogEntryBuilder` was generated to log any errors, or `null` if 
 
 #### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a log entry for any results within the provided List SaveResult&gt; where isSuccess() == true
+Creates a log entry for any results within the provided `List&lt;SaveResult&gt;` where `isSuccess() != true`
 
 ##### Parameters
 
@@ -4218,7 +4218,7 @@ The instance of `LogEntryBuilder` was generated to log any errors, or `null` if 
 
 #### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a log entry for any results within the provided List UpsertResult&gt; where isSuccess() == true
+Creates a log entry for any results within the provided `List&lt;UpsertResult&gt;` where `isSuccess() != true`
 
 ##### Parameters
 
@@ -4240,7 +4240,7 @@ The instance of `LogEntryBuilder` was generated to log any errors, or `null` if 
 
 #### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a log entry for any results within the provided List UpsertResult&gt; where isSuccess() == true
+Creates a log entry for any results within the provided `List&lt;UpsertResult&gt;` where `isSuccess() != true`
 
 ##### Parameters
 
@@ -4262,7 +4262,7 @@ The instance of `LogEntryBuilder` was generated to log any errors, or `null` if 
 
 #### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a log entry for any results within the provided List UndeleteResult&gt; where isSuccess() == true
+Creates a log entry for any results within the provided `List&lt;UndeleteResult&gt;` where `isSuccess() != true`
 
 ##### Parameters
 
@@ -4284,7 +4284,7 @@ The instance of `LogEntryBuilder` was generated to log any errors, or `null` if 
 
 #### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a log entry for any results within the provided List UndeleteResult&gt; where isSuccess() == true
+Creates a log entry for any results within the provided `List&lt;UndeleteResult&gt;` where `isSuccess() != true`
 
 ##### Parameters
 

--- a/docs/apex/Logger-Engine/Logger.md
+++ b/docs/apex/Logger-Engine/Logger.md
@@ -4084,6 +4084,226 @@ Boolean
 
 Boolean
 
+#### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
+
+Creates a log entry for any results within the provided List DeleteResult&gt; where isSuccess() == true
+
+##### Parameters
+
+| Param           | Description                                                               |
+| --------------- | ------------------------------------------------------------------------- |
+| `loggingLevel`  | The logging level to use for the log entry                                |
+| `logMessage`    | The instance of `LogMessage` to use to set the entry&apos;s message field |
+| `deleteResults` | The instance of `List&lt;Database.DeleteResult&gt;` to log                |
+
+##### Return
+
+**Type**
+
+LogEntryEventBuilder
+
+**Description**
+
+The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+
+#### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
+
+Creates a log entry for any results within the provided List DeleteResult&gt; where isSuccess() == true
+
+##### Parameters
+
+| Param           | Description                                                |
+| --------------- | ---------------------------------------------------------- |
+| `loggingLevel`  | The logging level to use for the log entry                 |
+| `message`       | The string to use to set the entry&apos;s message field    |
+| `deleteResults` | The instance of `List&lt;Database.DeleteResult&gt;` to log |
+
+##### Return
+
+**Type**
+
+LogEntryEventBuilder
+
+**Description**
+
+The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+
+#### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
+
+Creates a log entry for any results within the provided List MergeResult&gt; where isSuccess() == true
+
+##### Parameters
+
+| Param          | Description                                                               |
+| -------------- | ------------------------------------------------------------------------- |
+| `loggingLevel` | The logging level to use for the log entry                                |
+| `logMessage`   | The instance of `LogMessage` to use to set the entry&apos;s message field |
+| `mergeResults` | The instance of `List&lt;Database.MergeResult&gt;` to log                 |
+
+##### Return
+
+**Type**
+
+LogEntryEventBuilder
+
+**Description**
+
+The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+
+#### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
+
+Creates a log entry for any results within the provided List MergeResult&gt; where isSuccess() == true
+
+##### Parameters
+
+| Param          | Description                                               |
+| -------------- | --------------------------------------------------------- |
+| `loggingLevel` | The logging level to use for the log entry                |
+| `message`      | The string to use to set the entry&apos;s message field   |
+| `mergeResults` | The instance of `List&lt;Database.MergeResult&gt;` to log |
+
+##### Return
+
+**Type**
+
+LogEntryEventBuilder
+
+**Description**
+
+The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+
+#### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
+
+Creates a log entry for any results within the provided List SaveResult&gt; where isSuccess() == true
+
+##### Parameters
+
+| Param          | Description                                                               |
+| -------------- | ------------------------------------------------------------------------- |
+| `loggingLevel` | The logging level to use for the log entry                                |
+| `logMessage`   | The instance of `LogMessage` to use to set the entry&apos;s message field |
+| `saveResults`  | The instance of `List&lt;Database.SaveResult&gt;` to log                  |
+
+##### Return
+
+**Type**
+
+LogEntryEventBuilder
+
+**Description**
+
+The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+
+#### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
+
+Creates a log entry for any results within the provided List SaveResult&gt; where isSuccess() == true
+
+##### Parameters
+
+| Param          | Description                                              |
+| -------------- | -------------------------------------------------------- |
+| `loggingLevel` | The logging level to use for the log entry               |
+| `message`      | The string to use to set the entry&apos;s message field  |
+| `saveResults`  | The instance of `List&lt;Database.SaveResult&gt;` to log |
+
+##### Return
+
+**Type**
+
+LogEntryEventBuilder
+
+**Description**
+
+The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+
+#### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
+
+Creates a log entry for any results within the provided List UpsertResult&gt; where isSuccess() == true
+
+##### Parameters
+
+| Param           | Description                                                               |
+| --------------- | ------------------------------------------------------------------------- |
+| `loggingLevel`  | The logging level to use for the log entry                                |
+| `logMessage`    | The instance of `LogMessage` to use to set the entry&apos;s message field |
+| `upsertResults` | The instance of `List&lt;Database.UpsertResult&gt;` to log                |
+
+##### Return
+
+**Type**
+
+LogEntryEventBuilder
+
+**Description**
+
+The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+
+#### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
+
+Creates a log entry for any results within the provided List UpsertResult&gt; where isSuccess() == true
+
+##### Parameters
+
+| Param           | Description                                                |
+| --------------- | ---------------------------------------------------------- |
+| `loggingLevel`  | The logging level to use for the log entry                 |
+| `message`       | The string to use to set the entry&apos;s message field    |
+| `upsertResults` | The instance of `List&lt;Database.UpsertResult&gt;` to log |
+
+##### Return
+
+**Type**
+
+LogEntryEventBuilder
+
+**Description**
+
+The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+
+#### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
+
+Creates a log entry for any results within the provided List UndeleteResult&gt; where isSuccess() == true
+
+##### Parameters
+
+| Param             | Description                                                               |
+| ----------------- | ------------------------------------------------------------------------- |
+| `loggingLevel`    | The logging level to use for the log entry                                |
+| `logMessage`      | The instance of `LogMessage` to use to set the entry&apos;s message field |
+| `undeleteResults` | The instance of `List&lt;Database.UndeleteResult&gt;` to log              |
+
+##### Return
+
+**Type**
+
+LogEntryEventBuilder
+
+**Description**
+
+The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+
+#### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
+
+Creates a log entry for any results within the provided List UndeleteResult&gt; where isSuccess() == true
+
+##### Parameters
+
+| Param             | Description                                                  |
+| ----------------- | ------------------------------------------------------------ |
+| `loggingLevel`    | The logging level to use for the log entry                   |
+| `message`         | The string to use to set the entry&apos;s message field      |
+| `undeleteResults` | The instance of `List&lt;Database.UndeleteResult&gt;` to log |
+
+##### Return
+
+**Type**
+
+LogEntryEventBuilder
+
+**Description**
+
+The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+
 #### `meetsUserLoggingLevel(LoggingLevel logEntryLoggingLevel)` → `Boolean`
 
 Indicates if the specified logging level is enabled for the current user, based on the custom setting LoggerSettings\_\_c

--- a/docs/apex/Logger-Engine/LoggerCache.md
+++ b/docs/apex/Logger-Engine/LoggerCache.md
@@ -30,6 +30,8 @@ The singleton instance of `TransactionCache`
 
 #### LoggerCache.TransactionCache class
 
+Manages any transaction-specific caching
+
 ---
 
 ##### Methods

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -2429,6 +2429,211 @@ global with sharing class Logger {
     }
 
     /**
+     * @description Creates a log entry for any results within the provided List DeleteResult> where isSuccess() == true
+     * @param  loggingLevel  The logging level to use for the log entry
+     * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
+     * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
+     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     */
+    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.DeleteResult> deleteResults) {
+        if (isEnabled(loggingLevel) == false) {
+            return null;
+        } else {
+            return logDatabaseErrors(loggingLevel, logMessage.getMessage(), deleteResults);
+        }
+    }
+
+    /**
+     * @description Creates a log entry for any results within the provided List DeleteResult> where isSuccess() == true
+     * @param  loggingLevel  The logging level to use for the log entry
+     * @param  message       The string to use to set the entry's message field
+     * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
+     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     */
+    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.DeleteResult> deleteResults) {
+        if (isEnabled(loggingLevel) == false) {
+            return null;
+        }
+
+        List<Database.DeleteResult> resultsToLog = new List<Database.DeleteResult>();
+        for (Database.DeleteResult deleteResult : deleteResults) {
+            if (deleteResult.isSuccess() == false) {
+                resultsToLog.add(deleteResult);
+            }
+        }
+
+        LogEntryEventBuilder logEntryEventBuilder;
+        if (resultsToLog.isEmpty() == false) {
+            logEntryEventBuilder = newEntry(loggingLevel, message).setDatabaseResult(resultsToLog);
+        }
+        return logEntryEventBuilder;
+    }
+
+    /**
+     * @description Creates a log entry for any results within the provided List MergeResult> where isSuccess() == true
+     * @param  loggingLevel  The logging level to use for the log entry
+     * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
+     * @param  mergeResults The instance of `List<Database.MergeResult>` to log
+     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     */
+    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.MergeResult> mergeResults) {
+        if (isEnabled(loggingLevel) == false) {
+            return null;
+        } else {
+            return logDatabaseErrors(loggingLevel, logMessage.getMessage(), mergeResults);
+        }
+    }
+
+    /**
+     * @description Creates a log entry for any results within the provided List MergeResult> where isSuccess() == true
+     * @param  loggingLevel  The logging level to use for the log entry
+     * @param  message       The string to use to set the entry's message field
+     * @param  mergeResults The instance of `List<Database.MergeResult>` to log
+     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     */
+    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.MergeResult> mergeResults) {
+        if (isEnabled(loggingLevel) == false) {
+            return null;
+        }
+
+        List<Database.MergeResult> resultsToLog = new List<Database.MergeResult>();
+        for (Database.MergeResult mergeResult : mergeResults) {
+            if (mergeResult.isSuccess() == false) {
+                resultsToLog.add(mergeResult);
+            }
+        }
+
+        LogEntryEventBuilder logEntryEventBuilder;
+        if (resultsToLog.isEmpty() == false) {
+            logEntryEventBuilder = newEntry(loggingLevel, message).setDatabaseResult(resultsToLog);
+        }
+        return logEntryEventBuilder;
+    }
+
+    /**
+     * @description Creates a log entry for any results within the provided List SaveResult> where isSuccess() == true
+     * @param  loggingLevel  The logging level to use for the log entry
+     * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
+     * @param  saveResults The instance of `List<Database.SaveResult>` to log
+     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     */
+    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.SaveResult> saveResults) {
+        if (isEnabled(loggingLevel) == false) {
+            return null;
+        } else {
+            return logDatabaseErrors(loggingLevel, logMessage.getMessage(), saveResults);
+        }
+    }
+
+    /**
+     * @description Creates a log entry for any results within the provided List SaveResult> where isSuccess() == true
+     * @param  loggingLevel  The logging level to use for the log entry
+     * @param  message       The string to use to set the entry's message field
+     * @param  saveResults The instance of `List<Database.SaveResult>` to log
+     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     */
+    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.SaveResult> saveResults) {
+        if (isEnabled(loggingLevel) == false) {
+            return null;
+        }
+
+        List<Database.SaveResult> resultsToLog = new List<Database.SaveResult>();
+        for (Database.SaveResult saveResult : saveResults) {
+            if (saveResult.isSuccess() == false) {
+                resultsToLog.add(saveResult);
+            }
+        }
+
+        LogEntryEventBuilder logEntryEventBuilder;
+        if (resultsToLog.isEmpty() == false) {
+            logEntryEventBuilder = newEntry(loggingLevel, message).setDatabaseResult(resultsToLog);
+        }
+        return logEntryEventBuilder;
+    }
+
+    /**
+     * @description Creates a log entry for any results within the provided List UpsertResult> where isSuccess() == true
+     * @param  loggingLevel  The logging level to use for the log entry
+     * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
+     * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
+     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     */
+    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UpsertResult> upsertResults) {
+        if (isEnabled(loggingLevel) == false) {
+            return null;
+        } else {
+            return logDatabaseErrors(loggingLevel, logMessage.getMessage(), upsertResults);
+        }
+    }
+
+    /**
+     * @description Creates a log entry for any results within the provided List UpsertResult> where isSuccess() == true
+     * @param  loggingLevel  The logging level to use for the log entry
+     * @param  message       The string to use to set the entry's message field
+     * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
+     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     */
+    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UpsertResult> upsertResults) {
+        if (isEnabled(loggingLevel) == false) {
+            return null;
+        }
+
+        List<Database.UpsertResult> resultsToLog = new List<Database.UpsertResult>();
+        for (Database.UpsertResult upsertResult : upsertResults) {
+            if (upsertResult.isSuccess() == false) {
+                resultsToLog.add(upsertResult);
+            }
+        }
+
+        LogEntryEventBuilder logEntryEventBuilder;
+        if (resultsToLog.isEmpty() == false) {
+            logEntryEventBuilder = newEntry(loggingLevel, message).setDatabaseResult(resultsToLog);
+        }
+        return logEntryEventBuilder;
+    }
+
+    /**
+     * @description Creates a log entry for any results within the provided List UndeleteResult> where isSuccess() == true
+     * @param  loggingLevel  The logging level to use for the log entry
+     * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
+     * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
+     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     */
+    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UndeleteResult> undeleteResults) {
+        if (isEnabled(loggingLevel) == false) {
+            return null;
+        } else {
+            return logDatabaseErrors(loggingLevel, logMessage.getMessage(), undeleteResults);
+        }
+    }
+
+    /**
+     * @description Creates a log entry for any results within the provided List UndeleteResult> where isSuccess() == true
+     * @param  loggingLevel  The logging level to use for the log entry
+     * @param  message       The string to use to set the entry's message field
+     * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
+     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     */
+    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UndeleteResult> undeleteResults) {
+        if (isEnabled(loggingLevel) == false) {
+            return null;
+        }
+
+        List<Database.UndeleteResult> resultsToLog = new List<Database.UndeleteResult>();
+        for (Database.UndeleteResult undeleteResult : undeleteResults) {
+            if (undeleteResult.isSuccess() == false) {
+                resultsToLog.add(undeleteResult);
+            }
+        }
+
+        LogEntryEventBuilder logEntryEventBuilder;
+        if (resultsToLog.isEmpty() == false) {
+            logEntryEventBuilder = newEntry(loggingLevel, message).setDatabaseResult(resultsToLog);
+        }
+        return logEntryEventBuilder;
+    }
+
+    /**
      * @description Adds a new instance of LogEntryEventBuilder to Logger's buffer, if shouldSave == true
      * @param  loggingLevel The logging level enum value for the new entry
      * @param  logMessage   The instance of LogMessage to use as the entry's message

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -2429,7 +2429,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a log entry for any results within the provided List DeleteResult> where isSuccess() == true
+     * @description Creates a log entry for any results within the provided `List<DeleteResult>` where `isSuccess() != true`
      * @param  loggingLevel  The logging level to use for the log entry
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
@@ -2444,7 +2444,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a log entry for any results within the provided List DeleteResult> where isSuccess() == true
+     * @description Creates a log entry for any results within the provided `List<DeleteResult>` where `isSuccess() != true`
      * @param  loggingLevel  The logging level to use for the log entry
      * @param  message       The string to use to set the entry's message field
      * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
@@ -2470,7 +2470,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a log entry for any results within the provided List MergeResult> where isSuccess() == true
+     * @description Creates a log entry for any results within the provided `List<MergeResult>` where `isSuccess() != true`
      * @param  loggingLevel The logging level to use for the log entry
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResults The instance of `List<Database.MergeResult>` to log
@@ -2485,7 +2485,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a log entry for any results within the provided List MergeResult> where isSuccess() == true
+     * @description Creates a log entry for any results within the provided `List<MergeResult>` where `isSuccess() != true`
      * @param  loggingLevel The logging level to use for the log entry
      * @param  message      The string to use to set the entry's message field
      * @param  mergeResults The instance of `List<Database.MergeResult>` to log
@@ -2511,7 +2511,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a log entry for any results within the provided List SaveResult> where isSuccess() == true
+     * @description Creates a log entry for any results within the provided `List<SaveResult>` where `isSuccess() != true`
      * @param  loggingLevel The logging level to use for the log entry
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResults  The instance of `List<Database.SaveResult>` to log
@@ -2526,7 +2526,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a log entry for any results within the provided List SaveResult> where isSuccess() == true
+     * @description Creates a log entry for any results within the provided `List<SaveResult>` where `isSuccess() != true`
      * @param  loggingLevel The logging level to use for the log entry
      * @param  message      The string to use to set the entry's message field
      * @param  saveResults  The instance of `List<Database.SaveResult>` to log
@@ -2552,7 +2552,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a log entry for any results within the provided List UpsertResult> where isSuccess() == true
+     * @description Creates a log entry for any results within the provided `List<UpsertResult>` where `isSuccess() != true`
      * @param  loggingLevel  The logging level to use for the log entry
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
@@ -2567,7 +2567,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a log entry for any results within the provided List UpsertResult> where isSuccess() == true
+     * @description Creates a log entry for any results within the provided `List<UpsertResult>` where `isSuccess() != true`
      * @param  loggingLevel  The logging level to use for the log entry
      * @param  message       The string to use to set the entry's message field
      * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
@@ -2593,7 +2593,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a log entry for any results within the provided List UndeleteResult> where isSuccess() == true
+     * @description Creates a log entry for any results within the provided `List<UndeleteResult>` where `isSuccess() != true`
      * @param  loggingLevel    The logging level to use for the log entry
      * @param  logMessage      The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
@@ -2608,7 +2608,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a log entry for any results within the provided List UndeleteResult> where isSuccess() == true
+     * @description Creates a log entry for any results within the provided `List<UndeleteResult>` where `isSuccess() != true`
      * @param  loggingLevel    The logging level to use for the log entry
      * @param  message         The string to use to set the entry's message field
      * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -13,7 +13,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.7.3';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.7.4';
     private static final LoggingLevel DEFAULT_LOGGING_LEVEL = LoggingLevel.DEBUG;
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
     private static final Map<String, LogScenarioRule__mdt> MOCK_SCENARIO_TO_SCENARIO_RULE = new Map<String, LogScenarioRule__mdt>();

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -2435,7 +2435,7 @@ global with sharing class Logger {
      * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
      * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.DeleteResult> deleteResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.DeleteResult> deleteResults) {
         if (isEnabled(loggingLevel) == false) {
             return null;
         } else {
@@ -2450,7 +2450,7 @@ global with sharing class Logger {
      * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
      * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.DeleteResult> deleteResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.DeleteResult> deleteResults) {
         if (isEnabled(loggingLevel) == false) {
             return null;
         }
@@ -2471,12 +2471,12 @@ global with sharing class Logger {
 
     /**
      * @description Creates a log entry for any results within the provided List MergeResult> where isSuccess() == true
-     * @param  loggingLevel  The logging level to use for the log entry
-     * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
+     * @param  loggingLevel The logging level to use for the log entry
+     * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResults The instance of `List<Database.MergeResult>` to log
-     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     * @return              The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.MergeResult> mergeResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.MergeResult> mergeResults) {
         if (isEnabled(loggingLevel) == false) {
             return null;
         } else {
@@ -2486,12 +2486,12 @@ global with sharing class Logger {
 
     /**
      * @description Creates a log entry for any results within the provided List MergeResult> where isSuccess() == true
-     * @param  loggingLevel  The logging level to use for the log entry
-     * @param  message       The string to use to set the entry's message field
+     * @param  loggingLevel The logging level to use for the log entry
+     * @param  message      The string to use to set the entry's message field
      * @param  mergeResults The instance of `List<Database.MergeResult>` to log
-     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     * @return              The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.MergeResult> mergeResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.MergeResult> mergeResults) {
         if (isEnabled(loggingLevel) == false) {
             return null;
         }
@@ -2512,12 +2512,12 @@ global with sharing class Logger {
 
     /**
      * @description Creates a log entry for any results within the provided List SaveResult> where isSuccess() == true
-     * @param  loggingLevel  The logging level to use for the log entry
-     * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
-     * @param  saveResults The instance of `List<Database.SaveResult>` to log
-     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     * @param  loggingLevel The logging level to use for the log entry
+     * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
+     * @param  saveResults  The instance of `List<Database.SaveResult>` to log
+     * @return              The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.SaveResult> saveResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.SaveResult> saveResults) {
         if (isEnabled(loggingLevel) == false) {
             return null;
         } else {
@@ -2527,12 +2527,12 @@ global with sharing class Logger {
 
     /**
      * @description Creates a log entry for any results within the provided List SaveResult> where isSuccess() == true
-     * @param  loggingLevel  The logging level to use for the log entry
-     * @param  message       The string to use to set the entry's message field
-     * @param  saveResults The instance of `List<Database.SaveResult>` to log
-     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     * @param  loggingLevel The logging level to use for the log entry
+     * @param  message      The string to use to set the entry's message field
+     * @param  saveResults  The instance of `List<Database.SaveResult>` to log
+     * @return              The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.SaveResult> saveResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.SaveResult> saveResults) {
         if (isEnabled(loggingLevel) == false) {
             return null;
         }
@@ -2558,7 +2558,7 @@ global with sharing class Logger {
      * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
      * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UpsertResult> upsertResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UpsertResult> upsertResults) {
         if (isEnabled(loggingLevel) == false) {
             return null;
         } else {
@@ -2573,7 +2573,7 @@ global with sharing class Logger {
      * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
      * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UpsertResult> upsertResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UpsertResult> upsertResults) {
         if (isEnabled(loggingLevel) == false) {
             return null;
         }
@@ -2594,12 +2594,12 @@ global with sharing class Logger {
 
     /**
      * @description Creates a log entry for any results within the provided List UndeleteResult> where isSuccess() == true
-     * @param  loggingLevel  The logging level to use for the log entry
-     * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
+     * @param  loggingLevel    The logging level to use for the log entry
+     * @param  logMessage      The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
-     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     * @return                 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UndeleteResult> undeleteResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UndeleteResult> undeleteResults) {
         if (isEnabled(loggingLevel) == false) {
             return null;
         } else {
@@ -2609,12 +2609,12 @@ global with sharing class Logger {
 
     /**
      * @description Creates a log entry for any results within the provided List UndeleteResult> where isSuccess() == true
-     * @param  loggingLevel  The logging level to use for the log entry
-     * @param  message       The string to use to set the entry's message field
+     * @param  loggingLevel    The logging level to use for the log entry
+     * @param  message         The string to use to set the entry's message field
      * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
-     * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
+     * @return                 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    public static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UndeleteResult> undeleteResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UndeleteResult> undeleteResults) {
         if (isEnabled(loggingLevel) == false) {
             return null;
         }

--- a/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
+++ b/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
@@ -64,7 +64,9 @@ public class LoggerMockDataCreator {
             return (Database.DeleteResult) JSON.deserialize('{"success": true, "id": "' + recordId + '"}', Database.DeleteResult.class);
         } else {
             return (Database.DeleteResult) JSON.deserialize(
-                '{"success":false,"errors":[{"message": "Could not delete...", "statusCode": "DELETE_FAILED"}]}',
+                '{"success":false, "id": "' +
+                recordId +
+                '", "errors":[{"message": "Could not delete...", "statusCode": "DELETE_FAILED"}]}',
                 Database.DeleteResult.class
             );
         }

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -5918,7 +5918,43 @@ private class Logger_Tests {
 
     // Start logDatabaseErrors() test methods
     @IsTest
-    static void it_should_log_only_database_deleteResult_for_logMessage_when_isSuccess_is_false() {
+    static void it_should_skip_logging_database_deleteResult_for_logMessage_when_logging_level_is_disabled() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
+        Database.DeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(false, recordId);
+        List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, deleteResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, deleteResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_skip_logging_database_deleteResult_for_logMessage_when_no_errors_found() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
+        Database.DeleteResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
+        List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, anotherSuccessfulResult };
+        System.assertEquals(2, deleteResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, deleteResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_log_database_deleteResult_for_logMessage_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
         Id recordId = UserInfo.getUserId();
@@ -5933,12 +5969,49 @@ private class Logger_Tests {
         System.assertEquals(1, Logger.getBufferSize());
         System.assertNotEquals(null, returnedBuilder);
         System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.DeleteResult>{ unsuccessfulResult });
         System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
-    static void it_should_log_only_database_deleteResult_for_string_message_when_isSuccess_is_false() {
+    static void it_should_skip_logging_database_deleteResult_for_string_message_when_logging_level_is_disabled() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
+        Database.DeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(false, recordId);
+        List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, deleteResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, deleteResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_skip_logging_database_deleteResult_for_string_message_when_no_errors_found() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
+        Database.DeleteResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
+        List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, anotherSuccessfulResult };
+        System.assertEquals(2, deleteResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, deleteResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_log_database_deleteResult_for_string_message_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = UserInfo.getUserId();
@@ -5953,12 +6026,49 @@ private class Logger_Tests {
         System.assertEquals(1, Logger.getBufferSize());
         System.assertNotEquals(null, returnedBuilder);
         System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.DeleteResult>{ unsuccessfulResult });
         System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
-    static void it_should_log_only_database_mergeResult_for_logMessage_when_isSuccess_is_false() {
+    static void it_should_skip_logging_database_mergeResult_for_logMessage_when_logging_level_is_disabled() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
+        Database.MergeResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(false, recordId);
+        List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, mergeResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, mergeResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_skip_logging_database_mergeResult_for_logMessage_when_no_errors_found() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
+        Database.MergeResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
+        List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, anotherSuccessfulResult };
+        System.assertEquals(2, mergeResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, mergeResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_log_database_mergeResult_for_logMessage_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
         Id recordId = UserInfo.getUserId();
@@ -5973,12 +6083,49 @@ private class Logger_Tests {
         System.assertEquals(1, Logger.getBufferSize());
         System.assertNotEquals(null, returnedBuilder);
         System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.MergeResult>{ unsuccessfulResult });
         System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
-    static void it_should_log_only_database_mergeResult_for_string_message_when_isSuccess_is_false() {
+    static void it_should_skip_logging_database_mergeResult_for_string_message_when_logging_level_is_disabled() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
+        Database.MergeResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(false, recordId);
+        List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, mergeResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, mergeResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_skip_logging_database_mergeResult_for_string_message_when_no_errors_found() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
+        Database.MergeResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
+        List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, anotherSuccessfulResult };
+        System.assertEquals(2, mergeResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, mergeResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_log_database_mergeResult_for_string_message_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = UserInfo.getUserId();
@@ -5993,12 +6140,49 @@ private class Logger_Tests {
         System.assertEquals(1, Logger.getBufferSize());
         System.assertNotEquals(null, returnedBuilder);
         System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.MergeResult>{ unsuccessfulResult });
         System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
-    static void it_should_log_only_database_saveResult_for_logMessage_when_isSuccess_is_false() {
+    static void it_should_skip_logging_database_saveResult_for_logMessage_when_logging_level_is_disabled() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
+        Database.SaveResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(false, recordId);
+        List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, saveResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, saveResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_skip_logging_database_saveResult_for_logMessage_when_no_errors_found() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
+        Database.SaveResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
+        List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, anotherSuccessfulResult };
+        System.assertEquals(2, saveResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, saveResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_log_database_saveResult_for_logMessage_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
         Id recordId = UserInfo.getUserId();
@@ -6013,12 +6197,49 @@ private class Logger_Tests {
         System.assertEquals(1, Logger.getBufferSize());
         System.assertNotEquals(null, returnedBuilder);
         System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.SaveResult>{ unsuccessfulResult });
         System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
-    static void it_should_log_only_database_saveResult_for_string_message_when_isSuccess_is_false() {
+    static void it_should_skip_logging_database_saveResult_for_string_message_when_logging_level_is_disabled() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
+        Database.SaveResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(false, recordId);
+        List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, saveResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, saveResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_skip_logging_database_saveResult_for_string_message_when_no_errors_found() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
+        Database.SaveResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
+        List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, anotherSuccessfulResult };
+        System.assertEquals(2, saveResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, saveResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_log_database_saveResult_for_string_message_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = UserInfo.getUserId();
@@ -6033,12 +6254,49 @@ private class Logger_Tests {
         System.assertEquals(1, Logger.getBufferSize());
         System.assertNotEquals(null, returnedBuilder);
         System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.SaveResult>{ unsuccessfulResult });
         System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
-    static void it_should_log_only_database_upsertResult_for_logMessage_when_isSuccess_is_false() {
+    static void it_should_skip_logging_database_upsertResult_for_logMessage_when_logging_level_is_disabled() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
+        Database.UpsertResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true, recordId);
+        List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, upsertResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, upsertResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_skip_logging_database_upsertResult_for_logMessage_when_no_errors_found() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
+        Database.UpsertResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
+        List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, anotherSuccessfulResult };
+        System.assertEquals(2, upsertResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, upsertResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_log_database_upsertResult_for_logMessage_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
         Id recordId = UserInfo.getUserId();
@@ -6053,12 +6311,49 @@ private class Logger_Tests {
         System.assertEquals(1, Logger.getBufferSize());
         System.assertNotEquals(null, returnedBuilder);
         System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.UpsertResult>{ unsuccessfulResult });
         System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
-    static void it_should_log_only_database_upsertResult_for_string_message_when_isSuccess_is_false() {
+    static void it_should_skip_logging_database_upsertResult_for_string_message_when_logging_level_is_disabled() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
+        Database.UpsertResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true, recordId);
+        List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, upsertResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, upsertResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_skip_logging_database_upsertResult_for_string_message_when_no_errors_found() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
+        Database.UpsertResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
+        List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, anotherSuccessfulResult };
+        System.assertEquals(2, upsertResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, upsertResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_log_database_upsertResult_for_string_message_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = UserInfo.getUserId();
@@ -6073,12 +6368,49 @@ private class Logger_Tests {
         System.assertEquals(1, Logger.getBufferSize());
         System.assertNotEquals(null, returnedBuilder);
         System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.UpsertResult>{ unsuccessfulResult });
         System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
-    static void it_should_log_only_database_undeleteResult_for_logMessage_when_isSuccess_is_false() {
+    static void it_should_skip_logging_database_undeleteResult_for_logMessage_when_logging_level_is_disabled() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
+        Database.UndeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(false, recordId);
+        List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, undeleteResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, undeleteResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_skip_logging_database_undeleteResult_for_logMessage_when_no_errors_found() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
+        Database.UndeleteResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
+        List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, anotherSuccessfulResult };
+        System.assertEquals(2, undeleteResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, undeleteResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_log_database_undeleteResult_for_logMessage_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
         Id recordId = UserInfo.getUserId();
@@ -6093,12 +6425,49 @@ private class Logger_Tests {
         System.assertEquals(1, Logger.getBufferSize());
         System.assertNotEquals(null, returnedBuilder);
         System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.UndeleteResult>{ unsuccessfulResult });
         System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
-    static void it_should_log_only_database_undeleteResult_for_string_message_when_isSuccess_is_false() {
+    static void it_should_skip_logging_database_undeleteResult_for_string_message_when_logging_level_is_disabled() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
+        Database.UndeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(false, recordId);
+        List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, undeleteResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, undeleteResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_skip_logging_database_undeleteResult_for_string_message_when_no_errors_found() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
+        Database.UndeleteResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
+        List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, anotherSuccessfulResult };
+        System.assertEquals(2, undeleteResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, undeleteResults);
+
+        System.assertEquals(0, Logger.getBufferSize());
+        System.assertEquals(null, returnedBuilder);
+    }
+
+    @IsTest
+    static void it_should_log_database_undeleteResult_for_string_message_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = UserInfo.getUserId();
@@ -6113,6 +6482,7 @@ private class Logger_Tests {
         System.assertEquals(1, Logger.getBufferSize());
         System.assertNotEquals(null, returnedBuilder);
         System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
+        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.UndeleteResult>{ unsuccessfulResult });
         System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -5916,6 +5916,208 @@ private class Logger_Tests {
     }
     // End FINEST methods for String
 
+    // Start logDatabaseErrors() test methods
+    @IsTest
+    static void it_should_log_only_database_deleteResult_for_logMessage_when_isSuccess_is_false() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
+        Database.DeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(false, recordId);
+        List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, deleteResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, deleteResults);
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertNotEquals(null, returnedBuilder);
+        System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.DeleteResult>{ unsuccessfulResult });
+        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+    }
+
+    @IsTest
+    static void it_should_log_only_database_deleteResult_for_string_message_when_isSuccess_is_false() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
+        Database.DeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(false, recordId);
+        List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, deleteResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, deleteResults);
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertNotEquals(null, returnedBuilder);
+        System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
+        String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.DeleteResult>{ unsuccessfulResult });
+        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+    }
+
+    @IsTest
+    static void it_should_log_only_database_mergeResult_for_logMessage_when_isSuccess_is_false() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
+        Database.MergeResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(false, recordId);
+        List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, mergeResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, mergeResults);
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertNotEquals(null, returnedBuilder);
+        System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.MergeResult>{ unsuccessfulResult });
+        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+    }
+
+    @IsTest
+    static void it_should_log_only_database_mergeResult_for_string_message_when_isSuccess_is_false() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
+        Database.MergeResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(false, recordId);
+        List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, mergeResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, mergeResults);
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertNotEquals(null, returnedBuilder);
+        System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
+        String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.MergeResult>{ unsuccessfulResult });
+        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+    }
+
+    @IsTest
+    static void it_should_log_only_database_saveResult_for_logMessage_when_isSuccess_is_false() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
+        Database.SaveResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(false, recordId);
+        List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, saveResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, saveResults);
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertNotEquals(null, returnedBuilder);
+        System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.SaveResult>{ unsuccessfulResult });
+        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+    }
+
+    @IsTest
+    static void it_should_log_only_database_saveResult_for_string_message_when_isSuccess_is_false() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
+        Database.SaveResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(false, recordId);
+        List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, saveResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, saveResults);
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertNotEquals(null, returnedBuilder);
+        System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
+        String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.SaveResult>{ unsuccessfulResult });
+        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+    }
+
+    @IsTest
+    static void it_should_log_only_database_upsertResult_for_logMessage_when_isSuccess_is_false() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
+        Database.UpsertResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true, recordId);
+        List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, upsertResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, upsertResults);
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertNotEquals(null, returnedBuilder);
+        System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.UpsertResult>{ unsuccessfulResult });
+        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+    }
+
+    @IsTest
+    static void it_should_log_only_database_upsertResult_for_string_message_when_isSuccess_is_false() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
+        Database.UpsertResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true, recordId);
+        List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, upsertResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, upsertResults);
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertNotEquals(null, returnedBuilder);
+        System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
+        String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.UpsertResult>{ unsuccessfulResult });
+        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+    }
+
+    @IsTest
+    static void it_should_log_only_database_undeleteResult_for_logMessage_when_isSuccess_is_false() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
+        Id recordId = UserInfo.getUserId();
+        Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
+        Database.UndeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(false, recordId);
+        List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, undeleteResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, undeleteResults);
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertNotEquals(null, returnedBuilder);
+        System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.UndeleteResult>{ unsuccessfulResult });
+        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+    }
+
+    @IsTest
+    static void it_should_log_only_database_undeleteResult_for_string_message_when_isSuccess_is_false() {
+        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        String message = 'Some message';
+        Id recordId = UserInfo.getUserId();
+        Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
+        Database.UndeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(false, recordId);
+        List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, unsuccessfulResult };
+        System.assertEquals(2, undeleteResults.size());
+        System.assertEquals(0, Logger.getBufferSize());
+
+        LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, undeleteResults);
+
+        System.assertEquals(1, Logger.getBufferSize());
+        System.assertNotEquals(null, returnedBuilder);
+        System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
+        String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.UndeleteResult>{ unsuccessfulResult });
+        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+    }
+    // End logDatabaseErrors() test methods
+
     // Start newEntry for LogMessage test methods
     @IsTest
     static void it_should_add_a_new_entry_for_loggingLevel_with_logMessage_and_shouldSave_override() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.7.3",
+    "version": "4.7.4",
     "description": "Designed for Salesforce admins, developers & architects. A robust logger for Apex, Flow, Process Builder & Integrations.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -12,9 +12,9 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.7.3.NEXT",
-            "versionName": "Query Selector Classes",
-            "versionDescription": "Introduced 2 new selector classes to centralize queries (which will later help with some planned future enhancements), fixed some bugs",
+            "versionNumber": "4.7.4.NEXT",
+            "versionName": "New method Logger.logDatabaseErrors()",
+            "versionDescription": "Added new method Logger.logDatabaseErrors(), including several overloads for using LogMessage/String, as well as the different database result classes (Database.DeleteResult, Database.MergeResult, Database.SaveResult, Database.UpsertResult, Database.UndeleteResult)",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "default": true
         },

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -124,6 +124,7 @@
         "Nebula Logger - Core@4.7.1-8-plugin-framework-overhaul": "04t5Y0000015lgBQAQ",
         "Nebula Logger - Core@4.7.2-1-parent-log-transaction-id-bugfix": "04t5Y0000015lhdQAA",
         "Nebula Logger - Core@4.7.3-NEXT-query-selector-classes": "04t5Y0000015liHQAQ",
+        "Nebula Logger - Core@4.7.4-NEXT-new-method-logger.logdatabaseerrors()": "04t5Y0000015ligQAA",
         "Nebula Logger - Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.0-3": "04t5Y0000015lhiQAA",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.1-1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
This resolves #295 by adding a new method `Logger.logDatabaseErrors()`, including several overloads for using LogMessage/String, as well as the different database result classes. When this method is called, if the list of database results includes 1 or more errors (based on `isSuccess() == false`), then a new log entry is added, and the JSON of any unsuccessful database results is serialized/stored in the log entry.

The full list of method overloads is:

```java
global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.DeleteResult> deleteResults);
global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.DeleteResult> deleteResults);
global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.MergeResult> mergeResults);
global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.MergeResult> mergeResults);
global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.SaveResult> saveResults);
global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.SaveResult> saveResults);
global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UpsertResult> upsertResults);
global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UpsertResult> upsertResults);
global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UndeleteResult> undeleteResults);
global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UndeleteResult> undeleteResults);
```