### PR TITLE
Fix Slack Plugin URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,14 +695,14 @@ Note: the logger plugin framework is not available in the managed package due to
 
 ### Beta Plugin: Slack Integration
 
-The optional [Slack plugin](./nebula-logger/plugins/Slack/) leverages the Nebula Logger plugin framework to automatically send Slack notifications for logs that meet a certain (configurable) logging level. The plugin also serves as a functioning example of how to build your own plugin for Nebula Logger, such as how to:
+The optional [Slack plugin](./nebula-logger/plugins/slack) leverages the Nebula Logger plugin framework to automatically send Slack notifications for logs that meet a certain (configurable) logging level. The plugin also serves as a functioning example of how to build your own plugin for Nebula Logger, such as how to:
 
 -   Use Apex to apply custom logic to `Log__c` and `LogEntry__c` records
 -   Add custom fields and list views to Logger's objects
 -   Extend permission sets to include field-level security for your custom fields
 -   Leverage the new `LoggerParameter__mdt` CMDT object to store configuration for your plugin
 
-Check out the [Slack plugin](./nebula-logger-plugins/slack/) for more details on how to install & customize the plugin
+Check out the [Slack plugin](./nebula-logger/plugins/slack) for more details on how to install & customize the plugin
 
 ![Slack plugin: notification](./nebula-logger/plugins/slack/.images/slack-plugin-notification.png)
 

--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ Note: the logger plugin framework is not available in the managed package due to
 
 ### Beta Plugin: Slack Integration
 
-The optional [Slack plugin](./nebula-logger-plugins/Slack/) leverages the Nebula Logger plugin framework to automatically send Slack notifications for logs that meet a certain (configurable) logging level. The plugin also serves as a functioning example of how to build your own plugin for Nebula Logger, such as how to:
+The optional [Slack plugin](./nebula-logger/plugins/Slack/) leverages the Nebula Logger plugin framework to automatically send Slack notifications for logs that meet a certain (configurable) logging level. The plugin also serves as a functioning example of how to build your own plugin for Nebula Logger, such as how to:
 
 -   Use Apex to apply custom logic to `Log__c` and `LogEntry__c` records
 -   Add custom fields and list views to Logger's objects


### PR DESCRIPTION
Current slack plugin links point to the wrong directory.