### PR TITLE
Improved formula fields on LogEntry__c for transactional limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.8.2
+## Unlocked Package - v4.8.3
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015lvuQAA)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015lvuQAA)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.8.3
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015lvuQAA)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015lvuQAA)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015lw9QAA)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015lw9QAA)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
 ## Managed Package - v4.8.0

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsAggregateQueries__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsAggregateQueries__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsAggregateQueriesUsed__c ) + &apos; / &apos; + TEXT(LimitsAggregateQueriesMax__c )</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsAggregateQueriesUsed__c / LimitsAggregateQueriesMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsAggregateQueriesUsed__c / LimitsAggregateQueriesMax__c * 100) &lt; 90 &amp;&amp; (LimitsAggregateQueriesUsed__c / LimitsAggregateQueriesMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsAggregateQueriesUsed__c ) + &apos; / &apos; + TEXT(LimitsAggregateQueriesMax__c ) + &apos; (&apos; + TEXT(ROUND(LimitsAggregateQueriesUsed__c / LimitsAggregateQueriesMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Aggregate Queries</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsAsyncCalls__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsAsyncCalls__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsAsyncCallsUsed__c) + &apos; / &apos; + TEXT(LimitsAsyncCallsMax__c)</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsAsyncCallsUsed__c / LimitsAsyncCallsMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsAsyncCallsUsed__c / LimitsAsyncCallsMax__c * 100) &lt; 90 &amp;&amp; (LimitsAsyncCallsUsed__c / LimitsAsyncCallsMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsAsyncCallsUsed__c) + &apos; / &apos; + TEXT(LimitsAsyncCallsMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsAsyncCallsUsed__c / LimitsAsyncCallsMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Async Calls</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsCallouts__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsCallouts__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsCalloutsUsed__c ) + &apos; / &apos; + TEXT(LimitsCalloutsMax__c )</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsCalloutsUsed__c / LimitsCalloutsMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsCalloutsUsed__c / LimitsCalloutsMax__c * 100) &lt; 90 &amp;&amp; (LimitsCalloutsUsed__c / LimitsCalloutsMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsCalloutsUsed__c ) + &apos; / &apos; + TEXT(LimitsCalloutsMax__c ) + &apos; (&apos; + TEXT(ROUND(LimitsCalloutsUsed__c / LimitsCalloutsMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Callouts</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsCpuTime__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsCpuTime__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsCpuTimeUsed__c) + &apos; / &apos; + TEXT(LimitsCpuTimeMax__c)</formula>
+    <formula>IMAGE(
+    CASE(
+        IF(
+            (LimitsCpuTimeUsed__c / LimitsCpuTimeMax__c * 100) &gt;= 90,
+            &quot;red&quot;,
+            IF(
+            (LimitsCpuTimeUsed__c / LimitsCpuTimeMax__c * 100) &lt; 90 &amp;&amp; (LimitsCpuTimeUsed__c / LimitsCpuTimeMax__c * 100) &gt;= 80,
+            &quot;yellow&quot;,
+            &quot;green&quot;
+            )
+        ),
+        &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+        &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+        &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+        &quot;/s.gif&quot;
+    ),
+    &apos;&apos;, 16, 16
+)
+
++ &apos; &apos; +
+
+TEXT(LimitsCpuTimeUsed__c) + &apos; / &apos; + TEXT(LimitsCpuTimeMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsCpuTimeUsed__c / LimitsCpuTimeMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>CPU Time</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsDmlRows__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsDmlRows__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsDmlRowsUsed__c) + &apos; / &apos; + TEXT(LimitsDmlRowsMax__c)</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsDmlRowsUsed__c / LimitsDmlRowsMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsDmlRowsUsed__c / LimitsDmlRowsMax__c * 100) &lt; 90 &amp;&amp; (LimitsDmlRowsUsed__c / LimitsDmlRowsMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsDmlRowsUsed__c) + &apos; / &apos; + TEXT(LimitsDmlRowsMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsDmlRowsUsed__c / LimitsDmlRowsMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>DML Rows</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsDmlStatements__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsDmlStatements__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsDmlStatementsUsed__c ) + &apos; / &apos; + TEXT(LimitsDmlStatementsMax__c)</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsDmlStatementsUsed__c / LimitsDmlStatementsMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsDmlStatementsUsed__c / LimitsDmlStatementsMax__c * 100) &lt; 90 &amp;&amp; (LimitsDmlStatementsUsed__c / LimitsDmlStatementsMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsDmlStatementsUsed__c ) + &apos; / &apos; + TEXT(LimitsDmlStatementsMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsDmlStatementsUsed__c / LimitsDmlStatementsMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>DML Statements</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsEmailInvocations__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsEmailInvocations__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsEmailInvocationsUsed__c) + &apos; / &apos; + TEXT(LimitsEmailInvocationsMax__c)</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsEmailInvocationsUsed__c / LimitsEmailInvocationsMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsEmailInvocationsUsed__c / LimitsEmailInvocationsMax__c * 100) &lt; 90 &amp;&amp; (LimitsEmailInvocationsUsed__c / LimitsEmailInvocationsMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsEmailInvocationsUsed__c) + &apos; / &apos; + TEXT(LimitsEmailInvocationsMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsEmailInvocationsUsed__c / LimitsEmailInvocationsMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Email Invocations</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsFutureCalls__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsFutureCalls__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsFutureCallsUsed__c ) + &apos; / &apos; + TEXT(LimitsFutureCallsMax__c)</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsFutureCallsUsed__c / LimitsFutureCallsMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsFutureCallsUsed__c / LimitsFutureCallsMax__c * 100) &lt; 90 &amp;&amp; (LimitsFutureCallsUsed__c / LimitsFutureCallsMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsFutureCallsUsed__c ) + &apos; / &apos; + TEXT(LimitsFutureCallsMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsFutureCallsUsed__c / LimitsFutureCallsMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Future Calls</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsHeapSize__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsHeapSize__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsHeapSizeUsed__c) + &apos; / &apos; + TEXT(LimitsHeapSizeMax__c)</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsHeapSizeUsed__c / LimitsHeapSizeMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsHeapSizeUsed__c / LimitsHeapSizeMax__c * 100) &lt; 90 &amp;&amp; (LimitsHeapSizeUsed__c / LimitsHeapSizeMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsHeapSizeUsed__c) + &apos; / &apos; + TEXT(LimitsHeapSizeMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsHeapSizeUsed__c / LimitsHeapSizeMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Heap Size</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsMobilePushApexCalls__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsMobilePushApexCalls__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsMobilePushApexCallsUsed__c) + &apos; / &apos; + TEXT(LimitsMobilePushApexCallsMax__c)</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsMobilePushApexCallsUsed__c / LimitsMobilePushApexCallsMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsMobilePushApexCallsUsed__c / LimitsMobilePushApexCallsMax__c * 100) &lt; 90 &amp;&amp; (LimitsMobilePushApexCallsUsed__c / LimitsMobilePushApexCallsMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsMobilePushApexCallsUsed__c) + &apos; / &apos; + TEXT(LimitsMobilePushApexCallsMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsMobilePushApexCallsUsed__c / LimitsMobilePushApexCallsMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Mobile Push Apex Calls</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsPublishImmediateDmlStatements__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsPublishImmediateDmlStatements__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsPublishImmediateDmlStatementsUsed__c) + &apos; / &apos; + TEXT(LimitsPublishImmediateDmlStatementsMax__c)</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsPublishImmediateDmlStatementsUsed__c / LimitsPublishImmediateDmlStatementsMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsPublishImmediateDmlStatementsUsed__c / LimitsPublishImmediateDmlStatementsMax__c * 100) &lt; 90 &amp;&amp; (LimitsPublishImmediateDmlStatementsUsed__c / LimitsPublishImmediateDmlStatementsMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsPublishImmediateDmlStatementsUsed__c) + &apos; / &apos; + TEXT(LimitsPublishImmediateDmlStatementsMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsPublishImmediateDmlStatementsUsed__c / LimitsPublishImmediateDmlStatementsMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Publish Immediate DML Statements</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsQueueableJobs__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsQueueableJobs__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsQueueableJobsUsed__c) + &apos; / &apos; + TEXT(LimitsQueueableJobsMax__c)</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsQueueableJobsUsed__c / LimitsQueueableJobsMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsQueueableJobsUsed__c / LimitsQueueableJobsMax__c * 100) &lt; 90 &amp;&amp; (LimitsQueueableJobsUsed__c / LimitsQueueableJobsMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsQueueableJobsUsed__c) + &apos; / &apos; + TEXT(LimitsQueueableJobsMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsQueueableJobsUsed__c / LimitsQueueableJobsMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Queueable Jobs</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsSoqlQueries__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsSoqlQueries__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsSoqlQueriesUsed__c) + &apos; / &apos; + TEXT(LimitsSoqlQueriesMax__c)</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsSoqlQueriesUsed__c / LimitsSoqlQueriesMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsSoqlQueriesUsed__c / LimitsSoqlQueriesMax__c * 100) &lt; 90 &amp;&amp; (LimitsSoqlQueriesUsed__c / LimitsSoqlQueriesMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsSoqlQueriesUsed__c) + &apos; / &apos; + TEXT(LimitsSoqlQueriesMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsSoqlQueriesUsed__c / LimitsSoqlQueriesMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>SOQL Queries</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsSoqlQueryLocatorRows__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsSoqlQueryLocatorRows__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsSoqlQueryLocatorRowsUsed__c) + &apos; / &apos; + TEXT(LimitsSoqlQueryLocatorRowsMax__c)</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsSoqlQueryLocatorRowsUsed__c / LimitsSoqlQueryLocatorRowsMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsSoqlQueryLocatorRowsUsed__c / LimitsSoqlQueryLocatorRowsMax__c * 100) &lt; 90 &amp;&amp; (LimitsSoqlQueryLocatorRowsUsed__c / LimitsSoqlQueryLocatorRowsMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsSoqlQueryLocatorRowsUsed__c) + &apos; / &apos; + TEXT(LimitsSoqlQueryLocatorRowsMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsSoqlQueryLocatorRowsUsed__c / LimitsSoqlQueryLocatorRowsMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>SOQL Query Locator Rows</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsSoqlQueryRows__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsSoqlQueryRows__c.field-meta.xml
@@ -4,7 +4,28 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsSoqlQueryRowsUsed__c) + &apos; / &apos; + TEXT(LimitsSoqlQueryRowsMax__c)</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsSoqlQueryRowsUsed__c / LimitsSoqlQueryRowsMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsSoqlQueryRowsUsed__c / LimitsSoqlQueryRowsMax__c * 100) &lt; 90 &amp;&amp; (LimitsSoqlQueryRowsUsed__c / LimitsSoqlQueryRowsMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsSoqlQueryRowsUsed__c) + &apos; / &apos; + TEXT(LimitsSoqlQueryRowsMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsSoqlQueryRowsUsed__c / LimitsSoqlQueryRowsMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>SOQL Query Rows</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsSoslSearches__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsSoslSearches__c.field-meta.xml
@@ -4,9 +4,30 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <formula>TEXT(LimitsSoslSearchesUsed__c) + &apos; / &apos; + TEXT(LimitsSoslSearchesMax__c)</formula>
+    <formula>IMAGE(
+        CASE(
+            IF(
+                (LimitsSoslSearchesUsed__c / LimitsSoslSearchesMax__c * 100) &gt;= 90,
+                &quot;red&quot;,
+                IF(
+                (LimitsSoslSearchesUsed__c / LimitsSoslSearchesMax__c * 100) &lt; 90 &amp;&amp; (LimitsSoslSearchesUsed__c / LimitsSoslSearchesMax__c * 100) &gt;= 80,
+                &quot;yellow&quot;,
+                &quot;green&quot;
+                )
+            ),
+            &quot;green&quot;, &quot;/img/samples/flag_green.gif&quot;,
+            &quot;yellow&quot;, &quot;/img/samples/flag_yellow.gif&quot;,
+            &quot;red&quot;, &quot;/img/samples/flag_red.gif&quot;,
+            &quot;/s.gif&quot;
+        ),
+        &apos;&apos;, 16, 16
+    )
+
+    + &apos; &apos; +
+
+    TEXT(LimitsSoslSearchesUsed__c) + &apos; / &apos; + TEXT(LimitsSoslSearchesMax__c) + &apos; (&apos; + TEXT(ROUND(LimitsSoslSearchesUsed__c / LimitsSoslSearchesMax__c * 100, 2)) + &apos;%)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
-    <label>SOSL Searches</label>
+    <label>SOSL Searches</label>x
     <required>false</required>
     <securityClassification>Confidential</securityClassification>
     <trackTrending>false</trackTrending>

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.8.2';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.8.3';
     private static final LoggingLevel DEFAULT_LOGGING_LEVEL = LoggingLevel.DEBUG;
     private static final Set<String> IGNORED_APEX_CLASSES = getIgnoredApexClasses();
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.8.2",
+    "version": "4.8.3",
     "description": "Designed for Salesforce admins, developers & architects. A robust logger for Apex, Flow, Process Builder & Integrations.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -12,9 +12,9 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.8.2.NEXT",
-            "versionName": "More Controls for Scenario-Based Logging",
-            "versionDescription": "Replaced LogScenarioRule__mdt with an enhanced object LoggerScenarioRule__mdt & added new method Logger.endScenario() to provide more control for scenario-based logging",
+            "versionNumber": "4.8.3.NEXT",
+            "versionName": "Improved LogEntry__c Formula Fields for Limits",
+            "versionDescription": "Updated formula fields on LogEntry__c for limits to include the percentage of each limit used & to include a flag indicator (>= 90% displays a red flag, < 90 && >= 80: displays a yellow flag, otherwise a green flag is displayed)",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "default": true
         },

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -132,6 +132,7 @@
         "Nebula Logger - Core@4.8.0-ignore-origin-method": "04t5Y0000015lslQAA",
         "Nebula Logger - Core@4.8.1-new-logger-scenario-custom-object": "04t5Y0000015luIQAQ",
         "Nebula Logger - Core@4.8.2-more-controls-for-scenario-based-logging": "04t5Y0000015lvuQAA",
+        "Nebula Logger - Core@4.8.3-improved-logentry__c-formula-fields-for-limits": "04t5Y0000015lw9QAA",
         "Nebula Logger - Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
For each transaction limit returned [in the Limits class](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_methods_system_limits.htm), `LogEntry__c` has 3 fields: "limit name" used, "limit name" max, and a "limit name" formula field that shows "Used / Max". This is helpful for quickly checking how much of each limit has been consumed. However, for some limits with a large max value (such as Heap Size), the formula field does not format the numbers (which is apparently quite difficult to do in a formula field), so you end up with values like "12425 / 6000000" which can sometimes be hard to read at glance - it makes it hard to tell what percentage of the limit has been consumed, as shown in this screenshot:

![image](https://user-images.githubusercontent.com/1267157/192358040-1abc3c9c-8e2d-41d6-ba61-23a2cc5c9d90.png)

To help with this, I've made 2 changes to all of the limits formula fields:

1. Added a flag indicator based on the percent of the limit used, using somewhat arbitrary-but-sensible ranges:
    - 90% or more of a limit consumed: 🟥   a red flag is displayed
    - 80-90% of a limit consumed: 🟨 a yellow flag is displayed
    - Less than 80%: 🟩 a green flag is displayed
2. Added percentage calculation based on the limit used: to make it easier at a glance to know how much of a limit has been consumed, each field now displays the percent used in parenthesis

With these changes in place, the limits are now much easier to understand at a glance - the colored flags help indicate if there are any limits to be worried about (red & yellow flags), and the percentage calculation tells you exactly how close you are to a particular limit:

![image](https://user-images.githubusercontent.com/1267157/192358062-cfa70326-832f-4508-85cd-7acd228de0e0.png)
