### PR TITLE
Migrated to new System.Assert class, added System namespace to several references

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.9.4
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R7sQAE)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R7sQAE)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R8WQAU)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R8WQAU)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
 ## Managed Package - v4.9.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.9.3
+## Unlocked Package - v4.9.4
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R7sQAE)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R7sQAE)

--- a/config/experience-cloud/classes/ChangePasswordControllerTest.cls
+++ b/config/experience-cloud/classes/ChangePasswordControllerTest.cls
@@ -11,6 +11,6 @@ public with sharing class ChangePasswordControllerTest {
         controller.newPassword = 'qwerty1';
         controller.verifyNewPassword = 'qwerty1';
 
-        System.assertEquals(controller.changePassword(), null);
+        System.Assert.areEqual(controller.changePassword(), null);
     }
 }

--- a/config/experience-cloud/classes/ForgotPasswordControllerTest.cls
+++ b/config/experience-cloud/classes/ForgotPasswordControllerTest.cls
@@ -9,6 +9,6 @@ public with sharing class ForgotPasswordControllerTest {
         ForgotPasswordController controller = new ForgotPasswordController();
         controller.username = 'test@salesforce.com';
 
-        System.assertEquals(controller.forgotPassword(), null);
+        System.Assert.areEqual(controller.forgotPassword(), null);
     }
 }

--- a/config/experience-cloud/classes/MicrobatchSelfRegControllerTest.cls
+++ b/config/experience-cloud/classes/MicrobatchSelfRegControllerTest.cls
@@ -9,6 +9,6 @@ public with sharing class MicrobatchSelfRegControllerTest {
         controller.communityNickname = 'test';
 
         // registerUser will always return null when the page isn't accessed as a guest user
-        System.assert(controller.registerUser() == null);
+        System.Assert.isTrue(controller.registerUser() == null);
     }
 }

--- a/config/experience-cloud/classes/MyProfilePageController.cls
+++ b/config/experience-cloud/classes/MyProfilePageController.cls
@@ -55,7 +55,7 @@ public with sharing class MyProfilePageController {
         try {
             update user;
             isEdit = false;
-        } catch (DmlException e) {
+        } catch (System.DmlException e) {
             ApexPages.addMessages(e);
         }
     }

--- a/config/experience-cloud/classes/MyProfilePageController.cls
+++ b/config/experience-cloud/classes/MyProfilePageController.cls
@@ -35,7 +35,7 @@ public with sharing class MyProfilePageController {
                 fax,
                 contact.email
             FROM User
-            WHERE id = :UserInfo.getUserId()
+            WHERE id = :System.UserInfo.getUserId()
         ];
         // guest users should never be able to access this page
         if (user.usertype == 'GUEST') {
@@ -89,7 +89,7 @@ public with sharing class MyProfilePageController {
                 fax,
                 contact.email
             FROM User
-            WHERE id = :UserInfo.getUserId()
+            WHERE id = :System.UserInfo.getUserId()
         ];
     }
 }

--- a/config/experience-cloud/classes/MyProfilePageControllerTest.cls
+++ b/config/experience-cloud/classes/MyProfilePageControllerTest.cls
@@ -13,7 +13,7 @@ public with sharing class MyProfilePageControllerTest {
             User currentUser = [
                 SELECT id, title, firstname, lastname, email, phone, mobilephone, fax, street, city, state, postalcode, country
                 FROM User
-                WHERE id = :UserInfo.getUserId()
+                WHERE id = :System.UserInfo.getUserId()
             ];
             MyProfilePageController controller = new MyProfilePageController();
             System.Assert.areEqual(currentUser.Id, controller.getUser().Id, 'Did not successfully load the current user');

--- a/config/experience-cloud/classes/MyProfilePageControllerTest.cls
+++ b/config/experience-cloud/classes/MyProfilePageControllerTest.cls
@@ -16,44 +16,44 @@ public with sharing class MyProfilePageControllerTest {
                 WHERE id = :UserInfo.getUserId()
             ];
             MyProfilePageController controller = new MyProfilePageController();
-            System.assertEquals(currentUser.Id, controller.getUser().Id, 'Did not successfully load the current user');
-            System.assert(controller.getIsEdit() == false, 'isEdit should default to false');
+            System.Assert.areEqual(currentUser.Id, controller.getUser().Id, 'Did not successfully load the current user');
+            System.Assert.isTrue(controller.getIsEdit() == false, 'isEdit should default to false');
             controller.edit();
-            System.assert(controller.getIsEdit() == true);
+            System.Assert.isTrue(controller.getIsEdit() == true);
             controller.cancel();
-            System.assert(controller.getIsEdit() == false);
+            System.Assert.isTrue(controller.getIsEdit() == false);
 
-            System.assert(Page.ChangePassword.getUrl().equals(controller.changePassword().getUrl()));
+            System.Assert.isTrue(Page.ChangePassword.getUrl().equals(controller.changePassword().getUrl()));
 
             String randFax = Math.rint(Math.random() * 1000) + '5551234';
             controller.getUser().Fax = randFax;
             controller.save();
-            System.assert(controller.getIsEdit() == false);
+            System.Assert.isTrue(controller.getIsEdit() == false);
 
             currentUser = [SELECT id, fax FROM User WHERE id = :currentUser.Id];
-            System.assert(currentUser.fax == randFax);
+            System.Assert.isTrue(currentUser.fax == randFax);
         } else {
             User existingPortalUser = existingPortalUsers[0];
             String randFax = Math.rint(Math.random() * 1000) + '5551234';
 
             System.runAs(existingPortalUser) {
                 MyProfilePageController controller = new MyProfilePageController();
-                System.assertEquals(existingPortalUser.Id, controller.getUser().Id, 'Did not successfully load the current user');
-                System.assert(controller.getIsEdit() == false, 'isEdit should default to false');
+                System.Assert.areEqual(existingPortalUser.Id, controller.getUser().Id, 'Did not successfully load the current user');
+                System.Assert.isTrue(controller.getIsEdit() == false, 'isEdit should default to false');
                 controller.edit();
-                System.assert(controller.getIsEdit() == true);
+                System.Assert.isTrue(controller.getIsEdit() == true);
 
                 controller.cancel();
-                System.assert(controller.getIsEdit() == false);
+                System.Assert.isTrue(controller.getIsEdit() == false);
 
                 controller.getUser().Fax = randFax;
                 controller.save();
-                System.assert(controller.getIsEdit() == false);
+                System.Assert.isTrue(controller.getIsEdit() == false);
             }
 
             // verify that the user was updated
             existingPortalUser = [SELECT id, fax FROM User WHERE id = :existingPortalUser.Id];
-            System.assert(existingPortalUser.fax == randFax);
+            System.Assert.isTrue(existingPortalUser.fax == randFax);
         }
     }
 }

--- a/config/experience-cloud/classes/SiteLoginControllerTest.cls
+++ b/config/experience-cloud/classes/SiteLoginControllerTest.cls
@@ -10,6 +10,6 @@ global with sharing class SiteLoginControllerTest {
         controller.username = 'test@salesforce.com';
         controller.password = '123456';
 
-        System.assertEquals(controller.login(), null);
+        System.Assert.areEqual(controller.login(), null);
     }
 }

--- a/config/experience-cloud/classes/SiteRegisterControllerTest.cls
+++ b/config/experience-cloud/classes/SiteRegisterControllerTest.cls
@@ -10,10 +10,10 @@ public with sharing class SiteRegisterControllerTest {
         controller.email = 'test@force.com';
         controller.communityNickname = 'test';
         // registerUser will always return null when the page isn't accessed as a guest user
-        System.assert(controller.registerUser() == null);
+        System.Assert.isTrue(controller.registerUser() == null);
 
         controller.password = 'abcd1234';
         controller.confirmPassword = 'abcd123';
-        System.assert(controller.registerUser() == null);
+        System.Assert.isTrue(controller.registerUser() == null);
     }
 }

--- a/docs/apex/Log-Management/LogEntryEventStreamController.md
+++ b/docs/apex/Log-Management/LogEntryEventStreamController.md
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+
+## LogEntryEventStreamController class
+
+Controller class for lwc `logEntryEventStream`, used to stream Log Entries in console and Tabular view.
+
+---
+
+### Methods
+
+#### `getDatatableDisplayFields()` → `List<String>`
+
+Returns the list of columns to be displayed in LogEntryEventStream Datatable. The fields are configured in the Custom Meta Data (LoggerParameter.LogEntryEventStreisplayFields).
+
+##### Return
+
+**Type**
+
+List&lt;String&gt;
+
+**Description**
+
+The instance of `List&lt;String&gt;`, containing the list of columns to be displayed in
+
+---

--- a/docs/apex/Log-Management/LoggerEmailSender.md
+++ b/docs/apex/Log-Management/LoggerEmailSender.md
@@ -23,7 +23,7 @@ Sends an error email notification to the org&apos;s list of Apex Exception Email
 
 #### `sendErrorEmail(Schema.SObjectType sobjectType, List<Database.UpsertResult> upsertResults)` → `void`
 
-Sends an error email notification to the org&apos;s list of Apex Exception Email recipients, configured under Setup --&gt; Email --&gt; Apex Exception Email
+Sends an error email notification to the org&apos;s list of Apex System.Exception Email recipients, configured under Setup --&gt; Email --&gt; Apex System.Exception Email
 
 ##### Parameters
 

--- a/docs/apex/Logger-Engine/LogEntryEventBuilder.md
+++ b/docs/apex/Logger-Engine/LogEntryEventBuilder.md
@@ -14,7 +14,7 @@ Builder class that generates each `LogEntryEvent__e` record
 
 ### Constructors
 
-#### `LogEntryEventBuilder(LoggerSettings__c userSettings, LoggingLevel entryLoggingLevel, Boolean shouldSave, Set<String> ignoredOrigins)`
+#### `LogEntryEventBuilder(LoggerSettings__c userSettings, System.LoggingLevel entryLoggingLevel, Boolean shouldSave, Set<String> ignoredOrigins)`
 
 Used by `Logger` to instantiate a new instance of `LogEntryEventBuilder`
 
@@ -305,15 +305,15 @@ LogEntryEventBuilder
 
 The same instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `setExceptionDetails(Exception apexException)` → `LogEntryEventBuilder`
+#### `setExceptionDetails(System.Exception apexException)` → `LogEntryEventBuilder`
 
 Sets the log entry event&apos;s exception fields
 
 ##### Parameters
 
-| Param           | Description                            |
-| --------------- | -------------------------------------- |
-| `apexException` | The instance of an `Exception` to use. |
+| Param           | Description                                   |
+| --------------- | --------------------------------------------- |
+| `apexException` | The instance of an `System.Exception` to use. |
 
 ##### Return
 
@@ -325,7 +325,7 @@ LogEntryEventBuilder
 
 The same instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `setHttpRequestDetails(HttpRequest request)` → `LogEntryEventBuilder`
+#### `setHttpRequestDetails(System.HttpRequest request)` → `LogEntryEventBuilder`
 
 Sets the log entry event&apos;s HTTP Request fields
 
@@ -345,7 +345,7 @@ LogEntryEventBuilder
 
 The same instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `setHttpResponseDetails(HttpResponse response)` → `LogEntryEventBuilder`
+#### `setHttpResponseDetails(System.HttpResponse response)` → `LogEntryEventBuilder`
 
 Sets the log entry event&apos;s HTTP Response fields
 

--- a/docs/apex/Logger-Engine/Logger.md
+++ b/docs/apex/Logger-Engine/Logger.md
@@ -42,7 +42,7 @@ Default constructor
 
 #### `debug(LogMessage logMessage, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -63,7 +63,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(LogMessage logMessage, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -84,7 +84,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(LogMessage logMessage, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -105,7 +105,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(LogMessage logMessage, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -126,7 +126,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(LogMessage logMessage, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -147,7 +147,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(LogMessage logMessage, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -168,7 +168,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(LogMessage logMessage, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -189,7 +189,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(LogMessage logMessage, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -210,7 +210,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(LogMessage logMessage, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -231,7 +231,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(LogMessage logMessage, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -252,7 +252,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(LogMessage logMessage, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -273,7 +273,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(LogMessage logMessage, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -294,7 +294,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(LogMessage logMessage, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -315,7 +315,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(LogMessage logMessage)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -335,7 +335,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -356,7 +356,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -377,7 +377,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -398,7 +398,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -419,7 +419,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -440,7 +440,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -461,7 +461,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -482,7 +482,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -503,7 +503,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -524,7 +524,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -545,7 +545,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -566,7 +566,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -587,7 +587,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -608,7 +608,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `debug(String message)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
 
 ##### Parameters
 
@@ -638,7 +638,7 @@ End the specified scenario, if it&apos;s the currently active scenario, and roll
 
 #### `error(LogMessage logMessage, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -659,7 +659,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(LogMessage logMessage, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -680,7 +680,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(LogMessage logMessage, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -701,7 +701,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(LogMessage logMessage, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -722,7 +722,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(LogMessage logMessage, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -743,7 +743,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(LogMessage logMessage, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -764,7 +764,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(LogMessage logMessage, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -785,7 +785,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(LogMessage logMessage, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -806,7 +806,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(LogMessage logMessage, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -827,7 +827,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(LogMessage logMessage, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -846,16 +846,16 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `error(LogMessage logMessage, Exception apexException)` → `LogEntryEventBuilder`
+#### `error(LogMessage logMessage, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
 | Param           | Description                                                               |
 | --------------- | ------------------------------------------------------------------------- |
 | `logMessage`    | The instance of `LogMessage` to use to set the entry&apos;s message field |
-| `apexException` | The instance of `Exception` to log                                        |
+| `apexException` | The instance of `System.Exception` to log                                 |
 
 ##### Return
 
@@ -867,9 +867,9 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `error(LogMessage logMessage, Id recordId, Exception apexException)` → `LogEntryEventBuilder`
+#### `error(LogMessage logMessage, Id recordId, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -877,7 +877,7 @@ Creates a new log entry with logging level == `LoggingLevel.ERROR`
 | --------------- | ------------------------------------------------------------------------- |
 | `logMessage`    | The instance of `LogMessage` to use to set the entry&apos;s message field |
 | `recordId`      | The record ID of an `SObject` to log                                      |
-| `apexException` | The instance of `Exception` to log                                        |
+| `apexException` | The instance of `System.Exception` to log                                 |
 
 ##### Return
 
@@ -891,7 +891,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(LogMessage logMessage, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -910,9 +910,9 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `error(LogMessage logMessage, SObject record, Exception apexException)` → `LogEntryEventBuilder`
+#### `error(LogMessage logMessage, SObject record, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -920,7 +920,7 @@ Creates a new log entry with logging level == `LoggingLevel.ERROR`
 | --------------- | ------------------------------------------------------------------------- |
 | `logMessage`    | The instance of `LogMessage` to use to set the entry&apos;s message field |
 | `record`        | The `SObject` record to log                                               |
-| `apexException` | The instance of `Exception` to log                                        |
+| `apexException` | The instance of `System.Exception` to log                                 |
 
 ##### Return
 
@@ -934,7 +934,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(LogMessage logMessage, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -953,9 +953,9 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `error(LogMessage logMessage, List<SObject> records, Exception apexException)` → `LogEntryEventBuilder`
+#### `error(LogMessage logMessage, List<SObject> records, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -963,7 +963,7 @@ Creates a new log entry with logging level == `LoggingLevel.ERROR`
 | --------------- | ------------------------------------------------------------------------- |
 | `logMessage`    | The instance of `LogMessage` to use to set the entry&apos;s message field |
 | `records`       | The list of `SObject` records to log                                      |
-| `apexException` | The instance of `Exception` to log                                        |
+| `apexException` | The instance of `System.Exception` to log                                 |
 
 ##### Return
 
@@ -977,7 +977,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(LogMessage logMessage, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -998,7 +998,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(LogMessage logMessage)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1018,7 +1018,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1039,7 +1039,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1060,7 +1060,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1081,7 +1081,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1102,7 +1102,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1123,7 +1123,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1144,7 +1144,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1165,7 +1165,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1186,7 +1186,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1207,7 +1207,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1226,16 +1226,16 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `error(String message, Exception apexException)` → `LogEntryEventBuilder`
+#### `error(String message, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
 | Param           | Description                                             |
 | --------------- | ------------------------------------------------------- |
 | `message`       | The string to use to set the entry&apos;s message field |
-| `apexException` | The instance of `Exception` to log                      |
+| `apexException` | The instance of `System.Exception` to log               |
 
 ##### Return
 
@@ -1247,9 +1247,9 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `error(String message, Id recordId, Exception apexException)` → `LogEntryEventBuilder`
+#### `error(String message, Id recordId, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1257,7 +1257,7 @@ Creates a new log entry with logging level == `LoggingLevel.ERROR`
 | --------------- | ------------------------------------------------------- |
 | `message`       | The string to use to set the entry&apos;s message field |
 | `recordId`      | The record ID of an `SObject` to log                    |
-| `apexException` | The instance of `Exception` to log                      |
+| `apexException` | The instance of `System.Exception` to log               |
 
 ##### Return
 
@@ -1271,7 +1271,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1290,9 +1290,9 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `error(String message, SObject record, Exception apexException)` → `LogEntryEventBuilder`
+#### `error(String message, SObject record, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1300,7 +1300,7 @@ Creates a new log entry with logging level == `LoggingLevel.ERROR`
 | --------------- | ------------------------------------------------------- |
 | `message`       | The string to use to set the entry&apos;s message field |
 | `record`        | The `SObject` record to log                             |
-| `apexException` | The instance of `Exception` to log                      |
+| `apexException` | The instance of `System.Exception` to log               |
 
 ##### Return
 
@@ -1314,7 +1314,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1333,9 +1333,9 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `error(String message, List<SObject> records, Exception apexException)` → `LogEntryEventBuilder`
+#### `error(String message, List<SObject> records, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1343,7 +1343,7 @@ Creates a new log entry with logging level == `LoggingLevel.ERROR`
 | --------------- | ------------------------------------------------------------------------- |
 | `message`       | The instance of `LogMessage` to use to set the entry&apos;s message field |
 | `records`       | The list of `SObject` records to log                                      |
-| `apexException` | The instance of `Exception` to log                                        |
+| `apexException` | The instance of `System.Exception` to log                                 |
 
 ##### Return
 
@@ -1357,7 +1357,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1378,7 +1378,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `error(String message)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.ERROR`
+Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
 
 ##### Parameters
 
@@ -1396,9 +1396,19 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
+#### `execute(System.QueueableContext queueableContext)` → `void`
+
+Asynchronoulsy publishes the list of `LogEntryEvent__e` records
+
+##### Parameters
+
+| Param              | Description                                                |
+| ------------------ | ---------------------------------------------------------- |
+| `queueableContext` | The context of the current queue, provided by the platform |
+
 #### `fine(LogMessage logMessage, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1419,7 +1429,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(LogMessage logMessage, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1440,7 +1450,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(LogMessage logMessage, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1461,7 +1471,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(LogMessage logMessage, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1482,7 +1492,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(LogMessage logMessage, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1503,7 +1513,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(LogMessage logMessage, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1524,7 +1534,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(LogMessage logMessage, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1545,7 +1555,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(LogMessage logMessage, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1566,7 +1576,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(LogMessage logMessage, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1587,7 +1597,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(LogMessage logMessage, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1608,7 +1618,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(LogMessage logMessage, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1629,7 +1639,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(LogMessage logMessage, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1650,7 +1660,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(LogMessage logMessage, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1671,7 +1681,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(LogMessage logMessage)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1691,7 +1701,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1712,7 +1722,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1733,7 +1743,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1754,7 +1764,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1775,7 +1785,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1796,7 +1806,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1817,7 +1827,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1838,7 +1848,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1859,7 +1869,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1880,7 +1890,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1901,7 +1911,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1922,7 +1932,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1943,7 +1953,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1964,7 +1974,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `fine(String message)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINE`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
 
 ##### Parameters
 
@@ -1984,7 +1994,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2005,7 +2015,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2026,7 +2036,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2047,7 +2057,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2068,7 +2078,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2089,7 +2099,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2110,7 +2120,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2131,7 +2141,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2152,7 +2162,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2173,7 +2183,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2194,7 +2204,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2215,7 +2225,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2236,7 +2246,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2257,7 +2267,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(LogMessage logMessage)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2277,7 +2287,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2298,7 +2308,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2319,7 +2329,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2340,7 +2350,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2361,7 +2371,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2382,7 +2392,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2403,7 +2413,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2424,7 +2434,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2445,7 +2455,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2466,7 +2476,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2487,7 +2497,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2508,7 +2518,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2529,7 +2539,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2550,7 +2560,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finer(String message)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINER`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
 
 ##### Parameters
 
@@ -2570,7 +2580,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2591,7 +2601,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2612,7 +2622,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2633,7 +2643,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2654,7 +2664,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2675,7 +2685,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2696,7 +2706,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2717,7 +2727,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2738,7 +2748,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2759,7 +2769,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2780,7 +2790,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2801,7 +2811,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2822,7 +2832,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2843,7 +2853,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(LogMessage logMessage)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2863,7 +2873,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2884,7 +2894,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2905,7 +2915,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2926,7 +2936,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2947,7 +2957,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2968,7 +2978,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -2989,7 +2999,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -3010,7 +3020,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -3031,7 +3041,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -3052,7 +3062,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -3073,7 +3083,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -3094,7 +3104,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -3115,7 +3125,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -3136,7 +3146,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `finest(String message)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.FINEST`
+Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
 
 ##### Parameters
 
@@ -3186,7 +3196,7 @@ Quiddity
 
 Quiddity - The value of System.Request.getCurrent().getQuiddity()
 
-#### `getLoggingLevel(String loggingLevelName)` → `LoggingLevel`
+#### `getLoggingLevel(String loggingLevelName)` → `System.LoggingLevel`
 
 Converts a String to an instance of LoggingLevel
 
@@ -3200,11 +3210,11 @@ Converts a String to an instance of LoggingLevel
 
 **Type**
 
-LoggingLevel
+System.LoggingLevel
 
 **Description**
 
-The matching instance of LoggingLevel (or a default value if a match is not found)
+The matching instance of System.LoggingLevel (or a default value if a match is not found)
 
 #### `getNamespacePrefix()` → `String`
 
@@ -3276,7 +3286,7 @@ String
 
 String - The value of System.Request.getCurrent().getRequestId()
 
-#### `getUserLoggingLevel()` → `LoggingLevel`
+#### `getUserLoggingLevel()` → `System.LoggingLevel`
 
 Returns the logging level for the current user, based on the custom setting LoggerSettings\_\_c
 
@@ -3284,11 +3294,11 @@ Returns the logging level for the current user, based on the custom setting Logg
 
 **Type**
 
-LoggingLevel
+System.LoggingLevel
 
 **Description**
 
-LoggingLevel - The matching instance of LoggingLevel
+System.LoggingLevel - The matching instance of LoggingLevel
 
 #### `getUserSettings()` → `LoggerSettings__c`
 
@@ -3364,7 +3374,7 @@ Adds the specified Apex type to the list of ignored origin locations for the cur
 
 #### `info(LogMessage logMessage, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3385,7 +3395,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(LogMessage logMessage, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3406,7 +3416,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(LogMessage logMessage, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3427,7 +3437,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(LogMessage logMessage, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3448,7 +3458,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(LogMessage logMessage, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3469,7 +3479,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(LogMessage logMessage, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3490,7 +3500,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(LogMessage logMessage, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3511,7 +3521,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(LogMessage logMessage, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3532,7 +3542,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(LogMessage logMessage, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3553,7 +3563,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(LogMessage logMessage, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3574,7 +3584,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(LogMessage logMessage, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3595,7 +3605,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(LogMessage logMessage, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3616,7 +3626,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(LogMessage logMessage, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3637,7 +3647,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(LogMessage logMessage)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3657,7 +3667,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3678,7 +3688,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3699,7 +3709,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3720,7 +3730,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3741,7 +3751,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3762,7 +3772,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3783,7 +3793,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3804,7 +3814,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3825,7 +3835,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3846,7 +3856,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3867,7 +3877,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3888,7 +3898,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3909,7 +3919,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3930,7 +3940,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `info(String message)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.INFO`
+Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
 
 ##### Parameters
 
@@ -3986,7 +3996,7 @@ Boolean
 
 Boolean
 
-#### `isEnabled(LoggingLevel loggingLevel)` → `Boolean`
+#### `isEnabled(System.LoggingLevel loggingLevel)` → `Boolean`
 
 Indicates if logging for the specified logging level is enabled for the current user, based on the custom setting LoggerSettings\_\_c
 
@@ -4104,7 +4114,7 @@ Boolean
 
 Boolean
 
-#### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
+#### `logDatabaseErrors(System.LoggingLevel loggingLevel, LogMessage logMessage, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
 Creates a log entry for any results within the provided `List&lt;DeleteResult&gt;` where `isSuccess() != true`
 
@@ -4126,7 +4136,7 @@ LogEntryEventBuilder
 
 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
 
-#### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
+#### `logDatabaseErrors(System.LoggingLevel loggingLevel, String message, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
 Creates a log entry for any results within the provided `List&lt;DeleteResult&gt;` where `isSuccess() != true`
 
@@ -4148,7 +4158,7 @@ LogEntryEventBuilder
 
 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
 
-#### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
+#### `logDatabaseErrors(System.LoggingLevel loggingLevel, LogMessage logMessage, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
 Creates a log entry for any results within the provided `List&lt;MergeResult&gt;` where `isSuccess() != true`
 
@@ -4170,7 +4180,7 @@ LogEntryEventBuilder
 
 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
 
-#### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
+#### `logDatabaseErrors(System.LoggingLevel loggingLevel, String message, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
 Creates a log entry for any results within the provided `List&lt;MergeResult&gt;` where `isSuccess() != true`
 
@@ -4192,7 +4202,7 @@ LogEntryEventBuilder
 
 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
 
-#### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
+#### `logDatabaseErrors(System.LoggingLevel loggingLevel, LogMessage logMessage, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
 Creates a log entry for any results within the provided `List&lt;SaveResult&gt;` where `isSuccess() != true`
 
@@ -4214,7 +4224,7 @@ LogEntryEventBuilder
 
 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
 
-#### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
+#### `logDatabaseErrors(System.LoggingLevel loggingLevel, String message, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
 Creates a log entry for any results within the provided `List&lt;SaveResult&gt;` where `isSuccess() != true`
 
@@ -4236,7 +4246,7 @@ LogEntryEventBuilder
 
 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
 
-#### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
+#### `logDatabaseErrors(System.LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
 Creates a log entry for any results within the provided `List&lt;UpsertResult&gt;` where `isSuccess() != true`
 
@@ -4258,7 +4268,7 @@ LogEntryEventBuilder
 
 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
 
-#### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
+#### `logDatabaseErrors(System.LoggingLevel loggingLevel, String message, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
 Creates a log entry for any results within the provided `List&lt;UpsertResult&gt;` where `isSuccess() != true`
 
@@ -4280,7 +4290,7 @@ LogEntryEventBuilder
 
 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
 
-#### `logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
+#### `logDatabaseErrors(System.LoggingLevel loggingLevel,LogMessage logMessage,List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
 Creates a log entry for any results within the provided `List&lt;UndeleteResult&gt;` where `isSuccess() != true`
 
@@ -4302,7 +4312,7 @@ LogEntryEventBuilder
 
 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
 
-#### `logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
+#### `logDatabaseErrors(System.LoggingLevel loggingLevel, String message, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
 Creates a log entry for any results within the provided `List&lt;UndeleteResult&gt;` where `isSuccess() != true`
 
@@ -4324,7 +4334,7 @@ LogEntryEventBuilder
 
 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
 
-#### `meetsUserLoggingLevel(LoggingLevel logEntryLoggingLevel)` → `Boolean`
+#### `meetsUserLoggingLevel(System.LoggingLevel logEntryLoggingLevel)` → `Boolean`
 
 Indicates if the specified logging level is enabled for the current user, based on the custom setting LoggerSettings\_\_c
 
@@ -4344,7 +4354,7 @@ Boolean
 
 Boolean
 
-#### `newEntry(LoggingLevel loggingLevel, LogMessage logMessage, Boolean shouldSave)` → `LogEntryEventBuilder`
+#### `newEntry(System.LoggingLevel loggingLevel, LogMessage logMessage, Boolean shouldSave)` → `LogEntryEventBuilder`
 
 Adds a new instance of LogEntryEventBuilder to Logger&apos;s buffer, if shouldSave == true
 
@@ -4366,7 +4376,7 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of LogEntryEventBuilder
 
-#### `newEntry(LoggingLevel loggingLevel, LogMessage logMessage)` → `LogEntryEventBuilder`
+#### `newEntry(System.LoggingLevel loggingLevel, LogMessage logMessage)` → `LogEntryEventBuilder`
 
 Adds a new instance of LogEntryEventBuilder to Logger&apos;s buffer, if it meets the user&apos;s logging level
 
@@ -4387,7 +4397,7 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of LogEntryEventBuilder
 
-#### `newEntry(LoggingLevel loggingLevel, String message, Boolean shouldSave)` → `LogEntryEventBuilder`
+#### `newEntry(System.LoggingLevel loggingLevel, String message, Boolean shouldSave)` → `LogEntryEventBuilder`
 
 Adds a new instance of LogEntryEventBuilder to Logger&apos;s buffer, if it meets the user&apos;s logging level
 
@@ -4409,7 +4419,7 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of LogEntryEventBuilder
 
-#### `newEntry(LoggingLevel loggingLevel, String message)` → `LogEntryEventBuilder`
+#### `newEntry(System.LoggingLevel loggingLevel, String message)` → `LogEntryEventBuilder`
 
 Adds a new instance of LogEntryEventBuilder to Logger&apos;s buffer, if it meets the user&apos;s logging level
 
@@ -4494,7 +4504,7 @@ Pauses saving for the current transaction. Any calls to saveLog() are ignored un
 
 #### `warn(LogMessage logMessage, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4515,7 +4525,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(LogMessage logMessage, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4536,7 +4546,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(LogMessage logMessage, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4557,7 +4567,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(LogMessage logMessage, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4578,7 +4588,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(LogMessage logMessage, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4599,7 +4609,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(LogMessage logMessage, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4620,7 +4630,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(LogMessage logMessage, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4641,7 +4651,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(LogMessage logMessage, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4662,7 +4672,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(LogMessage logMessage, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4683,7 +4693,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(LogMessage logMessage, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4702,16 +4712,16 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `warn(LogMessage logMessage, Exception apexException)` → `LogEntryEventBuilder`
+#### `warn(LogMessage logMessage, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
 | Param           | Description                                                               |
 | --------------- | ------------------------------------------------------------------------- |
 | `logMessage`    | The instance of `LogMessage` to use to set the entry&apos;s message field |
-| `apexException` | The instance of `Exception` to log                                        |
+| `apexException` | The instance of `System.Exception` to log                                 |
 
 ##### Return
 
@@ -4723,9 +4733,9 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `warn(LogMessage logMessage, Id recordId, Exception apexException)` → `LogEntryEventBuilder`
+#### `warn(LogMessage logMessage, Id recordId, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4733,7 +4743,7 @@ Creates a new log entry with logging level == `LoggingLevel.WARN`
 | --------------- | ------------------------------------------------------------------------- |
 | `logMessage`    | The instance of `LogMessage` to use to set the entry&apos;s message field |
 | `recordId`      | The record ID of an `SObject` to log                                      |
-| `apexException` | The instance of `Exception` to log                                        |
+| `apexException` | The instance of `System.Exception` to log                                 |
 
 ##### Return
 
@@ -4747,7 +4757,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(LogMessage logMessage, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4766,9 +4776,9 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `warn(LogMessage logMessage, SObject record, Exception apexException)` → `LogEntryEventBuilder`
+#### `warn(LogMessage logMessage, SObject record, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4776,7 +4786,7 @@ Creates a new log entry with logging level == `LoggingLevel.WARN`
 | --------------- | ------------------------------------------------------------------------- |
 | `logMessage`    | The instance of `LogMessage` to use to set the entry&apos;s message field |
 | `record`        | The `SObject` record to log                                               |
-| `apexException` | The instance of `Exception` to log                                        |
+| `apexException` | The instance of `System.Exception` to log                                 |
 
 ##### Return
 
@@ -4790,7 +4800,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(LogMessage logMessage, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4809,9 +4819,9 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `warn(LogMessage logMessage, List<SObject> records, Exception apexException)` → `LogEntryEventBuilder`
+#### `warn(LogMessage logMessage, List<SObject> records, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4819,7 +4829,7 @@ Creates a new log entry with logging level == `LoggingLevel.WARN`
 | --------------- | ------------------------------------------------------------------------- |
 | `logMessage`    | The instance of `LogMessage` to use to set the entry&apos;s message field |
 | `records`       | The list of `SObject` records to log                                      |
-| `apexException` | The instance of `Exception` to log                                        |
+| `apexException` | The instance of `System.Exception` to log                                 |
 
 ##### Return
 
@@ -4833,7 +4843,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(LogMessage logMessage, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4854,7 +4864,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(LogMessage logMessage)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4874,7 +4884,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message, Database.DeleteResult deleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4895,7 +4905,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message, Database.MergeResult mergeResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4916,7 +4926,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message, Database.SaveResult saveResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4937,7 +4947,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message, Database.UndeleteResult undeleteResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4958,7 +4968,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message, Database.UpsertResult upsertResult)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -4979,7 +4989,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message, List<Database.DeleteResult> deleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -5000,7 +5010,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message, List<Database.MergeResult> mergeResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -5021,7 +5031,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message, List<Database.SaveResult> saveResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -5042,7 +5052,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message, List<Database.UndeleteResult> undeleteResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -5063,7 +5073,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message, List<Database.UpsertResult> upsertResults)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -5082,16 +5092,16 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `warn(String message, Exception apexException)` → `LogEntryEventBuilder`
+#### `warn(String message, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
 | Param           | Description                                             |
 | --------------- | ------------------------------------------------------- |
 | `message`       | The string to use to set the entry&apos;s message field |
-| `apexException` | The instance of `Exception` to log                      |
+| `apexException` | The instance of `System.Exception` to log               |
 
 ##### Return
 
@@ -5103,9 +5113,9 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `warn(String message, Id recordId, Exception apexException)` → `LogEntryEventBuilder`
+#### `warn(String message, Id recordId, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -5113,7 +5123,7 @@ Creates a new log entry with logging level == `LoggingLevel.WARN`
 | --------------- | ------------------------------------------------------- |
 | `message`       | The string to use to set the entry&apos;s message field |
 | `recordId`      | The record ID of an `SObject` to log                    |
-| `apexException` | The instance of `Exception` to log                      |
+| `apexException` | The instance of `System.Exception` to log               |
 
 ##### Return
 
@@ -5127,7 +5137,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message, Id recordId)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -5146,9 +5156,9 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `warn(String message, SObject record, Exception apexException)` → `LogEntryEventBuilder`
+#### `warn(String message, SObject record, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -5156,7 +5166,7 @@ Creates a new log entry with logging level == `LoggingLevel.WARN`
 | --------------- | ------------------------------------------------------- |
 | `message`       | The string to use to set the entry&apos;s message field |
 | `record`        | The `SObject` record to log                             |
-| `apexException` | The instance of `Exception` to log                      |
+| `apexException` | The instance of `System.Exception` to log               |
 
 ##### Return
 
@@ -5170,7 +5180,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message, SObject record)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -5189,9 +5199,9 @@ LogEntryEventBuilder
 
 The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining methods
 
-#### `warn(String message, List<SObject> records, Exception apexException)` → `LogEntryEventBuilder`
+#### `warn(String message, List<SObject> records, System.Exception apexException)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -5199,7 +5209,7 @@ Creates a new log entry with logging level == `LoggingLevel.WARN`
 | --------------- | ------------------------------------------------------------------------- |
 | `message`       | The instance of `LogMessage` to use to set the entry&apos;s message field |
 | `records`       | The list of `SObject` records to log                                      |
-| `apexException` | The instance of `Exception` to log                                        |
+| `apexException` | The instance of `System.Exception` to log                                 |
 
 ##### Return
 
@@ -5213,7 +5223,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message, List<SObject> records)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -5234,7 +5244,7 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 #### `warn(String message)` → `LogEntryEventBuilder`
 
-Creates a new log entry with logging level == `LoggingLevel.WARN`
+Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
 
 ##### Parameters
 
@@ -5259,19 +5269,5 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 #### Logger.QueueableSaver class
 
 Inner class for publishing log entries via the Queueable interface.
-
----
-
-##### Methods
-
-###### `execute(System.QueueableContext queueableContext)` → `void`
-
-Asynchronoulsy publishes the list of `LogEntryEvent__e` records
-
-####### Parameters
-
-| Param              | Description                                                |
-| ------------------ | ---------------------------------------------------------- |
-| `queueableContext` | The context of the current queue, provided by the platform |
 
 ---

--- a/docs/apex/Test-Utilities/LoggerMockDataCreator.md
+++ b/docs/apex/Test-Utilities/LoggerMockDataCreator.md
@@ -299,7 +299,7 @@ The mock instance of `Database.UpsertResult`
 
 #### `createHttpCallout()` → `MockHttpCallout`
 
-Generates an instance of the class `MockHttpCallout` that implements the interface `HttpCalloutMock`. This can be used when testing batch jobs.
+Generates an instance of the class `MockHttpCallout` that implements the interface `System.HttpCalloutMock`. This can be used when testing batch jobs.
 
 ##### Return
 
@@ -311,7 +311,7 @@ MockHttpCallout
 
 The instance of `MockHttpCallout`
 
-#### `createHttpRequest()` → `HttpRequest`
+#### `createHttpRequest()` → `System.HttpRequest`
 
 Generates an instance of `HttpRequest`. This can be used when testing logging capabilities for instances of `HttpRequest`.
 
@@ -319,13 +319,13 @@ Generates an instance of `HttpRequest`. This can be used when testing logging ca
 
 **Type**
 
-HttpRequest
+System.HttpRequest
 
 **Description**
 
 The instance of `HttpRequest`
 
-#### `createHttpResponse()` → `HttpResponse`
+#### `createHttpResponse()` → `System.HttpResponse`
 
 Generates an instance of `HttpResponse`. This can be used when testing logging capabilities for instances of `HttpResponse`.
 
@@ -333,7 +333,7 @@ Generates an instance of `HttpResponse`. This can be used when testing logging c
 
 **Type**
 
-HttpResponse
+System.HttpResponse
 
 **Description**
 
@@ -555,9 +555,9 @@ A new copy of the original `SObject` record that has the specified read-only fie
 
 ##### Properties
 
-###### `request` → `HttpRequest`
+###### `request` → `System.HttpRequest`
 
-###### `response` → `HttpResponse`
+###### `response` → `System.HttpResponse`
 
 ###### `responseBody` → `String`
 
@@ -567,7 +567,7 @@ A new copy of the original `SObject` record that has the specified read-only fie
 
 ##### Methods
 
-###### `respond(HttpRequest request)` → `HttpResponse`
+###### `respond(System.HttpRequest request)` → `System.HttpResponse`
 
 ###### `setResponseBody(String responseBody)` → `MockHttpCallout`
 

--- a/docs/apex/index.md
+++ b/docs/apex/index.md
@@ -76,6 +76,10 @@ Batch class used to delete old logs, based on `Log__c.LogRetentionDate__c &lt;= 
 
 Processes `LogEntryEvent__e` platform events and normalizes the data into `Log__c` and `LogEntry__c` records
 
+### [LogEntryEventStreamController](Log-Management/LogEntryEventStreamController)
+
+Controller class for lwc `logEntryEventStream`, used to stream Log Entries in console and Tabular view.
+
 ### [LogEntryFieldSetPicklist](Log-Management/LogEntryFieldSetPicklist)
 
 Dynamically returns `LogEntry__c` field sets in App Builder when configuring the component RelatedLogEntries

--- a/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
@@ -598,7 +598,7 @@ public class LoggerParameter {
     @TestVisible
     private static void setMock(LoggerParameter__mdt parameter) {
         if (String.isBlank(parameter.DeveloperName) == true) {
-            throw new IllegalArgumentException('DeveloperName is required on `LoggerParameter__mdt: \n' + JSON.serializePretty(parameter));
+            throw new System.IllegalArgumentException('DeveloperName is required on `LoggerParameter__mdt: \n' + JSON.serializePretty(parameter));
         }
         DEVELOPER_NAME_TO_RECORD.put(parameter.DeveloperName, parameter);
     }

--- a/nebula-logger/core/main/configuration/classes/LoggerPlugin.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerPlugin.cls
@@ -91,7 +91,7 @@ public without sharing class LoggerPlugin {
     @TestVisible
     private static void setMock(LoggerPlugin__mdt pluginConfiguration) {
         if (String.isBlank(pluginConfiguration.DeveloperName) == true) {
-            throw new IllegalArgumentException('DeveloperName is required on mock LoggerPlugin__mdt: \n' + JSON.serializePretty(pluginConfiguration));
+            throw new System.IllegalArgumentException('DeveloperName is required on mock LoggerPlugin__mdt: \n' + JSON.serializePretty(pluginConfiguration));
         }
         if (pluginConfiguration.IsEnabled__c == true) {
             DEVELOPER_NAME_TO_RECORD.put(pluginConfiguration.DeveloperName, pluginConfiguration);

--- a/nebula-logger/core/main/configuration/classes/LoggerScenarioRule.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerScenarioRule.cls
@@ -34,7 +34,7 @@ public without sharing class LoggerScenarioRule {
     @TestVisible
     private static void setMock(LoggerScenarioRule__mdt scenarioRule) {
         if (String.isBlank(scenarioRule.Scenario__c) == true) {
-            throw new IllegalArgumentException('Scenario__c is required on `LoggerScenarioRule__mdt: \n' + JSON.serializePretty(scenarioRule));
+            throw new System.IllegalArgumentException('Scenario__c is required on `LoggerScenarioRule__mdt: \n' + JSON.serializePretty(scenarioRule));
         }
 
         if (isValid(scenarioRule) == true) {

--- a/nebula-logger/core/main/log-management/classes/LogBatchPurgeController.cls
+++ b/nebula-logger/core/main/log-management/classes/LogBatchPurgeController.cls
@@ -72,7 +72,7 @@ public with sharing class LogBatchPurgeController {
             result.put('LogEntry__c', getLogEntryObjectSummary(dateFilterOption));
             result.put('LogEntryTag__c', getLogEntryTagObjectSummary(dateFilterOption));
             return result;
-        } catch (Exception ex) {
+        } catch (System.Exception ex) {
             throw createAuraHandledException(ex);
         }
     }
@@ -120,7 +120,7 @@ public with sharing class LogBatchPurgeController {
                 LIMIT 50
             ];
             return purgeBatchJobs;
-        } catch (Exception ex) {
+        } catch (System.Exception ex) {
             throw createAuraHandledException(ex);
         }
     }
@@ -144,13 +144,13 @@ public with sharing class LogBatchPurgeController {
         try {
             String jobId = Database.executeBatch(new LogBatchPurger(), PURGE_BATCH_SIZE);
             return jobId;
-        } catch (Exception ex) {
+        } catch (System.Exception ex) {
             throw createAuraHandledException(ex);
         }
     }
 
-    private static AuraHandledException createAuraHandledException(Exception ex) {
-        AuraHandledException auraHandledException = new AuraHandledException(ex.getMessage());
+    private static System.AuraHandledException createAuraHandledException(System.Exception ex) {
+        System.AuraHandledException auraHandledException = new System.AuraHandledException(ex.getMessage());
         auraHandledException.setMessage(ex.getMessage());
         return auraHandledException;
     }

--- a/nebula-logger/core/main/log-management/classes/LogBatchPurger.cls
+++ b/nebula-logger/core/main/log-management/classes/LogBatchPurger.cls
@@ -120,7 +120,7 @@ global with sharing class LogBatchPurger implements Database.Batchable<SObject>,
 
             LoggerDataStore.getDatabase().hardDeleteRecords(scopeRecords);
             Logger.saveLog();
-        } catch (Exception apexException) {
+        } catch (System.Exception apexException) {
             if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
                 Logger.error('Logger - Error deleting logs', apexException);
             }

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
@@ -417,7 +417,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
 
         LoggerSettings__c loggingUserSettings = Logger.getUserSettings(new User(Id = logEntryEvent.LoggedById__c, ProfileId = logEntryEvent.ProfileId__c));
         if (logEntryEvent.UserType__c == GUEST_USER_TYPE || String.isBlank(logOwnerId) == true || loggingUserSettings.IsAnonymousModeEnabled__c == true) {
-            logOwnerId = UserInfo.getUserId();
+            logOwnerId = System.UserInfo.getUserId();
         }
 
         if (logEntryEvent.TransactionScenario__c != null && LoggerScenarioRule.getAll().containsKey(logEntryEvent.TransactionScenario__c) == true) {

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
@@ -652,11 +652,11 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
         Organization organization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
         String statusApiEndpoint = 'https://api.status.salesforce.com/v1/instances/' + organization.InstanceName + '/status';
 
-        HttpRequest request = new HttpRequest();
+        System.HttpRequest request = new System.HttpRequest();
         request.setEndpoint(statusApiEndpoint);
         request.setMethod('GET');
 
-        HttpResponse response = new Http().send(request);
+        System.HttpResponse response = new System.Http().send(request);
         if (response.getStatusCode() >= 400) {
             String errorMessage =
                 'Callout failed for ' +
@@ -665,7 +665,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
                 response.getStatusCode() +
                 ', status message: ' +
                 response.getStatus();
-            throw new CalloutException(errorMessage);
+            throw new System.CalloutException(errorMessage);
         }
 
         StatusApiResponse statusApiResponse = (StatusApiResponse) JSON.deserialize(response.getBody(), StatusApiResponse.class);

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventStreamController.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventStreamController.cls
@@ -30,8 +30,8 @@ public with sharing class LogEntryEventStreamController {
     public static List<String> getDatatableDisplayFields() {
         try {
             return LoggerParameter.getStringList(DISPLAY_FIELDS_PARAMETER_NAME, DEFAULT_DISPLAY_FIELDS);
-        } catch (Exception e) {
-            throw new AuraHandledException(e.getMessage());
+        } catch (System.Exception e) {
+            throw new System.AuraHandledException(e.getMessage());
         }
     }
 }

--- a/nebula-logger/core/main/log-management/classes/LogHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogHandler.cls
@@ -67,7 +67,7 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
                 log.ClosedBy__c = null;
                 log.ClosedDate__c = null;
             } else {
-                log.ClosedBy__c = log.ClosedBy__c == null ? UserInfo.getUserId() : log.ClosedBy__c;
+                log.ClosedBy__c = log.ClosedBy__c == null ? System.UserInfo.getUserId() : log.ClosedBy__c;
                 log.ClosedDate__c = log.ClosedDate__c == null ? System.now() : log.ClosedDate__c;
             }
         }

--- a/nebula-logger/core/main/log-management/classes/LogManagementDataSelector.cls
+++ b/nebula-logger/core/main/log-management/classes/LogManagementDataSelector.cls
@@ -138,7 +138,7 @@ public without sharing virtual class LogManagementDataSelector {
      * @return           The matching `List<UserRecordAccess>` records
      */
     public virtual List<UserRecordAccess> getDeleteableUserRecordAccess(List<Id> recordIds) {
-        return [SELECT RecordId FROM UserRecordAccess WHERE UserId = :UserInfo.getUserId() AND RecordId IN :recordIds AND HasDeleteAccess = TRUE];
+        return [SELECT RecordId FROM UserRecordAccess WHERE UserId = :System.UserInfo.getUserId() AND RecordId IN :recordIds AND HasDeleteAccess = TRUE];
     }
 
     /**

--- a/nebula-logger/core/main/log-management/classes/LogViewerController.cls
+++ b/nebula-logger/core/main/log-management/classes/LogViewerController.cls
@@ -15,8 +15,8 @@ public with sharing class LogViewerController {
      */
     @AuraEnabled(cacheable=true)
     public static Log__c getLog(Id logId) {
-        SObjectAccessDecision securityDecision = System.Security.stripInaccessible(
-            AccessType.READABLE,
+        System.SObjectAccessDecision securityDecision = System.Security.stripInaccessible(
+            System.AccessType.READABLE,
             new List<Log__c>{ LogManagementDataSelector.getInstance().getLogById(logId) }
         );
         return securityDecision.getRecords().isEmpty() ? null : (Log__c) securityDecision.getRecords().get(0);

--- a/nebula-logger/core/main/log-management/classes/LoggerEmailSender.cls
+++ b/nebula-logger/core/main/log-management/classes/LoggerEmailSender.cls
@@ -59,8 +59,8 @@ public without sharing class LoggerEmailSender {
     }
 
     /**
-     * @description Sends an error email notification to the org's list of Apex Exception Email recipients,
-     *              configured under Setup --> Email --> Apex Exception Email
+     * @description Sends an error email notification to the org's list of Apex System.Exception Email recipients,
+     *              configured under Setup --> Email --> Apex System.Exception Email
      * @param  sobjectType The SObjectType of records being saved.
      * @param  upsertResults The list of Database.UpsertResult instances to use in the email.
      *                     If no errors are found in the provided list, then no email will be sent.

--- a/nebula-logger/core/main/log-management/classes/LoggerSettingsController.cls
+++ b/nebula-logger/core/main/log-management/classes/LoggerSettingsController.cls
@@ -98,7 +98,7 @@ public without sharing class LoggerSettingsController {
             if (canUserModifyLoggerSettings() == true) {
                 LoggerDataStore.getDatabase().upsertRecord(settingsRecord, Schema.LoggerSettings__c.Id);
             }
-        } catch (Exception ex) {
+        } catch (System.Exception ex) {
             throw createAuraHandledException(ex);
         }
     }
@@ -113,7 +113,7 @@ public without sharing class LoggerSettingsController {
             if (canUserModifyLoggerSettings() == true) {
                 LoggerDataStore.getDatabase().deleteRecord(settingsRecord);
             }
-        } catch (Exception ex) {
+        } catch (System.Exception ex) {
             throw createAuraHandledException(ex);
         }
     }
@@ -162,17 +162,17 @@ public without sharing class LoggerSettingsController {
                     }
                 }
                 when else {
-                    throw new IllegalArgumentException('Invalid SetupOwnerType: ' + setupOwnerType);
+                    throw new System.IllegalArgumentException('Invalid SetupOwnerType: ' + setupOwnerType);
                 }
             }
             return searchResults;
-        } catch (Exception ex) {
+        } catch (System.Exception ex) {
             throw createAuraHandledException(ex);
         }
     }
 
-    private static AuraHandledException createAuraHandledException(Exception ex) {
-        AuraHandledException auraHandledException = new AuraHandledException(ex.getMessage());
+    private static System.AuraHandledException createAuraHandledException(System.Exception ex) {
+        System.AuraHandledException auraHandledException = new System.AuraHandledException(ex.getMessage());
         auraHandledException.setMessage(ex.getMessage());
         return auraHandledException;
     }

--- a/nebula-logger/core/main/log-management/classes/LoggerSettingsController.cls
+++ b/nebula-logger/core/main/log-management/classes/LoggerSettingsController.cls
@@ -179,10 +179,10 @@ public without sharing class LoggerSettingsController {
 
     private static List<PicklistOption> getLoggingLevelOptions() {
         List<PicklistOption> picklistOptions = initializePicklistOptions();
-        for (Integer i = LoggingLevel.values().size() - 1; i > 0; i--) {
-            LoggingLevel currentLoggingLevel = LoggingLevel.values().get(i);
+        for (Integer i = System.LoggingLevel.values().size() - 1; i > 0; i--) {
+            System.LoggingLevel currentLoggingLevel = System.LoggingLevel.values().get(i);
 
-            if (currentLoggingLevel == LoggingLevel.NONE || currentLoggingLevel == LoggingLevel.INTERNAL) {
+            if (currentLoggingLevel == System.LoggingLevel.NONE || currentLoggingLevel == System.LoggingLevel.INTERNAL) {
                 continue;
             }
 

--- a/nebula-logger/core/main/log-management/classes/RelatedLogEntriesController.cls
+++ b/nebula-logger/core/main/log-management/classes/RelatedLogEntriesController.cls
@@ -50,7 +50,7 @@ public with sharing class RelatedLogEntriesController {
         }
 
         // Somewhat redundant security check for FLS (but extra security > less security)
-        SObjectAccessDecision securityDecision = System.Security.stripInaccessible(AccessType.READABLE, records);
+        System.SObjectAccessDecision securityDecision = System.Security.stripInaccessible(System.AccessType.READABLE, records);
         records = securityDecision.getRecords();
 
         Integer totalLogEntriesCount = LogManagementDataSelector.getInstance().getCountOfRelatedRecordLogEntries(recordId);

--- a/nebula-logger/core/main/logger-engine/classes/ComponentLogger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/ComponentLogger.cls
@@ -37,7 +37,7 @@ public inherited sharing class ComponentLogger {
             Logger.SaveMethod saveMethod = Logger.getSaveMethod();
             for (ComponentLogEntry componentLogEntry : componentLogEntries) {
                 Logger.setScenario(componentLogEntry.scenario);
-                LoggingLevel entryLoggingLevel = Logger.getLoggingLevel(componentLogEntry.loggingLevel);
+                System.LoggingLevel entryLoggingLevel = Logger.getLoggingLevel(componentLogEntry.loggingLevel);
                 LogEntryEventBuilder logEntryEventBuilder = Logger.newEntry(entryLoggingLevel, componentLogEntry.message).addTags(componentLogEntry.tags);
 
                 if (componentLogEntry.recordId != null) {
@@ -180,13 +180,13 @@ public inherited sharing class ComponentLogger {
 
         private Map<String, Integer> getSupportedLoggingLevels() {
             return new Map<String, Integer>{
-                LoggingLevel.ERROR.name() => LoggingLevel.ERROR.ordinal(),
-                LoggingLevel.WARN.name() => LoggingLevel.WARN.ordinal(),
-                LoggingLevel.INFO.name() => LoggingLevel.INFO.ordinal(),
-                LoggingLevel.DEBUG.name() => LoggingLevel.DEBUG.ordinal(),
-                LoggingLevel.FINE.name() => LoggingLevel.FINE.ordinal(),
-                LoggingLevel.FINER.name() => LoggingLevel.FINER.ordinal(),
-                LoggingLevel.FINEST.name() => LoggingLevel.FINEST.ordinal()
+                System.LoggingLevel.ERROR.name() => System.LoggingLevel.ERROR.ordinal(),
+                System.LoggingLevel.WARN.name() => System.LoggingLevel.WARN.ordinal(),
+                System.LoggingLevel.INFO.name() => System.LoggingLevel.INFO.ordinal(),
+                System.LoggingLevel.DEBUG.name() => System.LoggingLevel.DEBUG.ordinal(),
+                System.LoggingLevel.FINE.name() => System.LoggingLevel.FINE.ordinal(),
+                System.LoggingLevel.FINER.name() => System.LoggingLevel.FINER.ordinal(),
+                System.LoggingLevel.FINEST.name() => System.LoggingLevel.FINEST.ordinal()
             };
         }
 
@@ -211,7 +211,7 @@ public inherited sharing class ComponentLogger {
         @AuraEnabled
         public Integer ordinal { get; set; }
 
-        private ComponentLoggingLevel(LoggingLevel loggingLevel) {
+        private ComponentLoggingLevel(System.LoggingLevel loggingLevel) {
             this.name = loggingLevel.name();
             this.ordinal = loggingLevel.ordinal();
         }

--- a/nebula-logger/core/main/logger-engine/classes/ComponentLogger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/ComponentLogger.cls
@@ -56,9 +56,9 @@ public inherited sharing class ComponentLogger {
             }
             Logger.saveLog(saveMethod);
             return Logger.getTransactionId();
-        } catch (Exception apexException) {
+        } catch (System.Exception apexException) {
             String errorMessage = apexException.getMessage() + '\n' + apexException.getStackTraceString();
-            AuraHandledException auraException = new AuraHandledException(errorMessage);
+            System.AuraHandledException auraException = new System.AuraHandledException(errorMessage);
             auraException.setMessage(errorMessage);
             throw auraException;
         }

--- a/nebula-logger/core/main/logger-engine/classes/FlowLogger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/FlowLogger.cls
@@ -81,7 +81,7 @@ public inherited sharing class FlowLogger {
         public DateTime timestamp;
 
         // Private member variables
-        private LoggingLevel entryLoggingLevel;
+        private System.LoggingLevel entryLoggingLevel;
         private LogEntryEventBuilder logEntryEventBuilder;
         private LogEntryEvent__e logEntryEvent;
 
@@ -97,9 +97,9 @@ public inherited sharing class FlowLogger {
             // Set the logging level if it's blank
             if (String.isBlank(this.loggingLevelName)) {
                 if (String.isNotBlank(this.faultMessage)) {
-                    this.loggingLevelName = LoggingLevel.ERROR.name();
+                    this.loggingLevelName = System.LoggingLevel.ERROR.name();
                 } else {
-                    this.loggingLevelName = LoggingLevel.DEBUG.name();
+                    this.loggingLevelName = System.LoggingLevel.DEBUG.name();
                 }
             }
 

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -1050,7 +1050,7 @@ global with sharing class LogEntryEventBuilder {
             return records;
         }
 
-        SObjectAccessDecision securityDecision = System.Security.stripInaccessible(AccessType.READABLE, records, false);
+        System.SObjectAccessDecision securityDecision = System.Security.stripInaccessible(System.AccessType.READABLE, records, false);
         return securityDecision.getRecords();
     }
 

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -13,7 +13,7 @@
 )
 global with sharing class LogEntryEventBuilder {
     private static final Map<String, String> CACHED_SOBJECT_NAME_TO_CLASSIFICATION = new Map<String, String>();
-    private static final User CURRENT_USER = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+    private static final User CURRENT_USER = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
     private static final String NEW_LINE_DELIMITER = '\n';
 
     @TestVisible
@@ -862,14 +862,14 @@ global with sharing class LogEntryEventBuilder {
     }
 
     private static void setUserInfoDetails(LogEntryEvent__e templateLogEntryEvent) {
-        templateLogEntryEvent.Locale__c = UserInfo.getLocale();
-        templateLogEntryEvent.LoggedById__c = UserInfo.getUserId();
-        templateLogEntryEvent.ProfileId__c = UserInfo.getProfileId();
-        templateLogEntryEvent.ThemeDisplayed__c = UserInfo.getUiThemeDisplayed();
-        templateLogEntryEvent.TimeZoneId__c = UserInfo.getTimeZone().getId();
-        templateLogEntryEvent.TimeZoneName__c = UserInfo.getTimeZone().getDisplayName();
-        templateLogEntryEvent.UserRoleId__c = UserInfo.getUserRoleId();
-        templateLogEntryEvent.UserType__c = UserInfo.getUserType();
+        templateLogEntryEvent.Locale__c = System.UserInfo.getLocale();
+        templateLogEntryEvent.LoggedById__c = System.UserInfo.getUserId();
+        templateLogEntryEvent.ProfileId__c = System.UserInfo.getProfileId();
+        templateLogEntryEvent.ThemeDisplayed__c = System.UserInfo.getUiThemeDisplayed();
+        templateLogEntryEvent.TimeZoneId__c = System.UserInfo.getTimeZone().getId();
+        templateLogEntryEvent.TimeZoneName__c = System.UserInfo.getTimeZone().getDisplayName();
+        templateLogEntryEvent.UserRoleId__c = System.UserInfo.getUserRoleId();
+        templateLogEntryEvent.UserType__c = System.UserInfo.getUserType();
     }
 
     // Private static helper methods
@@ -911,10 +911,10 @@ global with sharing class LogEntryEventBuilder {
     private static String getOrganizationApiVersion() {
         // Small hack to determine the org's current API version (since Apex doesn't natively provide it)
         // Serializing any SObject w/ an ID will include the API version
-        // So, use UserInfo.getUserId() to create the current user's record without querying
+        // So, use System.UserInfo.getUserId() to create the current user's record without querying
         // Then parse the JSON to get the API version
         // Expected JSON: {"attributes":{"type":"User","url":"/services/data/v53.0/sobjects/User/005J000000AugnYIAR"}
-        String userJson = JSON.serialize(new User(Id = UserInfo.getUserId()));
+        String userJson = JSON.serialize(new User(Id = System.UserInfo.getUserId()));
         return userJson.substringAfter('/data/').substringBefore('/sobjects/User');
     }
 

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -20,7 +20,7 @@ global with sharing class LogEntryEventBuilder {
     private static Id networkId = System.Network.getNetworkId();
 
     private final LogEntryEvent__e logEntryEvent;
-    private final LoggingLevel entryLoggingLevel;
+    private final System.LoggingLevel entryLoggingLevel;
     private final LoggerSettings__c userSettings;
 
     @TestVisible
@@ -99,7 +99,7 @@ global with sharing class LogEntryEventBuilder {
      * @param  ignoredOrigins    A `Set<String>` of the names of any Apex classes that should be ignored when parsing the entry's origin
      */
     @SuppressWarnings('PMD.ExcessiveParameterList, PMD.NcssConstructorCount')
-    public LogEntryEventBuilder(LoggerSettings__c userSettings, LoggingLevel entryLoggingLevel, Boolean shouldSave, Set<String> ignoredOrigins) {
+    public LogEntryEventBuilder(LoggerSettings__c userSettings, System.LoggingLevel entryLoggingLevel, Boolean shouldSave, Set<String> ignoredOrigins) {
         this.shouldSave = shouldSave;
         if (this.shouldSave() == false) {
             return;

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -179,10 +179,10 @@ global with sharing class LogEntryEventBuilder {
 
     /**
      * @description Sets the log entry event's exception fields
-     * @param  apexException The instance of an `Exception` to use.
+     * @param  apexException The instance of an `System.Exception` to use.
      * @return               The same instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global LogEntryEventBuilder setExceptionDetails(Exception apexException) {
+    global LogEntryEventBuilder setExceptionDetails(System.Exception apexException) {
         if (this.shouldSave() == false) {
             return this;
         }
@@ -499,7 +499,7 @@ global with sharing class LogEntryEventBuilder {
      * @param  request The instance of `HttpRequest` to log
      * @return              The same instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global LogEntryEventBuilder setHttpRequestDetails(HttpRequest request) {
+    global LogEntryEventBuilder setHttpRequestDetails(System.HttpRequest request) {
         if (this.shouldSave() == false || request == null) {
             return this;
         }
@@ -520,7 +520,7 @@ global with sharing class LogEntryEventBuilder {
      * @param  response The instance of `HttpResponse` to log
      * @return              The same instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global LogEntryEventBuilder setHttpResponseDetails(HttpResponse response) {
+    global LogEntryEventBuilder setHttpResponseDetails(System.HttpResponse response) {
         if (this.shouldSave() == false || response == null) {
             return this;
         }
@@ -712,7 +712,7 @@ global with sharing class LogEntryEventBuilder {
             return;
         }
 
-        DmlException stackTraceException = new DmlException();
+        System.DmlException stackTraceException = new System.DmlException();
         this.parseStackTrace(stackTraceException.getStackTraceString());
     }
 

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -439,10 +439,10 @@ global with sharing class Logger {
     /**
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder error(LogMessage logMessage, Exception apexException) {
+    global static LogEntryEventBuilder error(LogMessage logMessage, System.Exception apexException) {
         return error().setExceptionDetails(apexException).setMessage(logMessage);
     }
 
@@ -450,10 +450,10 @@ global with sharing class Logger {
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  recordId      The record ID of an `SObject` to log
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder error(LogMessage logMessage, Id recordId, Exception apexException) {
+    global static LogEntryEventBuilder error(LogMessage logMessage, Id recordId, System.Exception apexException) {
         return error().setRecordId(recordId).setExceptionDetails(apexException).setMessage(logMessage);
     }
 
@@ -471,10 +471,10 @@ global with sharing class Logger {
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  record        The `SObject` record to log
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder error(LogMessage logMessage, SObject record, Exception apexException) {
+    global static LogEntryEventBuilder error(LogMessage logMessage, SObject record, System.Exception apexException) {
         return error().setRecordId(record).setExceptionDetails(apexException).setMessage(logMessage);
     }
 
@@ -492,10 +492,10 @@ global with sharing class Logger {
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  records       The list of `SObject` records to log
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder error(LogMessage logMessage, List<SObject> records, Exception apexException) {
+    global static LogEntryEventBuilder error(LogMessage logMessage, List<SObject> records, System.Exception apexException) {
         return error().setRecord(records).setExceptionDetails(apexException).setMessage(logMessage);
     }
 
@@ -621,10 +621,10 @@ global with sharing class Logger {
     /**
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message       The string to use to set the entry's message field
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder error(String message, Exception apexException) {
+    global static LogEntryEventBuilder error(String message, System.Exception apexException) {
         return error().setExceptionDetails(apexException).setMessage(message);
     }
 
@@ -632,10 +632,10 @@ global with sharing class Logger {
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message       The string to use to set the entry's message field
      * @param  recordId      The record ID of an `SObject` to log
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder error(String message, Id recordId, Exception apexException) {
+    global static LogEntryEventBuilder error(String message, Id recordId, System.Exception apexException) {
         return error().setRecordId(recordId).setExceptionDetails(apexException).setMessage(message);
     }
 
@@ -653,10 +653,10 @@ global with sharing class Logger {
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message       The string to use to set the entry's message field
      * @param  record        The `SObject` record to log
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder error(String message, SObject record, Exception apexException) {
+    global static LogEntryEventBuilder error(String message, SObject record, System.Exception apexException) {
         return error().setRecordId(record).setExceptionDetails(apexException).setMessage(message);
     }
 
@@ -674,10 +674,10 @@ global with sharing class Logger {
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message    The instance of `LogMessage` to use to set the entry's message field
      * @param  records       The list of `SObject` records to log
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder error(String message, List<SObject> records, Exception apexException) {
+    global static LogEntryEventBuilder error(String message, List<SObject> records, System.Exception apexException) {
         return error().setRecord(records).setExceptionDetails(apexException).setMessage(message);
     }
 
@@ -804,10 +804,10 @@ global with sharing class Logger {
     /**
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder warn(LogMessage logMessage, Exception apexException) {
+    global static LogEntryEventBuilder warn(LogMessage logMessage, System.Exception apexException) {
         return warn().setExceptionDetails(apexException).setMessage(logMessage);
     }
 
@@ -815,10 +815,10 @@ global with sharing class Logger {
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  recordId      The record ID of an `SObject` to log
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder warn(LogMessage logMessage, Id recordId, Exception apexException) {
+    global static LogEntryEventBuilder warn(LogMessage logMessage, Id recordId, System.Exception apexException) {
         return warn().setRecordId(recordId).setExceptionDetails(apexException).setMessage(logMessage);
     }
 
@@ -836,10 +836,10 @@ global with sharing class Logger {
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  record        The `SObject` record to log
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder warn(LogMessage logMessage, SObject record, Exception apexException) {
+    global static LogEntryEventBuilder warn(LogMessage logMessage, SObject record, System.Exception apexException) {
         return warn().setRecordId(record).setExceptionDetails(apexException).setMessage(logMessage);
     }
 
@@ -857,10 +857,10 @@ global with sharing class Logger {
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  records       The list of `SObject` records to log
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder warn(LogMessage logMessage, List<SObject> records, Exception apexException) {
+    global static LogEntryEventBuilder warn(LogMessage logMessage, List<SObject> records, System.Exception apexException) {
         return warn().setRecord(records).setExceptionDetails(apexException).setMessage(logMessage);
     }
 
@@ -986,10 +986,10 @@ global with sharing class Logger {
     /**
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message       The string to use to set the entry's message field
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder warn(String message, Exception apexException) {
+    global static LogEntryEventBuilder warn(String message, System.Exception apexException) {
         return warn().setExceptionDetails(apexException).setMessage(message);
     }
 
@@ -997,10 +997,10 @@ global with sharing class Logger {
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message       The string to use to set the entry's message field
      * @param  recordId      The record ID of an `SObject` to log
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder warn(String message, Id recordId, Exception apexException) {
+    global static LogEntryEventBuilder warn(String message, Id recordId, System.Exception apexException) {
         return warn().setRecordId(recordId).setExceptionDetails(apexException).setMessage(message);
     }
 
@@ -1018,10 +1018,10 @@ global with sharing class Logger {
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message       The string to use to set the entry's message field
      * @param  record        The `SObject` record to log
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder warn(String message, SObject record, Exception apexException) {
+    global static LogEntryEventBuilder warn(String message, SObject record, System.Exception apexException) {
         return warn().setRecordId(record).setExceptionDetails(apexException).setMessage(message);
     }
 
@@ -1039,10 +1039,10 @@ global with sharing class Logger {
      * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message    The instance of `LogMessage` to use to set the entry's message field
      * @param  records       The list of `SObject` records to log
-     * @param  apexException The instance of `Exception` to log
+     * @param  apexException The instance of `System.Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
-    global static LogEntryEventBuilder warn(String message, List<SObject> records, Exception apexException) {
+    global static LogEntryEventBuilder warn(String message, List<SObject> records, System.Exception apexException) {
         return warn().setRecord(records).setExceptionDetails(apexException).setMessage(message);
     }
 
@@ -3048,7 +3048,7 @@ global with sharing class Logger {
          * @param records The records to save.
          */
         public void insertRecords(List<SObject> records) {
-            HttpRequest request = new HttpRequest();
+            System.HttpRequest request = new System.HttpRequest();
             request.setEndpoint(baseURL + compositeEndpoint);
             request.setHeader('Authorization', 'Bearer ' + USER_SESSION_ID);
             request.setHeader('Content-Type', 'application/json; charset=utf-8');
@@ -3058,15 +3058,15 @@ global with sharing class Logger {
             RestSaveRequest saveRequest = new RestSaveRequest(records, allOrNone);
             request.setBody(JSON.serialize(saveRequest));
 
-            HttpResponse response = new Http().send(request);
+            System.HttpResponse response = new System.Http().send(request);
             this.validateResponse(response);
         }
 
-        private void validateResponse(Httpresponse response) {
+        private void validateResponse(System.HttpResponse response) {
             Integer statusCode = response.getStatusCode();
             if (statusCode >= 400) {
                 String errorMessage = 'Saving via REST API failed. Received request status code ' + statusCode + ', status message: ' + response.getStatus();
-                throw new CalloutException(errorMessage);
+                throw new System.CalloutException(errorMessage);
             }
         }
     }

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -48,9 +48,9 @@ global with sharing class Logger {
     private static final String USER_SESSION_ID {
         get {
             if (USER_SESSION_ID == null) {
-                USER_SESSION_ID = UserInfo.getSessionId();
-                // If UserInfo.getSessionId() returns null, set to an empty string to
-                // avoid calling UserInfo.getSessionId() again
+                USER_SESSION_ID = System.UserInfo.getSessionId();
+                // If System.UserInfo.getSessionId() returns null, set to an empty string to
+                // avoid calling System.UserInfo.getSessionId() again
                 USER_SESSION_ID = USER_SESSION_ID == null ? '' : USER_SESSION_ID;
             }
             return USER_SESSION_ID;
@@ -250,7 +250,7 @@ global with sharing class Logger {
     public static LoggerSettings__c getUserSettings() {
         // Only load the current user's settings once - this allows the instance to be modified in memory (as well as upserted if any changes should be persisted)
         if (userSettings == null) {
-            User currentUser = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+            User currentUser = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
             userSettings = getUserSettings(currentUser);
         }
         return userSettings;

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.9.3';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.9.4';
     private static final LoggingLevel DEFAULT_LOGGING_LEVEL = LoggingLevel.DEBUG;
     private static final Set<String> IGNORED_APEX_CLASSES = initializeIgnoredApexClasses();
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -16,7 +16,7 @@ global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
     private static final String CURRENT_VERSION_NUMBER = 'v4.9.4';
-    private static final LoggingLevel DEFAULT_LOGGING_LEVEL = LoggingLevel.DEBUG;
+    private static final System.LoggingLevel DEFAULT_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final Set<String> IGNORED_APEX_CLASSES = initializeIgnoredApexClasses();
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
     private static final String REQUEST_ID = System.Request.getCurrent().getRequestId();
@@ -68,7 +68,7 @@ global with sharing class Logger {
         set;
     }
 
-    private static LoggingLevel userLoggingLevel {
+    private static System.LoggingLevel userLoggingLevel {
         get {
             if (userLoggingLevel == null || userLoggingLevel.name() != getUserSettings().LoggingLevel__c) {
                 userLoggingLevel = getLoggingLevel(getUserSettings().LoggingLevel__c);
@@ -81,8 +81,8 @@ global with sharing class Logger {
     static {
         // 1 of 2 places in the codebase (except tests) that should use System.debug()
         // The rest of the codebase should use a method in Logger.cls
-        System.debug(LoggingLevel.INFO, 'Logger - Version Number: ' + getVersionNumber());
-        System.debug(LoggingLevel.INFO, 'Logger - Transaction ID: ' + getTransactionId());
+        System.debug(System.LoggingLevel.INFO, 'Logger - Version Number: ' + getVersionNumber());
+        System.debug(System.LoggingLevel.INFO, 'Logger - Transaction ID: ' + getTransactionId());
         setScenario(getUserSettings().DefaultScenario__c);
     }
 
@@ -165,7 +165,7 @@ global with sharing class Logger {
      * @param  loggingLevel - The logging level to check
      * @return Boolean
      */
-    global static Boolean isEnabled(LoggingLevel loggingLevel) {
+    global static Boolean isEnabled(System.LoggingLevel loggingLevel) {
         return isEnabled() && meetsUserLoggingLevel(loggingLevel);
     }
 
@@ -174,7 +174,7 @@ global with sharing class Logger {
      * @return Boolean
      */
     global static Boolean isErrorEnabled() {
-        return isEnabled() && meetsUserLoggingLevel(LoggingLevel.ERROR);
+        return isEnabled() && meetsUserLoggingLevel(System.LoggingLevel.ERROR);
     }
 
     /**
@@ -182,7 +182,7 @@ global with sharing class Logger {
      * @return Boolean
      */
     global static Boolean isWarnEnabled() {
-        return isEnabled() && meetsUserLoggingLevel(LoggingLevel.WARN);
+        return isEnabled() && meetsUserLoggingLevel(System.LoggingLevel.WARN);
     }
 
     /**
@@ -190,7 +190,7 @@ global with sharing class Logger {
      * @return Boolean
      */
     global static Boolean isInfoEnabled() {
-        return isEnabled() && meetsUserLoggingLevel(LoggingLevel.INFO);
+        return isEnabled() && meetsUserLoggingLevel(System.LoggingLevel.INFO);
     }
 
     /**
@@ -198,7 +198,7 @@ global with sharing class Logger {
      * @return Boolean
      */
     global static Boolean isDebugEnabled() {
-        return isEnabled() && meetsUserLoggingLevel(LoggingLevel.DEBUG);
+        return isEnabled() && meetsUserLoggingLevel(System.LoggingLevel.DEBUG);
     }
 
     /**
@@ -206,7 +206,7 @@ global with sharing class Logger {
      * @return Boolean
      */
     global static Boolean isFineEnabled() {
-        return isEnabled() && meetsUserLoggingLevel(LoggingLevel.FINE);
+        return isEnabled() && meetsUserLoggingLevel(System.LoggingLevel.FINE);
     }
 
     /**
@@ -214,7 +214,7 @@ global with sharing class Logger {
      * @return Boolean
      */
     global static Boolean isFinerEnabled() {
-        return isEnabled() && meetsUserLoggingLevel(LoggingLevel.FINER);
+        return isEnabled() && meetsUserLoggingLevel(System.LoggingLevel.FINER);
     }
 
     /**
@@ -222,7 +222,7 @@ global with sharing class Logger {
      * @return Boolean
      */
     global static Boolean isFinestEnabled() {
-        return isEnabled() && meetsUserLoggingLevel(LoggingLevel.FINEST);
+        return isEnabled() && meetsUserLoggingLevel(System.LoggingLevel.FINEST);
     }
 
     /**
@@ -230,15 +230,15 @@ global with sharing class Logger {
      * @param logEntryLoggingLevel the logging level to check.
      * @return Boolean
      */
-    global static Boolean meetsUserLoggingLevel(LoggingLevel logEntryLoggingLevel) {
+    global static Boolean meetsUserLoggingLevel(System.LoggingLevel logEntryLoggingLevel) {
         return userLoggingLevel.ordinal() <= logEntryLoggingLevel.ordinal();
     }
 
     /**
      * @description Returns the logging level for the current user, based on the custom setting LoggerSettings__c
-     * @return LoggingLevel - The matching instance of LoggingLevel
+     * @return System.LoggingLevel - The matching instance of LoggingLevel
      */
-    global static LoggingLevel getUserLoggingLevel() {
+    global static System.LoggingLevel getUserLoggingLevel() {
         return userLoggingLevel;
     }
 
@@ -337,7 +337,7 @@ global with sharing class Logger {
 
     // ERROR logging level methods
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -347,7 +347,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -357,7 +357,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -367,7 +367,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage     The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -377,7 +377,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -387,7 +387,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -397,7 +397,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResults The instance of `List<Database.MergeResult>` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -407,7 +407,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResults The instance of `List<Database.SaveResult>` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -417,7 +417,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage      The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -427,7 +427,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -437,7 +437,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  apexException The instance of `Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -447,7 +447,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  recordId      The record ID of an `SObject` to log
      * @param  apexException The instance of `Exception` to log
@@ -458,7 +458,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  recordId   The record ID of an `SObject` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -468,7 +468,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  record        The `SObject` record to log
      * @param  apexException The instance of `Exception` to log
@@ -479,7 +479,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  record     The `SObject` record to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -489,7 +489,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  records       The list of `SObject` records to log
      * @param  apexException The instance of `Exception` to log
@@ -500,7 +500,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  records    The list of `SObject` records to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -510,7 +510,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -519,7 +519,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message   The string to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -529,7 +529,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message     The string to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -539,7 +539,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message    The string to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -549,7 +549,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message        The string to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -559,7 +559,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message      The string to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -569,7 +569,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message       The string to use to set the entry's message field
      * @param  deleteResults The list of `Database.DeleteResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -579,7 +579,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message      The string to use to set the entry's message field
      * @param  mergeResults The list of `Database.MergeResult` instances to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -589,7 +589,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message     The string to use to set the entry's message field
      * @param  saveResults The list of `Database.SaveResult` instances to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -599,7 +599,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message         The string to use to set the entry's message field
      * @param  undeleteResults The list of `Database.UndeleteResult` instances to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -609,7 +609,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message       The string to use to set the entry's message field
      * @param  upsertResults The list of `Database.UpsertResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -619,7 +619,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message       The string to use to set the entry's message field
      * @param  apexException The instance of `Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -629,7 +629,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message       The string to use to set the entry's message field
      * @param  recordId      The record ID of an `SObject` to log
      * @param  apexException The instance of `Exception` to log
@@ -640,7 +640,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message  The string to use to set the entry's message field
      * @param  recordId The record ID of an `SObject` to log
      * @return          The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -650,7 +650,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message       The string to use to set the entry's message field
      * @param  record        The `SObject` record to log
      * @param  apexException The instance of `Exception` to log
@@ -661,7 +661,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message The string to use to set the entry's message field
      * @param  record  The `SObject` record to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -671,7 +671,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message    The instance of `LogMessage` to use to set the entry's message field
      * @param  records       The list of `SObject` records to log
      * @param  apexException The instance of `Exception` to log
@@ -682,7 +682,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message The string to use to set the entry's message field
      * @param  records The list of `SObject` records to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -692,7 +692,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.ERROR`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.ERROR`
      * @param  message The string to use to set the entry's message field
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -702,7 +702,7 @@ global with sharing class Logger {
 
     // WARN logging level methods
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -712,7 +712,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -722,7 +722,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -732,7 +732,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage     The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -742,7 +742,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -752,7 +752,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -762,7 +762,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResults The instance of `List<Database.MergeResult>` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -772,7 +772,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResults The instance of `List<Database.SaveResult>` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -782,7 +782,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage      The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -792,7 +792,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -802,7 +802,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  apexException The instance of `Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -812,7 +812,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  recordId      The record ID of an `SObject` to log
      * @param  apexException The instance of `Exception` to log
@@ -823,7 +823,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  recordId   The record ID of an `SObject` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -833,7 +833,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  record        The `SObject` record to log
      * @param  apexException The instance of `Exception` to log
@@ -844,7 +844,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  record     The `SObject` record to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -854,7 +854,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  records       The list of `SObject` records to log
      * @param  apexException The instance of `Exception` to log
@@ -865,7 +865,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  records    The list of `SObject` records to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -875,7 +875,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -884,7 +884,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message   The string to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -894,7 +894,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message     The string to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -904,7 +904,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message    The string to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -914,7 +914,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message        The string to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -924,7 +924,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message      The string to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -934,7 +934,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message       The string to use to set the entry's message field
      * @param  deleteResults The list of `Database.DeleteResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -944,7 +944,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message      The string to use to set the entry's message field
      * @param  mergeResults The list of `Database.MergeResult` instances to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -954,7 +954,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message     The string to use to set the entry's message field
      * @param  saveResults The list of `Database.SaveResult` instances to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -964,7 +964,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message         The string to use to set the entry's message field
      * @param  undeleteResults The list of `Database.UndeleteResult` instances to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -974,7 +974,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message       The string to use to set the entry's message field
      * @param  upsertResults The list of `Database.UpsertResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -984,7 +984,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message       The string to use to set the entry's message field
      * @param  apexException The instance of `Exception` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -994,7 +994,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message       The string to use to set the entry's message field
      * @param  recordId      The record ID of an `SObject` to log
      * @param  apexException The instance of `Exception` to log
@@ -1005,7 +1005,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message  The string to use to set the entry's message field
      * @param  recordId The record ID of an `SObject` to log
      * @return          The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1015,7 +1015,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message       The string to use to set the entry's message field
      * @param  record        The `SObject` record to log
      * @param  apexException The instance of `Exception` to log
@@ -1026,7 +1026,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message The string to use to set the entry's message field
      * @param  record  The `SObject` record to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1036,7 +1036,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message    The instance of `LogMessage` to use to set the entry's message field
      * @param  records       The list of `SObject` records to log
      * @param  apexException The instance of `Exception` to log
@@ -1047,7 +1047,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message The string to use to set the entry's message field
      * @param  records The list of `SObject` records to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1057,7 +1057,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.WARN`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.WARN`
      * @param  message The string to use to set the entry's message field
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -1066,7 +1066,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1076,7 +1076,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1086,7 +1086,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1096,7 +1096,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage     The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1106,7 +1106,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1116,7 +1116,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1126,7 +1126,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResults The instance of `List<Database.MergeResult>` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1136,7 +1136,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResults The instance of `List<Database.SaveResult>` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1146,7 +1146,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage      The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1156,7 +1156,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1166,7 +1166,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  recordId   The record ID of an `SObject` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1176,7 +1176,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  record     The `SObject` record to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1186,7 +1186,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  records    The list of `SObject` records to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1196,7 +1196,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -1205,7 +1205,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message   The string to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1215,7 +1215,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message     The string to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1225,7 +1225,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message    The string to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1235,7 +1235,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message        The string to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1245,7 +1245,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message      The string to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1255,7 +1255,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message       The string to use to set the entry's message field
      * @param  deleteResults The list of `Database.DeleteResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1265,7 +1265,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message      The string to use to set the entry's message field
      * @param  mergeResults The list of `Database.MergeResult` instances to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1275,7 +1275,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message     The string to use to set the entry's message field
      * @param  saveResults The list of `Database.SaveResult` instances to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1285,7 +1285,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message         The string to use to set the entry's message field
      * @param  undeleteResults The list of `Database.UndeleteResult` instances to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1295,7 +1295,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message       The string to use to set the entry's message field
      * @param  upsertResults The list of `Database.UpsertResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1305,7 +1305,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message  The string to use to set the entry's message field
      * @param  recordId The record ID of an `SObject` to log
      * @return          The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1315,7 +1315,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message The string to use to set the entry's message field
      * @param  record  The `SObject` record to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1325,7 +1325,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message The string to use to set the entry's message field
      * @param  records The list of `SObject` records to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1335,7 +1335,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.INFO`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.INFO`
      * @param  message The string to use to set the entry's message field
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -1345,7 +1345,7 @@ global with sharing class Logger {
 
     // DEBUG log level methods
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1355,7 +1355,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1365,7 +1365,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1375,7 +1375,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage     The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1385,7 +1385,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1395,7 +1395,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1405,7 +1405,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResults The instance of `List<Database.MergeResult>` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1415,7 +1415,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResults The instance of `List<Database.SaveResult>` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1425,7 +1425,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage      The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1435,7 +1435,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1445,7 +1445,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  recordId   The record ID of an `SObject` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1455,7 +1455,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  record     The `SObject` record to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1465,7 +1465,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  records    The list of `SObject` records to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1475,7 +1475,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -1484,7 +1484,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message   The string to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1494,7 +1494,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message     The string to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1504,7 +1504,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message    The string to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1514,7 +1514,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message        The string to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1524,7 +1524,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message      The string to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1534,7 +1534,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message       The string to use to set the entry's message field
      * @param  deleteResults The list of `Database.DeleteResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1544,7 +1544,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message      The string to use to set the entry's message field
      * @param  mergeResults The list of `Database.MergeResult` instances to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1554,7 +1554,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message     The string to use to set the entry's message field
      * @param  saveResults The list of `Database.SaveResult` instances to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1564,7 +1564,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message         The string to use to set the entry's message field
      * @param  undeleteResults The list of `Database.UndeleteResult` instances to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1574,7 +1574,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message       The string to use to set the entry's message field
      * @param  upsertResults The list of `Database.UpsertResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1584,7 +1584,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message  The string to use to set the entry's message field
      * @param  recordId The record ID of an `SObject` to log
      * @return          The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1594,7 +1594,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message The string to use to set the entry's message field
      * @param  record  The `SObject` record to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1604,7 +1604,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message The string to use to set the entry's message field
      * @param  records The list of `SObject` records to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1614,7 +1614,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.DEBUG`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.DEBUG`
      * @param  message The string to use to set the entry's message field
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -1624,7 +1624,7 @@ global with sharing class Logger {
 
     // FINE log level methods
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1634,7 +1634,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1644,7 +1644,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1654,7 +1654,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage     The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1664,7 +1664,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1674,7 +1674,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1684,7 +1684,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResults The instance of `List<Database.MergeResult>` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1694,7 +1694,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResults The instance of `List<Database.SaveResult>` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1704,7 +1704,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage      The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1714,7 +1714,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1724,7 +1724,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  recordId   The record ID of an `SObject` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1734,7 +1734,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  record     The `SObject` record to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1744,7 +1744,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  records    The list of `SObject` records to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1754,7 +1754,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -1763,7 +1763,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message   The string to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1773,7 +1773,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message     The string to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1783,7 +1783,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message    The string to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1793,7 +1793,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message        The string to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1803,7 +1803,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message      The string to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1813,7 +1813,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message       The string to use to set the entry's message field
      * @param  deleteResults The list of `Database.DeleteResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1823,7 +1823,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message      The string to use to set the entry's message field
      * @param  mergeResults The list of `Database.MergeResult` instances to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1833,7 +1833,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message     The string to use to set the entry's message field
      * @param  saveResults The list of `Database.SaveResult` instances to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1843,7 +1843,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message         The string to use to set the entry's message field
      * @param  undeleteResults The list of `Database.UndeleteResult` instances to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1853,7 +1853,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message       The string to use to set the entry's message field
      * @param  upsertResults The list of `Database.UpsertResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1863,7 +1863,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message  The string to use to set the entry's message field
      * @param  recordId The record ID of an `SObject` to log
      * @return          The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1873,7 +1873,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message The string to use to set the entry's message field
      * @param  record  The `SObject` record to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1883,7 +1883,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message The string to use to set the entry's message field
      * @param  records The list of `SObject` records to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1893,7 +1893,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINE`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINE`
      * @param  message The string to use to set the entry's message field
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -1903,7 +1903,7 @@ global with sharing class Logger {
 
     // FINER log level methods
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1913,7 +1913,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1923,7 +1923,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1933,7 +1933,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage     The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1943,7 +1943,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1953,7 +1953,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1963,7 +1963,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResults The instance of `List<Database.MergeResult>` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1973,7 +1973,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResults The instance of `List<Database.SaveResult>` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1983,7 +1983,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage      The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -1993,7 +1993,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2003,7 +2003,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  recordId   The record ID of an `SObject` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2013,7 +2013,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  record     The `SObject` record to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2023,7 +2023,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  records    The list of `SObject` records to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2033,7 +2033,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -2042,7 +2042,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message   The string to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2052,7 +2052,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message     The string to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2062,7 +2062,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message    The string to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2072,7 +2072,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message        The string to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2082,7 +2082,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message      The string to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2092,7 +2092,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message       The string to use to set the entry's message field
      * @param  deleteResults The list of `Database.DeleteResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2102,7 +2102,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message      The string to use to set the entry's message field
      * @param  mergeResults The list of `Database.MergeResult` instances to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2112,7 +2112,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message     The string to use to set the entry's message field
      * @param  saveResults The list of `Database.SaveResult` instances to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2122,7 +2122,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message         The string to use to set the entry's message field
      * @param  undeleteResults The list of `Database.UndeleteResult` instances to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2132,7 +2132,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message       The string to use to set the entry's message field
      * @param  upsertResults The list of `Database.UpsertResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2142,7 +2142,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message  The string to use to set the entry's message field
      * @param  recordId The record ID of an `SObject` to log
      * @return          The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2152,7 +2152,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message The string to use to set the entry's message field
      * @param  record  The `SObject` record to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2162,7 +2162,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message The string to use to set the entry's message field
      * @param  records The list of `SObject` records to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2172,7 +2172,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINER`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINER`
      * @param  message The string to use to set the entry's message field
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -2182,7 +2182,7 @@ global with sharing class Logger {
 
     // FINEST log level methods
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2192,7 +2192,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2202,7 +2202,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2212,7 +2212,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage     The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2222,7 +2222,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2232,7 +2232,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2242,7 +2242,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage   The instance of `LogMessage` to use to set the entry's message field
      * @param  mergeResults The instance of `List<Database.MergeResult>` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2252,7 +2252,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage  The instance of `LogMessage` to use to set the entry's message field
      * @param  saveResults The instance of `List<Database.SaveResult>` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2262,7 +2262,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage      The instance of `LogMessage` to use to set the entry's message field
      * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2272,7 +2272,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage    The instance of `LogMessage` to use to set the entry's message field
      * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2282,7 +2282,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  recordId   The record ID of an `SObject` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2292,7 +2292,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  record     The `SObject` record to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2302,7 +2302,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @param  records    The list of `SObject` records to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2312,7 +2312,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  logMessage The instance of `LogMessage` to use to set the entry's message field
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -2321,7 +2321,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message   The string to use to set the entry's message field
      * @param  deleteResult The instance of `Database.DeleteResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2331,7 +2331,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message     The string to use to set the entry's message field
      * @param  mergeResult The instance of `Database.MergeResult` to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2341,7 +2341,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message    The string to use to set the entry's message field
      * @param  saveResult The instance of `Database.SaveResult` to log
      * @return            The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2351,7 +2351,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message        The string to use to set the entry's message field
      * @param  undeleteResult The instance of `Database.UndeleteResult` to log
      * @return                The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2361,7 +2361,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message      The string to use to set the entry's message field
      * @param  upsertResult The instance of `Database.UpsertResult` to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2371,7 +2371,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message       The string to use to set the entry's message field
      * @param  deleteResults The list of `Database.DeleteResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2381,7 +2381,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message      The string to use to set the entry's message field
      * @param  mergeResults The list of `Database.MergeResult` instances to log
      * @return              The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2391,7 +2391,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message     The string to use to set the entry's message field
      * @param  saveResults The list of `Database.SaveResult` instances to log
      * @return             The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2401,7 +2401,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message         The string to use to set the entry's message field
      * @param  undeleteResults The list of `Database.UndeleteResult` instances to log
      * @return                 The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2411,7 +2411,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message       The string to use to set the entry's message field
      * @param  upsertResults The list of `Database.UpsertResult` instances to log
      * @return               The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2421,7 +2421,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message  The string to use to set the entry's message field
      * @param  recordId The record ID of an `SObject` to log
      * @return          The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2431,7 +2431,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message The string to use to set the entry's message field
      * @param  record  The `SObject` record to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2441,7 +2441,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message The string to use to set the entry's message field
      * @param  records The list of `SObject` records to log
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
@@ -2451,7 +2451,7 @@ global with sharing class Logger {
     }
 
     /**
-     * @description Creates a new log entry with logging level == `LoggingLevel.FINEST`
+     * @description Creates a new log entry with logging level == ` System.LoggingLevel.FINEST`
      * @param  message The string to use to set the entry's message field
      * @return         The new entry's instance of `LogEntryEventBuilder`, useful for chaining methods
      */
@@ -2466,7 +2466,7 @@ global with sharing class Logger {
      * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
      * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.DeleteResult> deleteResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(System.LoggingLevel loggingLevel, LogMessage logMessage, List<Database.DeleteResult> deleteResults) {
         return logDatabaseErrors(loggingLevel, logMessage.getMessage(), deleteResults);
     }
 
@@ -2477,7 +2477,7 @@ global with sharing class Logger {
      * @param  deleteResults The instance of `List<Database.DeleteResult>` to log
      * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.DeleteResult> deleteResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(System.LoggingLevel loggingLevel, String message, List<Database.DeleteResult> deleteResults) {
         List<Database.DeleteResult> resultsToLog = new List<Database.DeleteResult>();
         for (Database.DeleteResult deleteResult : deleteResults) {
             if (deleteResult.isSuccess() == false) {
@@ -2496,7 +2496,7 @@ global with sharing class Logger {
      * @param  mergeResults The instance of `List<Database.MergeResult>` to log
      * @return              The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.MergeResult> mergeResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(System.LoggingLevel loggingLevel, LogMessage logMessage, List<Database.MergeResult> mergeResults) {
         return logDatabaseErrors(loggingLevel, logMessage.getMessage(), mergeResults);
     }
 
@@ -2507,7 +2507,7 @@ global with sharing class Logger {
      * @param  mergeResults The instance of `List<Database.MergeResult>` to log
      * @return              The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.MergeResult> mergeResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(System.LoggingLevel loggingLevel, String message, List<Database.MergeResult> mergeResults) {
         List<Database.MergeResult> resultsToLog = new List<Database.MergeResult>();
         for (Database.MergeResult mergeResult : mergeResults) {
             if (mergeResult.isSuccess() == false) {
@@ -2526,7 +2526,7 @@ global with sharing class Logger {
      * @param  saveResults  The instance of `List<Database.SaveResult>` to log
      * @return              The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.SaveResult> saveResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(System.LoggingLevel loggingLevel, LogMessage logMessage, List<Database.SaveResult> saveResults) {
         return logDatabaseErrors(loggingLevel, logMessage.getMessage(), saveResults);
     }
 
@@ -2537,7 +2537,7 @@ global with sharing class Logger {
      * @param  saveResults  The instance of `List<Database.SaveResult>` to log
      * @return              The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.SaveResult> saveResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(System.LoggingLevel loggingLevel, String message, List<Database.SaveResult> saveResults) {
         List<Database.SaveResult> resultsToLog = new List<Database.SaveResult>();
         for (Database.SaveResult saveResult : saveResults) {
             if (saveResult.isSuccess() == false) {
@@ -2556,7 +2556,7 @@ global with sharing class Logger {
      * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
      * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UpsertResult> upsertResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(System.LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UpsertResult> upsertResults) {
         return logDatabaseErrors(loggingLevel, logMessage.getMessage(), upsertResults);
     }
 
@@ -2567,7 +2567,7 @@ global with sharing class Logger {
      * @param  upsertResults The instance of `List<Database.UpsertResult>` to log
      * @return               The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UpsertResult> upsertResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(System.LoggingLevel loggingLevel, String message, List<Database.UpsertResult> upsertResults) {
         List<Database.UpsertResult> resultsToLog = new List<Database.UpsertResult>();
         for (Database.UpsertResult upsertResult : upsertResults) {
             if (upsertResult.isSuccess() == false) {
@@ -2586,7 +2586,11 @@ global with sharing class Logger {
      * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
      * @return                 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, LogMessage logMessage, List<Database.UndeleteResult> undeleteResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(
+        System.LoggingLevel loggingLevel,
+        LogMessage logMessage,
+        List<Database.UndeleteResult> undeleteResults
+    ) {
         return logDatabaseErrors(loggingLevel, logMessage.getMessage(), undeleteResults);
     }
 
@@ -2597,7 +2601,7 @@ global with sharing class Logger {
      * @param  undeleteResults The instance of `List<Database.UndeleteResult>` to log
      * @return                 The instance of `LogEntryBuilder` was generated to log any errors, or `null` if there are no errors
      */
-    global static LogEntryEventBuilder logDatabaseErrors(LoggingLevel loggingLevel, String message, List<Database.UndeleteResult> undeleteResults) {
+    global static LogEntryEventBuilder logDatabaseErrors(System.LoggingLevel loggingLevel, String message, List<Database.UndeleteResult> undeleteResults) {
         List<Database.UndeleteResult> resultsToLog = new List<Database.UndeleteResult>();
         for (Database.UndeleteResult undeleteResult : undeleteResults) {
             if (undeleteResult.isSuccess() == false) {
@@ -2616,7 +2620,7 @@ global with sharing class Logger {
      * @param  shouldSave   Controls if the new entry will be saved. This can be used to save entries, even if the entry's logging level does not meet the user's logging level
      * @return              The new entry's instance of LogEntryEventBuilder
      */
-    global static LogEntryEventBuilder newEntry(LoggingLevel loggingLevel, LogMessage logMessage, Boolean shouldSave) {
+    global static LogEntryEventBuilder newEntry(System.LoggingLevel loggingLevel, LogMessage logMessage, Boolean shouldSave) {
         return newEntry(loggingLevel, shouldSave).setMessage(logMessage);
     }
 
@@ -2626,7 +2630,7 @@ global with sharing class Logger {
      * @param  logMessage   The instance of LogMessage to use as the entry's message
      * @return              The new entry's instance of LogEntryEventBuilder
      */
-    global static LogEntryEventBuilder newEntry(LoggingLevel loggingLevel, LogMessage logMessage) {
+    global static LogEntryEventBuilder newEntry(System.LoggingLevel loggingLevel, LogMessage logMessage) {
         return newEntry(loggingLevel).setMessage(logMessage);
     }
 
@@ -2637,7 +2641,7 @@ global with sharing class Logger {
      * @param  shouldSave   Controls if the new entry will be saved. This can be used to save entries, even if the entry's logging level does not meet the user's logging level
      * @return              The new entry's instance of LogEntryEventBuilder
      */
-    global static LogEntryEventBuilder newEntry(LoggingLevel loggingLevel, String message, Boolean shouldSave) {
+    global static LogEntryEventBuilder newEntry(System.LoggingLevel loggingLevel, String message, Boolean shouldSave) {
         return newEntry(loggingLevel, shouldSave).setMessage(message);
     }
 
@@ -2647,7 +2651,7 @@ global with sharing class Logger {
      * @param  message      The string to use as the entry's message
      * @return              The new entry's instance of LogEntryEventBuilder
      */
-    global static LogEntryEventBuilder newEntry(LoggingLevel loggingLevel, String message) {
+    global static LogEntryEventBuilder newEntry(System.LoggingLevel loggingLevel, String message) {
         return newEntry(loggingLevel).setMessage(message);
     }
 
@@ -2866,9 +2870,9 @@ global with sharing class Logger {
     /**
      * @description Converts a String to an instance of LoggingLevel
      * @param  loggingLevelName The string name of an Apex logging level
-     * @return                  The matching instance of LoggingLevel (or a default value if a match is not found)
+     * @return                  The matching instance of System.LoggingLevel (or a default value if a match is not found)
      */
-    global static LoggingLevel getLoggingLevel(String loggingLevelName) {
+    global static System.LoggingLevel getLoggingLevel(String loggingLevelName) {
         try {
             return System.LoggingLevel.valueOf(loggingLevelName?.trim().toUpperCase());
         } catch (NoSuchElementException ex) {
@@ -2886,38 +2890,38 @@ global with sharing class Logger {
 
     // Private logging level methods to keep global methods simpler/cleaner
     private static LogEntryEventBuilder error() {
-        return newEntry(LoggingLevel.ERROR);
+        return newEntry(System.LoggingLevel.ERROR);
     }
 
     private static LogEntryEventBuilder warn() {
-        return newEntry(LoggingLevel.WARN);
+        return newEntry(System.LoggingLevel.WARN);
     }
 
     private static LogEntryEventBuilder info() {
-        return newEntry(LoggingLevel.INFO);
+        return newEntry(System.LoggingLevel.INFO);
     }
 
     private static LogEntryEventBuilder debug() {
-        return newEntry(LoggingLevel.DEBUG);
+        return newEntry(System.LoggingLevel.DEBUG);
     }
 
     private static LogEntryEventBuilder fine() {
-        return newEntry(LoggingLevel.FINE);
+        return newEntry(System.LoggingLevel.FINE);
     }
 
     private static LogEntryEventBuilder finer() {
-        return newEntry(LoggingLevel.FINER);
+        return newEntry(System.LoggingLevel.FINER);
     }
 
     private static LogEntryEventBuilder finest() {
-        return newEntry(LoggingLevel.FINEST);
+        return newEntry(System.LoggingLevel.FINEST);
     }
 
-    private static LogEntryEventBuilder newEntry(LoggingLevel loggingLevel) {
+    private static LogEntryEventBuilder newEntry(System.LoggingLevel loggingLevel) {
         return newEntry(loggingLevel, isEnabled(loggingLevel));
     }
 
-    private static LogEntryEventBuilder newEntry(LoggingLevel loggingLevel, Boolean shouldSave) {
+    private static LogEntryEventBuilder newEntry(System.LoggingLevel loggingLevel, Boolean shouldSave) {
         LogEntryEventBuilder logEntryEventBuilder = new LogEntryEventBuilder(getUserSettings(), loggingLevel, shouldSave, IGNORED_APEX_CLASSES);
         if (logEntryEventBuilder.shouldSave() == true) {
             LogEntryEvent__e logEntryEvent = logEntryEventBuilder.getLogEntryEvent();

--- a/nebula-logger/core/main/logger-engine/classes/LoggerEngineDataSelector.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerEngineDataSelector.cls
@@ -73,7 +73,7 @@ public without sharing virtual class LoggerEngineDataSelector {
             return null;
         }
 
-        Id userId = UserInfo.getUserId();
+        Id userId = System.UserInfo.getUserId();
         String cacheKey = 'AuthSession' + userId;
         if (LoggerCache.getSessionCache().contains(cacheKey) == true) {
             return (LoggerSObjectProxy.AuthSession) LoggerCache.getSessionCache().get(cacheKey);
@@ -183,7 +183,7 @@ public without sharing virtual class LoggerEngineDataSelector {
             return null;
         }
 
-        Id userId = UserInfo.getUserId();
+        Id userId = System.UserInfo.getUserId();
         String cacheKey = 'User' + userId;
         if (LoggerCache.getSessionCache().contains(cacheKey) == true) {
             return (User) LoggerCache.getSessionCache().get(cacheKey);

--- a/nebula-logger/core/tests/configuration/classes/LoggerCache_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerCache_Tests.cls
@@ -19,24 +19,24 @@ private class LoggerCache_Tests {
     static void it_adds_new_key_to_transaction_cache() {
         String mockKey = 'SomeKey';
         User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
 
         LoggerCache.getTransactionCache().put(mockKey, mockValue);
 
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
     static void it_adds_new_key_with_null_value_to_transaction_cache() {
         String mockKey = 'SomeKey';
         User mockValue = null;
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
 
         LoggerCache.getTransactionCache().put(mockKey, mockValue);
 
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
@@ -44,28 +44,28 @@ private class LoggerCache_Tests {
         String mockKey = 'SomeKey';
         User oldMockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
         LoggerCache.getTransactionCache().put(mockKey, oldMockValue);
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(oldMockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(oldMockValue, LoggerCache.getTransactionCache().get(mockKey));
         Account newMockValue = new Account(Name = 'Some fake account');
 
         LoggerCache.getTransactionCache().put(mockKey, newMockValue);
 
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(newMockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(newMockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
     static void it_removes_value_for_existing_key_in_transaction_cache() {
         String mockKey = 'SomeKey';
         User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
         LoggerCache.getTransactionCache().put(mockKey, mockValue);
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
 
         LoggerCache.getTransactionCache().remove(mockKey);
 
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
     }
 
     @IsTest
@@ -73,23 +73,23 @@ private class LoggerCache_Tests {
         String mockKey = 'SomeKey';
         User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockOrganizationPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
-        System.assertEquals(true, mockOrganizationPartitionDelegate.isAvailable());
+        System.Assert.isTrue(mockOrganizationPartitionDelegate.isAvailable());
         LoggerCache.setMockOrganizationPartitionDelegate(mockOrganizationPartitionDelegate);
-        System.assertEquals(0, mockOrganizationPartitionDelegate.containsMethodCallCount);
-        System.assertEquals(false, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(1, mockOrganizationPartitionDelegate.containsMethodCallCount);
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(0, mockOrganizationPartitionDelegate.putMethodCallCount);
+        System.Assert.areEqual(0, mockOrganizationPartitionDelegate.containsMethodCallCount);
+        System.Assert.isFalse(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(1, mockOrganizationPartitionDelegate.containsMethodCallCount);
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(0, mockOrganizationPartitionDelegate.putMethodCallCount);
 
         LoggerCache.getOrganizationCache().put(mockKey, mockValue);
 
-        System.assertEquals(1, mockOrganizationPartitionDelegate.putMethodCallCount);
-        System.assertEquals(true, mockOrganizationPartitionDelegate.contains(mockKey));
-        System.assertEquals(mockValue, mockOrganizationPartitionDelegate.get(mockKey));
-        System.assertEquals(true, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.areEqual(1, mockOrganizationPartitionDelegate.putMethodCallCount);
+        System.Assert.isTrue(mockOrganizationPartitionDelegate.contains(mockKey));
+        System.Assert.areEqual(mockValue, mockOrganizationPartitionDelegate.get(mockKey));
+        System.Assert.isTrue(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
@@ -97,23 +97,23 @@ private class LoggerCache_Tests {
         String mockKey = 'SomeKey';
         User mockValue = null;
         MockPlatformCachePartitionDelegate mockOrganizationPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
-        System.assertEquals(true, mockOrganizationPartitionDelegate.isAvailable());
+        System.Assert.isTrue(mockOrganizationPartitionDelegate.isAvailable());
         LoggerCache.setMockOrganizationPartitionDelegate(mockOrganizationPartitionDelegate);
-        System.assertEquals(0, mockOrganizationPartitionDelegate.containsMethodCallCount);
-        System.assertEquals(false, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(1, mockOrganizationPartitionDelegate.containsMethodCallCount);
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(0, mockOrganizationPartitionDelegate.putMethodCallCount);
+        System.Assert.areEqual(0, mockOrganizationPartitionDelegate.containsMethodCallCount);
+        System.Assert.isFalse(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(1, mockOrganizationPartitionDelegate.containsMethodCallCount);
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(0, mockOrganizationPartitionDelegate.putMethodCallCount);
 
         LoggerCache.getOrganizationCache().put(mockKey, mockValue);
 
-        System.assertEquals(1, mockOrganizationPartitionDelegate.putMethodCallCount);
-        System.assertEquals(true, mockOrganizationPartitionDelegate.contains(mockKey));
-        System.assertEquals(LoggerCache.PLATFORM_CACHE_NULL_VALUE, mockOrganizationPartitionDelegate.get(mockKey));
-        System.assertEquals(true, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.areEqual(1, mockOrganizationPartitionDelegate.putMethodCallCount);
+        System.Assert.isTrue(mockOrganizationPartitionDelegate.contains(mockKey));
+        System.Assert.areEqual(LoggerCache.PLATFORM_CACHE_NULL_VALUE, mockOrganizationPartitionDelegate.get(mockKey));
+        System.Assert.isTrue(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
@@ -121,23 +121,23 @@ private class LoggerCache_Tests {
         String mockKey = 'SomeKey';
         User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockOrganizationPartitionDelegate = new MockPlatformCachePartitionDelegate(false);
-        System.assertEquals(false, mockOrganizationPartitionDelegate.isAvailable());
+        System.Assert.isFalse(mockOrganizationPartitionDelegate.isAvailable());
         LoggerCache.setMockOrganizationPartitionDelegate(mockOrganizationPartitionDelegate);
-        System.assertEquals(0, mockOrganizationPartitionDelegate.containsMethodCallCount);
-        System.assertEquals(false, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(0, mockOrganizationPartitionDelegate.containsMethodCallCount);
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(0, mockOrganizationPartitionDelegate.putMethodCallCount);
+        System.Assert.areEqual(0, mockOrganizationPartitionDelegate.containsMethodCallCount);
+        System.Assert.isFalse(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(0, mockOrganizationPartitionDelegate.containsMethodCallCount);
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(0, mockOrganizationPartitionDelegate.putMethodCallCount);
 
         LoggerCache.getOrganizationCache().put(mockKey, mockValue);
 
-        System.assertEquals(0, mockOrganizationPartitionDelegate.putMethodCallCount);
-        System.assertEquals(false, mockOrganizationPartitionDelegate.contains(mockKey));
-        System.assertEquals(null, mockOrganizationPartitionDelegate.get(mockKey));
-        System.assertEquals(true, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.areEqual(0, mockOrganizationPartitionDelegate.putMethodCallCount);
+        System.Assert.isFalse(mockOrganizationPartitionDelegate.contains(mockKey));
+        System.Assert.isNull(mockOrganizationPartitionDelegate.get(mockKey));
+        System.Assert.isTrue(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
@@ -145,26 +145,26 @@ private class LoggerCache_Tests {
         String mockKey = 'SomeKey';
         User oldMockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockOrganizationPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
-        System.assertEquals(true, mockOrganizationPartitionDelegate.isAvailable());
+        System.Assert.isTrue(mockOrganizationPartitionDelegate.isAvailable());
         LoggerCache.setMockOrganizationPartitionDelegate(mockOrganizationPartitionDelegate);
-        System.assertEquals(0, mockOrganizationPartitionDelegate.putMethodCallCount);
+        System.Assert.areEqual(0, mockOrganizationPartitionDelegate.putMethodCallCount);
         LoggerCache.getOrganizationCache().put(mockKey, oldMockValue);
-        System.assertEquals(true, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(oldMockValue, LoggerCache.getOrganizationCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(oldMockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(oldMockValue, LoggerCache.getOrganizationCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(oldMockValue, LoggerCache.getTransactionCache().get(mockKey));
         Account newMockValue = new Account(Name = 'Some fake account');
-        System.assertEquals(1, mockOrganizationPartitionDelegate.putMethodCallCount);
+        System.Assert.areEqual(1, mockOrganizationPartitionDelegate.putMethodCallCount);
 
         LoggerCache.getOrganizationCache().put(mockKey, newMockValue);
 
-        System.assertEquals(2, mockOrganizationPartitionDelegate.putMethodCallCount);
-        System.assertEquals(true, mockOrganizationPartitionDelegate.contains(mockKey));
-        System.assertEquals(newMockValue, mockOrganizationPartitionDelegate.get(mockKey));
-        System.assertEquals(true, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(newMockValue, LoggerCache.getOrganizationCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(newMockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.areEqual(2, mockOrganizationPartitionDelegate.putMethodCallCount);
+        System.Assert.isTrue(mockOrganizationPartitionDelegate.contains(mockKey));
+        System.Assert.areEqual(newMockValue, mockOrganizationPartitionDelegate.get(mockKey));
+        System.Assert.isTrue(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(newMockValue, LoggerCache.getOrganizationCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(newMockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
@@ -173,16 +173,16 @@ private class LoggerCache_Tests {
         User transactionCacheValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
         Account organizationCacheValue = new Account(Name = 'Some fake account');
         MockPlatformCachePartitionDelegate mockOrganizationPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
-        System.assertEquals(true, mockOrganizationPartitionDelegate.isAvailable());
+        System.Assert.isTrue(mockOrganizationPartitionDelegate.isAvailable());
         LoggerCache.setMockOrganizationPartitionDelegate(mockOrganizationPartitionDelegate);
         mockOrganizationPartitionDelegate.put(mockKey, organizationCacheValue, 5, Cache.Visibility.NAMESPACE, false);
-        System.assertEquals(true, mockOrganizationPartitionDelegate.contains(mockKey));
+        System.Assert.isTrue(mockOrganizationPartitionDelegate.contains(mockKey));
         LoggerCache.getTransactionCache().put(mockKey, transactionCacheValue);
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
 
         Object returnedValue = LoggerCache.getOrganizationCache().get(mockKey);
 
-        System.assertEquals(transactionCacheValue, returnedValue);
+        System.Assert.areEqual(transactionCacheValue, returnedValue);
     }
 
     @IsTest
@@ -190,25 +190,25 @@ private class LoggerCache_Tests {
         String mockKey = 'SomeKey';
         User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockOrganizationPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
-        System.assertEquals(true, mockOrganizationPartitionDelegate.isAvailable());
+        System.Assert.isTrue(mockOrganizationPartitionDelegate.isAvailable());
         LoggerCache.setMockOrganizationPartitionDelegate(mockOrganizationPartitionDelegate);
-        System.assertEquals(false, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
         LoggerCache.getOrganizationCache().put(mockKey, mockValue);
-        System.assertEquals(true, mockOrganizationPartitionDelegate.contains(mockKey));
-        System.assertEquals(mockValue, mockOrganizationPartitionDelegate.get(mockKey));
-        System.assertEquals(true, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
-        System.assertEquals(0, mockOrganizationPartitionDelegate.removeMethodCallCount);
+        System.Assert.isTrue(mockOrganizationPartitionDelegate.contains(mockKey));
+        System.Assert.areEqual(mockValue, mockOrganizationPartitionDelegate.get(mockKey));
+        System.Assert.isTrue(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.areEqual(0, mockOrganizationPartitionDelegate.removeMethodCallCount);
 
         LoggerCache.getOrganizationCache().remove(mockKey);
 
-        System.assertEquals(1, mockOrganizationPartitionDelegate.removeMethodCallCount);
-        System.assertEquals(false, mockOrganizationPartitionDelegate.contains(mockKey));
-        System.assertEquals(false, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(1, mockOrganizationPartitionDelegate.removeMethodCallCount);
+        System.Assert.isFalse(mockOrganizationPartitionDelegate.contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
     }
 
     @IsTest
@@ -216,23 +216,23 @@ private class LoggerCache_Tests {
         String mockKey = 'SomeKey';
         User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockSessionPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
-        System.assertEquals(true, mockSessionPartitionDelegate.isAvailable());
+        System.Assert.isTrue(mockSessionPartitionDelegate.isAvailable());
         LoggerCache.setMockSessionPartitionDelegate(mockSessionPartitionDelegate);
-        System.assertEquals(0, mockSessionPartitionDelegate.containsMethodCallCount);
-        System.assertEquals(false, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(1, mockSessionPartitionDelegate.containsMethodCallCount);
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(0, mockSessionPartitionDelegate.putMethodCallCount);
+        System.Assert.areEqual(0, mockSessionPartitionDelegate.containsMethodCallCount);
+        System.Assert.isFalse(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(1, mockSessionPartitionDelegate.containsMethodCallCount);
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(0, mockSessionPartitionDelegate.putMethodCallCount);
 
         LoggerCache.getSessionCache().put(mockKey, mockValue);
 
-        System.assertEquals(1, mockSessionPartitionDelegate.putMethodCallCount);
-        System.assertEquals(true, mockSessionPartitionDelegate.contains(mockKey));
-        System.assertEquals(mockValue, mockSessionPartitionDelegate.get(mockKey));
-        System.assertEquals(true, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getSessionCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.areEqual(1, mockSessionPartitionDelegate.putMethodCallCount);
+        System.Assert.isTrue(mockSessionPartitionDelegate.contains(mockKey));
+        System.Assert.areEqual(mockValue, mockSessionPartitionDelegate.get(mockKey));
+        System.Assert.isTrue(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getSessionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
@@ -240,23 +240,23 @@ private class LoggerCache_Tests {
         String mockKey = 'SomeKey';
         User mockValue = null;
         MockPlatformCachePartitionDelegate mockSessionPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
-        System.assertEquals(true, mockSessionPartitionDelegate.isAvailable());
+        System.Assert.isTrue(mockSessionPartitionDelegate.isAvailable());
         LoggerCache.setMockSessionPartitionDelegate(mockSessionPartitionDelegate);
-        System.assertEquals(0, mockSessionPartitionDelegate.containsMethodCallCount);
-        System.assertEquals(false, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(1, mockSessionPartitionDelegate.containsMethodCallCount);
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(0, mockSessionPartitionDelegate.putMethodCallCount);
+        System.Assert.areEqual(0, mockSessionPartitionDelegate.containsMethodCallCount);
+        System.Assert.isFalse(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(1, mockSessionPartitionDelegate.containsMethodCallCount);
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(0, mockSessionPartitionDelegate.putMethodCallCount);
 
         LoggerCache.getSessionCache().put(mockKey, mockValue);
 
-        System.assertEquals(1, mockSessionPartitionDelegate.putMethodCallCount);
-        System.assertEquals(true, mockSessionPartitionDelegate.contains(mockKey));
-        System.assertEquals(LoggerCache.PLATFORM_CACHE_NULL_VALUE, mockSessionPartitionDelegate.get(mockKey));
-        System.assertEquals(true, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getSessionCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.areEqual(1, mockSessionPartitionDelegate.putMethodCallCount);
+        System.Assert.isTrue(mockSessionPartitionDelegate.contains(mockKey));
+        System.Assert.areEqual(LoggerCache.PLATFORM_CACHE_NULL_VALUE, mockSessionPartitionDelegate.get(mockKey));
+        System.Assert.isTrue(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getSessionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
@@ -264,23 +264,23 @@ private class LoggerCache_Tests {
         String mockKey = 'SomeKey';
         User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockSessionPartitionDelegate = new MockPlatformCachePartitionDelegate(false);
-        System.assertEquals(false, mockSessionPartitionDelegate.isAvailable());
+        System.Assert.isFalse(mockSessionPartitionDelegate.isAvailable());
         LoggerCache.setMockSessionPartitionDelegate(mockSessionPartitionDelegate);
-        System.assertEquals(0, mockSessionPartitionDelegate.containsMethodCallCount);
-        System.assertEquals(false, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(0, mockSessionPartitionDelegate.containsMethodCallCount);
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(0, mockSessionPartitionDelegate.putMethodCallCount);
+        System.Assert.areEqual(0, mockSessionPartitionDelegate.containsMethodCallCount);
+        System.Assert.isFalse(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(0, mockSessionPartitionDelegate.containsMethodCallCount);
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(0, mockSessionPartitionDelegate.putMethodCallCount);
 
         LoggerCache.getSessionCache().put(mockKey, mockValue);
 
-        System.assertEquals(0, mockSessionPartitionDelegate.putMethodCallCount);
-        System.assertEquals(false, mockSessionPartitionDelegate.contains(mockKey));
-        System.assertEquals(null, mockSessionPartitionDelegate.get(mockKey));
-        System.assertEquals(true, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getSessionCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.areEqual(0, mockSessionPartitionDelegate.putMethodCallCount);
+        System.Assert.isFalse(mockSessionPartitionDelegate.contains(mockKey));
+        System.Assert.isNull(mockSessionPartitionDelegate.get(mockKey));
+        System.Assert.isTrue(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getSessionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
@@ -288,26 +288,26 @@ private class LoggerCache_Tests {
         String mockKey = 'SomeKey';
         User oldMockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockSessionPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
-        System.assertEquals(true, mockSessionPartitionDelegate.isAvailable());
+        System.Assert.isTrue(mockSessionPartitionDelegate.isAvailable());
         LoggerCache.setMockSessionPartitionDelegate(mockSessionPartitionDelegate);
-        System.assertEquals(0, mockSessionPartitionDelegate.putMethodCallCount);
+        System.Assert.areEqual(0, mockSessionPartitionDelegate.putMethodCallCount);
         LoggerCache.getSessionCache().put(mockKey, oldMockValue);
-        System.assertEquals(true, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(oldMockValue, LoggerCache.getSessionCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(oldMockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(oldMockValue, LoggerCache.getSessionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(oldMockValue, LoggerCache.getTransactionCache().get(mockKey));
         Account newMockValue = new Account(Name = 'Some fake account');
-        System.assertEquals(1, mockSessionPartitionDelegate.putMethodCallCount);
+        System.Assert.areEqual(1, mockSessionPartitionDelegate.putMethodCallCount);
 
         LoggerCache.getSessionCache().put(mockKey, newMockValue);
 
-        System.assertEquals(2, mockSessionPartitionDelegate.putMethodCallCount);
-        System.assertEquals(true, mockSessionPartitionDelegate.contains(mockKey));
-        System.assertEquals(newMockValue, mockSessionPartitionDelegate.get(mockKey));
-        System.assertEquals(true, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(newMockValue, LoggerCache.getSessionCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(newMockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.areEqual(2, mockSessionPartitionDelegate.putMethodCallCount);
+        System.Assert.isTrue(mockSessionPartitionDelegate.contains(mockKey));
+        System.Assert.areEqual(newMockValue, mockSessionPartitionDelegate.get(mockKey));
+        System.Assert.isTrue(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(newMockValue, LoggerCache.getSessionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(newMockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
@@ -316,16 +316,16 @@ private class LoggerCache_Tests {
         User transactionCacheValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
         Account sessionCacheValue = new Account(Name = 'Some fake account');
         MockPlatformCachePartitionDelegate mockSessionPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
-        System.assertEquals(true, mockSessionPartitionDelegate.isAvailable());
+        System.Assert.isTrue(mockSessionPartitionDelegate.isAvailable());
         LoggerCache.setMockSessionPartitionDelegate(mockSessionPartitionDelegate);
         mockSessionPartitionDelegate.put(mockKey, sessionCacheValue, 5, Cache.Visibility.NAMESPACE, false);
-        System.assertEquals(true, mockSessionPartitionDelegate.contains(mockKey));
+        System.Assert.isTrue(mockSessionPartitionDelegate.contains(mockKey));
         LoggerCache.getTransactionCache().put(mockKey, transactionCacheValue);
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
 
         Object returnedValue = LoggerCache.getSessionCache().get(mockKey);
 
-        System.assertEquals(transactionCacheValue, returnedValue);
+        System.Assert.areEqual(transactionCacheValue, returnedValue);
     }
 
     @IsTest
@@ -333,25 +333,25 @@ private class LoggerCache_Tests {
         String mockKey = 'SomeKey';
         User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockSessionPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
-        System.assertEquals(true, mockSessionPartitionDelegate.isAvailable());
+        System.Assert.isTrue(mockSessionPartitionDelegate.isAvailable());
         LoggerCache.setMockSessionPartitionDelegate(mockSessionPartitionDelegate);
-        System.assertEquals(false, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
         LoggerCache.getSessionCache().put(mockKey, mockValue);
-        System.assertEquals(true, mockSessionPartitionDelegate.contains(mockKey));
-        System.assertEquals(mockValue, mockSessionPartitionDelegate.get(mockKey));
-        System.assertEquals(true, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getSessionCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
-        System.assertEquals(0, mockSessionPartitionDelegate.removeMethodCallCount);
+        System.Assert.isTrue(mockSessionPartitionDelegate.contains(mockKey));
+        System.Assert.areEqual(mockValue, mockSessionPartitionDelegate.get(mockKey));
+        System.Assert.isTrue(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getSessionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.areEqual(0, mockSessionPartitionDelegate.removeMethodCallCount);
 
         LoggerCache.getSessionCache().remove(mockKey);
 
-        System.assertEquals(1, mockSessionPartitionDelegate.removeMethodCallCount);
-        System.assertEquals(false, mockSessionPartitionDelegate.contains(mockKey));
-        System.assertEquals(false, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(1, mockSessionPartitionDelegate.removeMethodCallCount);
+        System.Assert.isFalse(mockSessionPartitionDelegate.contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
     }
 
     // Since the class `Cache.Partition` can't have be mocked & can't have its methods overridden,

--- a/nebula-logger/core/tests/configuration/classes/LoggerCache_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerCache_Tests.cls
@@ -18,7 +18,7 @@ private class LoggerCache_Tests {
     @IsTest
     static void it_adds_new_key_to_transaction_cache() {
         String mockKey = 'SomeKey';
-        User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User mockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
 
         LoggerCache.getTransactionCache().put(mockKey, mockValue);
@@ -42,7 +42,7 @@ private class LoggerCache_Tests {
     @IsTest
     static void it_updates_value_for_existing_key_in_transaction_cache() {
         String mockKey = 'SomeKey';
-        User oldMockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User oldMockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         LoggerCache.getTransactionCache().put(mockKey, oldMockValue);
         System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
         System.Assert.areEqual(oldMockValue, LoggerCache.getTransactionCache().get(mockKey));
@@ -57,7 +57,7 @@ private class LoggerCache_Tests {
     @IsTest
     static void it_removes_value_for_existing_key_in_transaction_cache() {
         String mockKey = 'SomeKey';
-        User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User mockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
         LoggerCache.getTransactionCache().put(mockKey, mockValue);
         System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
@@ -71,7 +71,7 @@ private class LoggerCache_Tests {
     @IsTest
     static void it_adds_new_key_to_organization_and_transaction_cache_when_platform_cache_is_available() {
         String mockKey = 'SomeKey';
-        User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User mockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockOrganizationPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
         System.Assert.isTrue(mockOrganizationPartitionDelegate.isAvailable());
         LoggerCache.setMockOrganizationPartitionDelegate(mockOrganizationPartitionDelegate);
@@ -119,7 +119,7 @@ private class LoggerCache_Tests {
     @IsTest
     static void it_adds_new_key_to_only_transaction_cache_when_organization_platform_cache_is_not_available() {
         String mockKey = 'SomeKey';
-        User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User mockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockOrganizationPartitionDelegate = new MockPlatformCachePartitionDelegate(false);
         System.Assert.isFalse(mockOrganizationPartitionDelegate.isAvailable());
         LoggerCache.setMockOrganizationPartitionDelegate(mockOrganizationPartitionDelegate);
@@ -143,7 +143,7 @@ private class LoggerCache_Tests {
     @IsTest
     static void it_updates_value_for_existing_key_in_organization_and_transaction_cache_when_platform_cache_is_available() {
         String mockKey = 'SomeKey';
-        User oldMockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User oldMockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockOrganizationPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
         System.Assert.isTrue(mockOrganizationPartitionDelegate.isAvailable());
         LoggerCache.setMockOrganizationPartitionDelegate(mockOrganizationPartitionDelegate);
@@ -170,7 +170,7 @@ private class LoggerCache_Tests {
     @IsTest
     static void it_returns_value_in_transaction_cache_when_organization_and_transaction_cache_both_contain_key() {
         String mockKey = 'SomeKey';
-        User transactionCacheValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User transactionCacheValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         Account organizationCacheValue = new Account(Name = 'Some fake account');
         MockPlatformCachePartitionDelegate mockOrganizationPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
         System.Assert.isTrue(mockOrganizationPartitionDelegate.isAvailable());
@@ -188,7 +188,7 @@ private class LoggerCache_Tests {
     @IsTest
     static void it_removes_value_for_existing_key_in_organization_and_transaction_cache_when_platform_cache_is_available() {
         String mockKey = 'SomeKey';
-        User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User mockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockOrganizationPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
         System.Assert.isTrue(mockOrganizationPartitionDelegate.isAvailable());
         LoggerCache.setMockOrganizationPartitionDelegate(mockOrganizationPartitionDelegate);
@@ -214,7 +214,7 @@ private class LoggerCache_Tests {
     @IsTest
     static void it_adds_new_key_to_session_and_transaction_cache_when_platform_cache_is_available() {
         String mockKey = 'SomeKey';
-        User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User mockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockSessionPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
         System.Assert.isTrue(mockSessionPartitionDelegate.isAvailable());
         LoggerCache.setMockSessionPartitionDelegate(mockSessionPartitionDelegate);
@@ -262,7 +262,7 @@ private class LoggerCache_Tests {
     @IsTest
     static void it_adds_new_key_to_only_transaction_cache_when_session_platform_cache_is_not_available() {
         String mockKey = 'SomeKey';
-        User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User mockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockSessionPartitionDelegate = new MockPlatformCachePartitionDelegate(false);
         System.Assert.isFalse(mockSessionPartitionDelegate.isAvailable());
         LoggerCache.setMockSessionPartitionDelegate(mockSessionPartitionDelegate);
@@ -286,7 +286,7 @@ private class LoggerCache_Tests {
     @IsTest
     static void it_updates_value_for_existing_key_in_session_and_transaction_cache_when_platform_cache_is_available() {
         String mockKey = 'SomeKey';
-        User oldMockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User oldMockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockSessionPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
         System.Assert.isTrue(mockSessionPartitionDelegate.isAvailable());
         LoggerCache.setMockSessionPartitionDelegate(mockSessionPartitionDelegate);
@@ -313,7 +313,7 @@ private class LoggerCache_Tests {
     @IsTest
     static void it_returns_value_in_transaction_cache_when_session_and_transaction_cache_both_contain_key() {
         String mockKey = 'SomeKey';
-        User transactionCacheValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User transactionCacheValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         Account sessionCacheValue = new Account(Name = 'Some fake account');
         MockPlatformCachePartitionDelegate mockSessionPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
         System.Assert.isTrue(mockSessionPartitionDelegate.isAvailable());
@@ -331,7 +331,7 @@ private class LoggerCache_Tests {
     @IsTest
     static void it_removes_value_for_existing_key_in_session_and_transaction_cache_when_platform_cache_is_available() {
         String mockKey = 'SomeKey';
-        User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User mockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         MockPlatformCachePartitionDelegate mockSessionPartitionDelegate = new MockPlatformCachePartitionDelegate(true);
         System.Assert.isTrue(mockSessionPartitionDelegate.isAvailable());
         LoggerCache.setMockSessionPartitionDelegate(mockSessionPartitionDelegate);

--- a/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
@@ -7,7 +7,7 @@
 @IsTest(IsParallel=true)
 private class LoggerParameter_Tests {
     private static User getUserRecord() {
-        return new User(Id = UserInfo.getUserId(), Username = UserInfo.getUserName());
+        return new User(Id = System.UserInfo.getUserId(), Username = System.UserInfo.getUsername());
     }
 
     @IsTest
@@ -366,7 +366,7 @@ private class LoggerParameter_Tests {
 
     @IsTest
     static void it_should_return_id_parameter() {
-        Id parameterValue = UserInfo.getUserId();
+        Id parameterValue = System.UserInfo.getUserId();
         LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'MyId', Value__c = JSON.serialize(parameterValue));
         LoggerParameter.setMock(mockParameter);
 
@@ -377,7 +377,7 @@ private class LoggerParameter_Tests {
 
     @IsTest
     static void it_should_return_id_list_parameter() {
-        List<Id> parameterValue = new List<Id>{ UserInfo.getUserId() };
+        List<Id> parameterValue = new List<Id>{ System.UserInfo.getUserId() };
         LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'MyIdList', Value__c = JSON.serialize(parameterValue));
         LoggerParameter.setMock(mockParameter);
 

--- a/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
@@ -13,11 +13,11 @@ private class LoggerParameter_Tests {
     @IsTest
     static void it_should_throw_exception_when_mock_record_developer_name_is_null() {
         LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = null);
-        Exception thrownIllegalArgumentException;
+        System.Exception thrownIllegalArgumentException;
 
         try {
             LoggerParameter.setMock(mockParameter);
-        } catch (IllegalArgumentException ex) {
+        } catch (System.IllegalArgumentException ex) {
             thrownIllegalArgumentException = ex;
         }
 

--- a/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
@@ -21,7 +21,7 @@ private class LoggerParameter_Tests {
             thrownIllegalArgumentException = ex;
         }
 
-        System.assertNotEquals(null, thrownIllegalArgumentException);
+        System.Assert.isNotNull(thrownIllegalArgumentException);
     }
 
     @IsTest
@@ -31,8 +31,8 @@ private class LoggerParameter_Tests {
 
         String returnedValue = LoggerParameter.getString(mockParameter.DeveloperName, null);
 
-        System.assertNotEquals(null, returnedValue);
-        System.assertEquals(mockParameter.Value__c, returnedValue);
+        System.Assert.isNotNull(returnedValue);
+        System.Assert.areEqual(mockParameter.Value__c, returnedValue);
     }
 
     @IsTest
@@ -43,7 +43,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.CALL_STATUS_API;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -54,7 +54,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.ENABLE_SYSTEM_MESSAGES;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -65,7 +65,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.ENABLE_TAGGING;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -76,7 +76,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.QUERY_APEX_CLASS_DATA;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -87,7 +87,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.QUERY_AUTH_SESSION_DATA;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -101,7 +101,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.QUERY_AUTH_SESSION_DATA_SYNCHRONOUSLY;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -112,7 +112,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.QUERY_FLOW_DEFINITION_VIEW_DATA;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -123,7 +123,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.QUERY_NETWORK_DATA;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -134,7 +134,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.QUERY_NETWORK_DATA_SYNCHRONOUSLY;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -145,7 +145,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.QUERY_ORGANIZATION_DATA;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -159,7 +159,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -170,7 +170,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.QUERY_RELATED_RECORD_DATA;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -181,7 +181,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.QUERY_USER_DATA;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -192,7 +192,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.QUERY_USER_DATA_SYNCHRONOUSLY;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -203,7 +203,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -215,7 +215,7 @@ private class LoggerParameter_Tests {
 
         String returnedValue = LoggerParameter.SYSTEM_DEBUG_MESSAGE_FORMAT;
 
-        System.assertEquals(configuredValue, returnedValue);
+        System.Assert.areEqual(configuredValue, returnedValue);
     }
 
     @IsTest
@@ -226,7 +226,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.USE_PLATFORM_CACHE;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -237,7 +237,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.USE_TOPICS_FOR_TAGS;
 
-        System.assertEquals(mockValue, returnedValue);
+        System.Assert.areEqual(mockValue, returnedValue);
     }
 
     @IsTest
@@ -248,7 +248,7 @@ private class LoggerParameter_Tests {
 
         Boolean returnedValue = LoggerParameter.getBoolean(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -259,7 +259,7 @@ private class LoggerParameter_Tests {
 
         List<Boolean> returnedValue = LoggerParameter.getBooleanList(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -271,9 +271,9 @@ private class LoggerParameter_Tests {
 
         List<Boolean> returnedValue = LoggerParameter.getBooleanList(mockParameter.DeveloperName, defaultParameterValue);
 
-        System.assertEquals(null, parameterValue);
-        System.assertNotEquals(parameterValue, returnedValue, 'Returned value should not match configured null parameter value');
-        System.assertEquals(defaultParameterValue, returnedValue, 'Returned value does not match expected default parameter value');
+        System.Assert.isNull(parameterValue);
+        System.Assert.areNotEqual(parameterValue, returnedValue, 'Returned value should not match configured null parameter value');
+        System.Assert.areEqual(defaultParameterValue, returnedValue, 'Returned value does not match expected default parameter value');
     }
 
     @IsTest
@@ -284,7 +284,7 @@ private class LoggerParameter_Tests {
 
         Date returnedValue = LoggerParameter.getDate(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -295,7 +295,7 @@ private class LoggerParameter_Tests {
 
         List<Date> returnedValue = LoggerParameter.getDateList(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -306,7 +306,7 @@ private class LoggerParameter_Tests {
 
         Datetime returnedValue = LoggerParameter.getDatetime(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -317,7 +317,7 @@ private class LoggerParameter_Tests {
 
         List<Datetime> returnedValue = LoggerParameter.getDatetimeList(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -328,7 +328,7 @@ private class LoggerParameter_Tests {
 
         Decimal returnedValue = LoggerParameter.getDecimal(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -339,7 +339,7 @@ private class LoggerParameter_Tests {
 
         List<Decimal> returnedValue = LoggerParameter.getDecimalList(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -350,7 +350,7 @@ private class LoggerParameter_Tests {
 
         Double returnedValue = LoggerParameter.getDouble(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -361,7 +361,7 @@ private class LoggerParameter_Tests {
 
         List<Double> returnedValue = LoggerParameter.getDoubleList(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -372,7 +372,7 @@ private class LoggerParameter_Tests {
 
         Id returnedValue = LoggerParameter.getId(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -383,7 +383,7 @@ private class LoggerParameter_Tests {
 
         List<Id> returnedValue = LoggerParameter.getIdList(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -394,7 +394,7 @@ private class LoggerParameter_Tests {
 
         Integer returnedValue = LoggerParameter.getInteger(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -405,7 +405,7 @@ private class LoggerParameter_Tests {
 
         List<Integer> returnedValue = LoggerParameter.getIntegerList(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -416,7 +416,7 @@ private class LoggerParameter_Tests {
 
         Long returnedValue = LoggerParameter.getLong(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -427,7 +427,7 @@ private class LoggerParameter_Tests {
 
         List<Long> returnedValue = LoggerParameter.getLongList(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -438,7 +438,7 @@ private class LoggerParameter_Tests {
 
         SObject returnedValue = LoggerParameter.getSObject(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -449,7 +449,7 @@ private class LoggerParameter_Tests {
 
         List<SObject> returnedValue = LoggerParameter.getSObjectList(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -460,7 +460,7 @@ private class LoggerParameter_Tests {
 
         String returnedValue = LoggerParameter.getString(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -471,7 +471,7 @@ private class LoggerParameter_Tests {
 
         List<String> returnedValue = LoggerParameter.getStringList(mockParameter.DeveloperName, null);
 
-        System.assertEquals(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
+        System.Assert.areEqual(parameterValue, returnedValue, 'Returned value does not match expected parameter value');
     }
 
     @IsTest
@@ -486,9 +486,9 @@ private class LoggerParameter_Tests {
 
         List<LoggerParameter__mdt> matchingParameters = LoggerParameter.matchOnPrefix(developerNamePrefix);
 
-        System.assertEquals(2, matchingParameters.size());
+        System.Assert.areEqual(2, matchingParameters.size());
         for (LoggerParameter__mdt matchingParameter : matchingParameters) {
-            System.assertEquals(
+            System.Assert.areEqual(
                 true,
                 matchingParameter.DeveloperName == firstMatchingMockParameter.DeveloperName ||
                 matchingParameter.DeveloperName == secondMatchingMockParameter.DeveloperName,

--- a/nebula-logger/core/tests/configuration/classes/LoggerPlugin_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerPlugin_Tests.cls
@@ -56,11 +56,11 @@ private class LoggerPlugin_Tests {
             Schema.LoggerPlugin__mdt.SObjectHandlerExecutionOrder__c
         );
 
-        System.assertEquals(expectedSortedPluginConfigurations.size(), returnedPluginConfigurations.size());
+        System.Assert.areEqual(expectedSortedPluginConfigurations.size(), returnedPluginConfigurations.size());
         for (Integer i = 0; i < returnedPluginConfigurations.size(); i++) {
             LoggerPlugin__mdt expectedSortedPluginConfiguration = expectedSortedPluginConfigurations.get(i);
             LoggerPlugin__mdt returnedPluginConfiguration = returnedPluginConfigurations.get(i);
-            System.assertEquals(expectedSortedPluginConfiguration, returnedPluginConfiguration, 'Records at index ' + i + ' don\'t match');
+            System.Assert.areEqual(expectedSortedPluginConfiguration, returnedPluginConfiguration, 'Records at index ' + i + ' don\'t match');
         }
     }
 
@@ -68,30 +68,30 @@ private class LoggerPlugin_Tests {
     static void it_should_return_batchable_apex_plugin_instance_for_valid_class() {
         LoggerPlugin.Batchable batchableApexPlugin = LoggerPlugin.newBatchableInstance(ExampleBatchPurgerPlugin.class.getName());
 
-        System.assertNotEquals(null, batchableApexPlugin, ExampleBatchPurgerPlugin.class.getName());
-        System.assertEquals(true, batchableApexPlugin instanceof ExampleBatchPurgerPlugin);
+        System.Assert.isNotNull(batchableApexPlugin, ExampleBatchPurgerPlugin.class.getName());
+        System.Assert.isInstanceOfType(batchableApexPlugin, ExampleBatchPurgerPlugin.class);
     }
 
     @IsTest
     static void it_should_return_null_batchable_apex_plugin_instance_for_invalid_class() {
         LoggerPlugin.Batchable batchableApexPlugin = LoggerPlugin.newBatchableInstance('Some fake class, this definitely doesn\'t exist');
 
-        System.assertEquals(null, batchableApexPlugin);
+        System.Assert.isNull(batchableApexPlugin);
     }
 
     @IsTest
     static void it_should_return_triggerable_apex_plugin_instance_for_valid_class() {
         LoggerPlugin.Triggerable triggerableApexPlugin = LoggerPlugin.newTriggerableInstance(ExampleTriggerablePlugin.class.getName());
 
-        System.assertNotEquals(null, triggerableApexPlugin, ExampleTriggerablePlugin.class.getName());
-        System.assertEquals(true, triggerableApexPlugin instanceof ExampleTriggerablePlugin);
+        System.Assert.isNotNull(triggerableApexPlugin, ExampleTriggerablePlugin.class.getName());
+        System.Assert.isInstanceOfType(triggerableApexPlugin, ExampleTriggerablePlugin.class);
     }
 
     @IsTest
     static void it_should_return_null_triggerable_apex_plugin_instance_for_invalid_class() {
         LoggerPlugin.Triggerable triggerableApexPlugin = LoggerPlugin.newTriggerableInstance('Some fake class, this definitely doesn\'t exist');
 
-        System.assertEquals(null, triggerableApexPlugin);
+        System.Assert.isNull(triggerableApexPlugin);
     }
 
     private static LoggerPlugin__mdt createMockPluginConfiguration(String developerName) {

--- a/nebula-logger/core/tests/configuration/classes/LoggerScenarioRule_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerScenarioRule_Tests.cls
@@ -17,8 +17,8 @@ private class LoggerScenarioRule_Tests {
             thrownIllegalArgumentException = ex;
         }
 
-        System.assertNotEquals(null, thrownIllegalArgumentException);
-        System.assertEquals(true, thrownIllegalArgumentException.getMessage().startsWith('Scenario__c is required on `LoggerScenarioRule__mdt'));
+        System.Assert.isNotNull(thrownIllegalArgumentException);
+        System.Assert.isTrue(thrownIllegalArgumentException.getMessage().startsWith('Scenario__c is required on `LoggerScenarioRule__mdt'));
     }
 
     @IsTest
@@ -32,10 +32,10 @@ private class LoggerScenarioRule_Tests {
 
         Map<String, LoggerScenarioRule__mdt> returnedScenariosToRule = LoggerScenarioRule.getAll();
 
-        System.assertEquals(mockRules.size(), returnedScenariosToRule.size());
+        System.Assert.areEqual(mockRules.size(), returnedScenariosToRule.size());
         for (LoggerScenarioRule__mdt mockRule : mockRules) {
-            System.assertEquals(true, returnedScenariosToRule.containsKey(mockRule.Scenario__c));
-            System.assertEquals(mockRule, returnedScenariosToRule.get(mockRule.Scenario__c));
+            System.Assert.isTrue(returnedScenariosToRule.containsKey(mockRule.Scenario__c));
+            System.Assert.areEqual(mockRule, returnedScenariosToRule.get(mockRule.Scenario__c));
         }
     }
 
@@ -51,7 +51,7 @@ private class LoggerScenarioRule_Tests {
 
         LoggerScenarioRule__mdt returnedRule = LoggerScenarioRule.getInstance(mockRule.Scenario__c);
 
-        System.assertEquals(mockRule, returnedRule);
+        System.Assert.areEqual(mockRule, returnedRule);
     }
 
     @IsTest
@@ -66,7 +66,7 @@ private class LoggerScenarioRule_Tests {
 
         LoggerScenarioRule__mdt returnedRule = LoggerScenarioRule.getInstance(mockRule.Scenario__c);
 
-        System.assertEquals(mockRule, returnedRule);
+        System.Assert.areEqual(mockRule, returnedRule);
     }
 
     @IsTest
@@ -80,7 +80,7 @@ private class LoggerScenarioRule_Tests {
 
         LoggerScenarioRule__mdt returnedRule = LoggerScenarioRule.getInstance(mockRule.Scenario__c);
 
-        System.assertEquals(mockRule, returnedRule);
+        System.Assert.areEqual(mockRule, returnedRule);
     }
 
     @IsTest
@@ -95,7 +95,7 @@ private class LoggerScenarioRule_Tests {
 
         LoggerScenarioRule__mdt returnedRule = LoggerScenarioRule.getInstance(mockRule.Scenario__c);
 
-        System.assertEquals(mockRule, returnedRule);
+        System.Assert.areEqual(mockRule, returnedRule);
     }
 
     @IsTest
@@ -110,7 +110,7 @@ private class LoggerScenarioRule_Tests {
 
         LoggerScenarioRule__mdt returnedRule = LoggerScenarioRule.getInstance(mockRule.Scenario__c);
 
-        System.assertEquals(null, returnedRule);
+        System.Assert.isNull(returnedRule);
     }
 
     @IsTest
@@ -124,6 +124,6 @@ private class LoggerScenarioRule_Tests {
 
         LoggerScenarioRule__mdt returnedRule = LoggerScenarioRule.getInstance(mockRule.Scenario__c);
 
-        System.assertEquals(null, returnedRule);
+        System.Assert.isNull(returnedRule);
     }
 }

--- a/nebula-logger/core/tests/configuration/classes/LoggerScenarioRule_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerScenarioRule_Tests.cls
@@ -9,11 +9,11 @@ private class LoggerScenarioRule_Tests {
     @IsTest
     static void it_should_throw_exception_when_mock_record_scenario_is_null() {
         LoggerScenarioRule__mdt mockRule = new LoggerScenarioRule__mdt(Scenario__c = null);
-        Exception thrownIllegalArgumentException;
+        System.Exception thrownIllegalArgumentException;
 
         try {
             LoggerScenarioRule.setMock(mockRule);
-        } catch (IllegalArgumentException ex) {
+        } catch (System.IllegalArgumentException ex) {
             thrownIllegalArgumentException = ex;
         }
 

--- a/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
+++ b/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
@@ -281,7 +281,7 @@ public class LoggerMockDataCreator {
      * @return   The generated `User` record - it is not automatically inserted into the database.
      */
     public static User createUser() {
-        return createUser(UserInfo.getProfileId());
+        return createUser(System.UserInfo.getProfileId());
     }
 
     /**
@@ -338,7 +338,7 @@ public class LoggerMockDataCreator {
      * @return   The matching `User` record
      */
     public static User getUser() {
-        return getUser(UserInfo.getUserId());
+        return getUser(System.UserInfo.getUserId());
     }
 
     /**
@@ -365,7 +365,7 @@ public class LoggerMockDataCreator {
         insert queue;
 
         // To avoid a MIXED_DML_OPERATION exception, use System.runs() for inserting the QueueSObject record
-        System.runAs(new User(Id = UserInfo.getUserId())) {
+        System.runAs(new User(Id = System.UserInfo.getUserId())) {
             QueueSObject queueSObject = new QueueSObject(QueueId = queue.Id, SObjectType = sobjectType.getDescribe().getName());
             insert queueSObject;
         }

--- a/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
+++ b/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
@@ -202,7 +202,7 @@ public class LoggerMockDataCreator {
     }
 
     /**
-     * @description Generates an instance of the class `MockHttpCallout` that implements the interface `HttpCalloutMock`.
+     * @description Generates an instance of the class `MockHttpCallout` that implements the interface `System.HttpCalloutMock`.
      *              This can be used when testing batch jobs.
      * @return      The instance of `MockHttpCallout`
      */
@@ -214,8 +214,8 @@ public class LoggerMockDataCreator {
      * @description Generates an instance of `HttpRequest`. This can be used when testing logging capabilities for instances of `HttpRequest`.
      * @return      The instance of `HttpRequest`
      */
-    public static HttpRequest createHttpRequest() {
-        HttpRequest request = new HttpRequest();
+    public static System.HttpRequest createHttpRequest() {
+        System.HttpRequest request = new System.HttpRequest();
         request.setBody('Hello, world!');
         request.setCompressed(true);
         request.setEndpoint('https://fake.salesforce.com');
@@ -227,8 +227,8 @@ public class LoggerMockDataCreator {
      * @description Generates an instance of `HttpResponse`. This can be used when testing logging capabilities for instances of `HttpResponse`.
      * @return      The instance of `HttpResponse`
      */
-    public static HttpResponse createHttpResponse() {
-        HttpResponse response = new HttpResponse();
+    public static System.HttpResponse createHttpResponse() {
+        System.HttpResponse response = new System.HttpResponse();
         response.setBody('Hello, world!');
         response.setHeader('someKey', 'some string value');
         response.setHeader('anotherKey', 'an amazing example value, wow');
@@ -430,9 +430,9 @@ public class LoggerMockDataCreator {
     }
 
     @SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
-    public class MockHttpCallout implements HttpCalloutMock {
-        public HttpRequest request { get; private set; }
-        public HttpResponse response { get; private set; }
+    public class MockHttpCallout implements System.HttpCalloutMock {
+        public System.HttpRequest request { get; private set; }
+        public System.HttpResponse response { get; private set; }
         public String responseBody { get; private set; }
         public Integer statusCode { get; private set; }
 
@@ -449,10 +449,10 @@ public class LoggerMockDataCreator {
             return this;
         }
 
-        public HttpResponse respond(HttpRequest request) {
+        public System.HttpResponse respond(System.HttpRequest request) {
             this.request = request;
 
-            this.response = new HttpResponse();
+            this.response = new System.HttpResponse();
             if (String.isNotBlank(this.responseBody) == true) {
                 response.setBody(this.responseBody);
             }

--- a/nebula-logger/core/tests/log-management/classes/LogBatchPurgeController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogBatchPurgeController_Tests.cls
@@ -27,10 +27,10 @@ private class LogBatchPurgeController_Tests {
         Set<String> expectedLogPurgeActions = new Set<String>{ LogBatchPurgeController.DELETE_LOG_PURGE_ACTION };
         expectedLogPurgeActions.addAll(fakeLogPurgeActions);
         Integer expectedLogPurgeActionsSize = expectedLogPurgeActions.size();
-        System.assertEquals(expectedLogPurgeActionsSize, picklistOptions.size(), 'Purge Action size mismatch');
+        System.Assert.areEqual(expectedLogPurgeActionsSize, picklistOptions.size(), 'Purge Action size mismatch');
         for (LogBatchPurgeController.PicklistOption picklistOption : picklistOptions) {
-            System.assertEquals(picklistOption.value, picklistOption.label, 'Purge action label mismatch');
-            System.assertEquals(true, expectedLogPurgeActions.contains(picklistOption.value), 'Purge Action not found');
+            System.Assert.areEqual(picklistOption.value, picklistOption.label, 'Purge action label mismatch');
+            System.Assert.isTrue(expectedLogPurgeActions.contains(picklistOption.value), 'Purge Action not found');
         }
     }
 
@@ -44,18 +44,18 @@ private class LogBatchPurgeController_Tests {
 
         List<AggregateResult> logObjectResult = LogBatchPurgeController.getLogObjectSummary('TODAY');
         Integer expectedAggregateResultSize = 2;
-        System.assertEquals(expectedAggregateResultSize, logObjectResult.size(), 'Log object summary size should match');
+        System.Assert.areEqual(expectedAggregateResultSize, logObjectResult.size(), 'Log object summary size should match');
 
         for (AggregateResult summary : logObjectResult) {
             if (summary.get('LogPurgeAction__c') === DEFAULT_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionDelete,
                     summary.get('expr0'),
                     'Log object summary should match for purge action : delete'
                 );
             }
             if (summary.get('LogPurgeAction__c') === CUSTOM_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionCustom,
                     summary.get('expr0'),
                     'Log object summary should match for purge action : custom'
@@ -76,14 +76,14 @@ private class LogBatchPurgeController_Tests {
         List<AggregateResult> logObjectResult = LogBatchPurgeController.getLogObjectSummary('THIS_WEEK');
 
         Integer expectedAggregateResultSize = 2;
-        System.assertEquals(expectedAggregateResultSize, logObjectResult.size(), 'log summary size mismatch');
+        System.Assert.areEqual(expectedAggregateResultSize, logObjectResult.size(), 'log summary size mismatch');
 
         for (AggregateResult summary : logObjectResult) {
             if (summary.get('LogPurgeAction__c') === DEFAULT_PURGE_ACTION) {
-                System.assertEquals(expectedRecordCountWithPurgeActionDelete, summary.get('expr0'), 'log object summary mismatch for purge action : delete');
+                System.Assert.areEqual(expectedRecordCountWithPurgeActionDelete, summary.get('expr0'), 'log object summary mismatch for purge action : delete');
             }
             if (summary.get('LogPurgeAction__c') === CUSTOM_PURGE_ACTION) {
-                System.assertEquals(expectedRecordCountWithPurgeActionCustom, summary.get('expr0'), 'log object summary mismatch for purge action : custom');
+                System.Assert.areEqual(expectedRecordCountWithPurgeActionCustom, summary.get('expr0'), 'log object summary mismatch for purge action : custom');
             }
         }
     }
@@ -99,18 +99,18 @@ private class LogBatchPurgeController_Tests {
 
         List<AggregateResult> logObjectResult = LogBatchPurgeController.getLogObjectSummary('THIS_MONTH');
         Integer expectedAggregateResultSize = 2;
-        System.assertEquals(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
+        System.Assert.areEqual(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
 
         for (AggregateResult summary : logObjectResult) {
             if (summary.get('LogPurgeAction__c') === DEFAULT_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionDelete,
                     summary.get('expr0'),
                     'log object summary should match for purge action : delete'
                 );
             }
             if (summary.get('LogPurgeAction__c') === CUSTOM_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionCustom,
                     summary.get('expr0'),
                     'log object summary should match for purge action : custom'
@@ -129,18 +129,18 @@ private class LogBatchPurgeController_Tests {
 
         List<AggregateResult> logObjectResult = LogBatchPurgeController.getLogEntryObjectSummary('TODAY');
         Integer expectedAggregateResultSize = 2;
-        System.assertEquals(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
+        System.Assert.areEqual(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
 
         for (AggregateResult summary : logObjectResult) {
             if (summary.get('LogPurgeAction__c') === DEFAULT_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionDelete,
                     summary.get('expr0'),
                     'log object summary should match for purge action : delete'
                 );
             }
             if (summary.get('LogPurgeAction__c') === CUSTOM_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionCustom,
                     summary.get('expr0'),
                     'log object summary should match for purge action : custom'
@@ -160,18 +160,18 @@ private class LogBatchPurgeController_Tests {
 
         List<AggregateResult> logObjectResult = LogBatchPurgeController.getLogEntryObjectSummary('THIS_WEEK');
         Integer expectedAggregateResultSize = 2;
-        System.assertEquals(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
+        System.Assert.areEqual(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
 
         for (AggregateResult summary : logObjectResult) {
             if (summary.get('LogPurgeAction__c') === DEFAULT_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionDelete,
                     summary.get('expr0'),
                     'log object summary should match for purge action : delete'
                 );
             }
             if (summary.get('LogPurgeAction__c') === CUSTOM_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionCustom,
                     summary.get('expr0'),
                     'log object summary should match for purge action : custom'
@@ -191,18 +191,18 @@ private class LogBatchPurgeController_Tests {
 
         List<AggregateResult> logObjectResult = LogBatchPurgeController.getLogEntryObjectSummary('THIS_MONTH');
         Integer expectedAggregateResultSize = 2;
-        System.assertEquals(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
+        System.Assert.areEqual(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
 
         for (AggregateResult summary : logObjectResult) {
             if (summary.get('LogPurgeAction__c') === DEFAULT_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionDelete,
                     summary.get('expr0'),
                     'log object summary should match for purge action : delete'
                 );
             }
             if (summary.get('LogPurgeAction__c') === CUSTOM_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionCustom,
                     summary.get('expr0'),
                     'log object summary should match for purge action : custom'
@@ -221,18 +221,18 @@ private class LogBatchPurgeController_Tests {
 
         List<AggregateResult> logObjectResult = LogBatchPurgeController.getLogEntryTagObjectSummary('TODAY');
         Integer expectedAggregateResultSize = 2;
-        System.assertEquals(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
+        System.Assert.areEqual(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
 
         for (AggregateResult summary : logObjectResult) {
             if (summary.get('LogPurgeAction__c') === DEFAULT_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionDelete,
                     summary.get('expr0'),
                     'log object summary should match for purge action : delete'
                 );
             }
             if (summary.get('LogPurgeAction__c') === CUSTOM_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionCustom,
                     summary.get('expr0'),
                     'log object summary should match for purge action : custom'
@@ -251,18 +251,18 @@ private class LogBatchPurgeController_Tests {
 
         List<AggregateResult> logObjectResult = LogBatchPurgeController.getLogEntryTagObjectSummary('THIS_WEEK');
         Integer expectedAggregateResultSize = 2;
-        System.assertEquals(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
+        System.Assert.areEqual(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
 
         for (AggregateResult summary : logObjectResult) {
             if (summary.get('LogPurgeAction__c') === DEFAULT_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionDelete,
                     summary.get('expr0'),
                     'log object summary should match for purge action : delete'
                 );
             }
             if (summary.get('LogPurgeAction__c') === CUSTOM_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionCustom,
                     summary.get('expr0'),
                     'log object summary should match for purge action : custom'
@@ -281,18 +281,18 @@ private class LogBatchPurgeController_Tests {
 
         List<AggregateResult> logObjectResult = LogBatchPurgeController.getLogEntryTagObjectSummary('THIS_MONTH');
         Integer expectedAggregateResultSize = 2;
-        System.assertEquals(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
+        System.Assert.areEqual(expectedAggregateResultSize, logObjectResult.size(), 'log summary size should match');
 
         for (AggregateResult summary : logObjectResult) {
             if (summary.get('LogPurgeAction__c') === DEFAULT_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionDelete,
                     summary.get('expr0'),
                     'log object summary should match for purge action : delete'
                 );
             }
             if (summary.get('LogPurgeAction__c') === CUSTOM_PURGE_ACTION) {
-                System.assertEquals(
+                System.Assert.areEqual(
                     expectedRecordCountWithPurgeActionCustom,
                     summary.get('expr0'),
                     'log object summary should match for purge action : custom'
@@ -313,13 +313,13 @@ private class LogBatchPurgeController_Tests {
         List<AggregateResult> logEntryObjectSummary = (List<AggregateResult>) metricsResult.get('LogEntry__c');
         List<AggregateResult> logEntryTagObjectSummary = (List<AggregateResult>) metricsResult.get('LogEntryTag__c');
 
-        System.assertNotEquals(null, metricsResult.get('Log__c'), 'it should return metrics for Log__c object');
-        System.assertNotEquals(null, metricsResult.get('LogEntry__c'), 'it should return metrics for LogEntry__c object');
-        System.assertNotEquals(null, metricsResult.get('LogEntryTag__c'), 'it should return metrics for LogEntryTag__c object');
+        System.Assert.isNotNull(metricsResult.get('Log__c'), 'it should return metrics for Log__c object');
+        System.Assert.isNotNull(metricsResult.get('LogEntry__c'), 'it should return metrics for LogEntry__c object');
+        System.Assert.isNotNull(metricsResult.get('LogEntryTag__c'), 'it should return metrics for LogEntryTag__c object');
 
-        System.assertEquals(2, logObjectSummary.size(), 'it should return Log__c object summary records');
-        System.assertEquals(2, logEntryObjectSummary.size(), 'it should return LogEntry__c object summary records');
-        System.assertEquals(2, logEntryTagObjectSummary.size(), 'it should return LogEntry__c object summary records');
+        System.Assert.areEqual(2, logObjectSummary.size(), 'it should return Log__c object summary records');
+        System.Assert.areEqual(2, logEntryObjectSummary.size(), 'it should return LogEntry__c object summary records');
+        System.Assert.areEqual(2, logEntryTagObjectSummary.size(), 'it should return LogEntry__c object summary records');
     }
 
     @IsTest
@@ -336,8 +336,8 @@ private class LogBatchPurgeController_Tests {
         insert new List<SObject>{ setupEntityAccess, permissionSetAssignment };
 
         System.runAs(standardUser) {
-            System.assertEquals(true, FeatureManagement.checkPermission(CAN_EXECUTE_LOG_BATCH_PURGER_PERMISSION), permissionSetAssignment);
-            System.assertEquals(
+            System.Assert.isTrue(FeatureManagement.checkPermission(CAN_EXECUTE_LOG_BATCH_PURGER_PERMISSION), JSON.serializePretty(permissionSetAssignment));
+            System.Assert.areEqual(
                 true,
                 LogBatchPurgeController.canUserRunLogBatchPurger(),
                 'it didnot allow user to execute purge batch when custom permission assigned'
@@ -351,14 +351,14 @@ private class LogBatchPurgeController_Tests {
         LogBatchPurgeController.runPurgeBatch();
         System.Test.stopTest();
         List<AsyncApexJob> purgeJobs = LogBatchPurgeController.getPurgeBatchJobRecords();
-        System.assertEquals(1, purgeJobs.size(), 'should return purge batch job records');
+        System.Assert.areEqual(1, purgeJobs.size(), 'should return purge batch job records');
         for (AsyncApexJob job : purgeJobs) {
-            System.assertNotEquals(null, job.JobType, 'it should return job type');
-            System.assertNotEquals(null, job.JobItemsProcessed, 'it should return JobItemsProcessed');
-            System.assertNotEquals(null, job.NumberOfErrors, 'it should return noOfErrors');
-            System.assertNotEquals(null, job.Status, 'it should return JobStatus');
-            System.assertNotEquals(null, job.CreatedDate, 'it should return job CreatedDate');
-            System.assertNotEquals(null, job.CreatedBy.Name, 'it should return job CreatedBy.Name');
+            System.Assert.isNotNull(job.JobType, 'it should return job type');
+            System.Assert.isNotNull(job.JobItemsProcessed, 'it should return JobItemsProcessed');
+            System.Assert.isNotNull(job.NumberOfErrors, 'it should return noOfErrors');
+            System.Assert.isNotNull(job.Status, 'it should return JobStatus');
+            System.Assert.isNotNull(job.CreatedDate, 'it should return job CreatedDate');
+            System.Assert.isNotNull(job.CreatedBy.Name, 'it should return job CreatedBy.Name');
         }
     }
 
@@ -375,8 +375,8 @@ private class LogBatchPurgeController_Tests {
         insert new List<SObject>{ setupEntityAccess };
 
         System.runAs(standardUser) {
-            System.assertEquals(false, FeatureManagement.checkPermission(CAN_EXECUTE_LOG_BATCH_PURGER_PERMISSION), 'permission set assigned');
-            System.assertEquals(
+            System.Assert.isFalse(FeatureManagement.checkPermission(CAN_EXECUTE_LOG_BATCH_PURGER_PERMISSION), 'permission set assigned');
+            System.Assert.areEqual(
                 false,
                 LogBatchPurgeController.canUserRunLogBatchPurger(),
                 'it did allow user to execute purge batch when custom permission is not assigned'
@@ -403,7 +403,7 @@ private class LogBatchPurgeController_Tests {
                 AND ApexClass.Name = :apexClassName
                 AND Id = :jobId
         ];
-        System.assertEquals(1, purgeBatchJobs.size(), 'should execute the purge batch job');
+        System.Assert.areEqual(1, purgeBatchJobs.size(), 'should execute the purge batch job');
     }
 
     //helper methods

--- a/nebula-logger/core/tests/log-management/classes/LogBatchPurgeController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogBatchPurgeController_Tests.cls
@@ -447,7 +447,7 @@ private class LogBatchPurgeController_Tests {
 
         List<LogEntry__c> logEntries = new List<LogEntry__c>();
         for (Integer i = 0; i < noOfRecords; i++) {
-            LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.INFO.name());
+            LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = System.LoggingLevel.INFO.name());
             LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
             logEntries.add(logEntry);
         }

--- a/nebula-logger/core/tests/log-management/classes/LogBatchPurgeScheduler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogBatchPurgeScheduler_Tests.cls
@@ -20,7 +20,7 @@ private class LogBatchPurgeScheduler_Tests {
         LogBatchPurgeScheduler scheduler = new LogBatchPurgeScheduler(specifiedBatchSize);
         scheduler.execute(null);
 
-        System.assertEquals(specifiedBatchSize, scheduler.batchSize);
+        System.Assert.areEqual(specifiedBatchSize, scheduler.batchSize);
     }
 
     @IsTest
@@ -30,7 +30,7 @@ private class LogBatchPurgeScheduler_Tests {
         LogBatchPurgeScheduler scheduler = new LogBatchPurgeScheduler(nullBatchSize);
         scheduler.execute(null);
 
-        System.assertEquals(LogBatchPurger.getDefaultBatchSize(), scheduler.batchSize);
+        System.Assert.areEqual(LogBatchPurger.getDefaultBatchSize(), scheduler.batchSize);
     }
 
     @IsTest
@@ -45,7 +45,7 @@ private class LogBatchPurgeScheduler_Tests {
         System.Test.stopTest();
 
         List<Log__c> logs = [SELECT Id FROM Log__c];
-        System.assertEquals(0, logs.size());
+        System.Assert.areEqual(0, logs.size());
     }
 
     @IsTest
@@ -60,9 +60,9 @@ private class LogBatchPurgeScheduler_Tests {
         System.Test.stopTest();
 
         List<Log__c> logs = [SELECT Id FROM Log__c];
-        System.assertEquals(1, logs.size());
+        System.Assert.areEqual(1, logs.size());
         List<LogEntry__c> logEntries = [SELECT Id, Message__c FROM LogEntry__c];
-        System.assertNotEquals(0, logEntries.size());
+        System.Assert.areNotEqual(0, logEntries.size());
         Boolean foundExpectedMessage = false;
         String expectedMessage = new LogMessage(LogBatchPurgeScheduler.SCHEDULER_SYSTEM_MESSAGE_TEMPLATE, (System.SchedulableContext) null).getMessage();
         for (LogEntry__c logEntry : logEntries) {
@@ -70,6 +70,6 @@ private class LogBatchPurgeScheduler_Tests {
                 foundExpectedMessage = true;
             }
         }
-        System.assertEquals(true, foundExpectedMessage, 'Expected system message not found');
+        System.Assert.isTrue(foundExpectedMessage, 'Expected system message not found');
     }
 }

--- a/nebula-logger/core/tests/log-management/classes/LogBatchPurger_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogBatchPurger_Tests.cls
@@ -50,7 +50,7 @@ private class LogBatchPurger_Tests {
 
     @IsTest
     static void it_returns_2000_for_the_default_batch_size() {
-        System.assertEquals(2000, LogBatchPurger.getDefaultBatchSize());
+        System.Assert.areEqual(2000, LogBatchPurger.getDefaultBatchSize());
     }
 
     @IsTest
@@ -68,14 +68,14 @@ private class LogBatchPurger_Tests {
             thrownNullPointerException = ex;
         }
 
-        System.assertNotEquals(null, thrownNullPointerException);
+        System.Assert.isNotNull(thrownNullPointerException);
     }
 
     @IsTest
     static void it_should_default_batch_size_for_chained_job_batch_size() {
         LogBatchPurger batchJobInstance = new LogBatchPurger();
 
-        System.assertEquals(LogBatchPurger.getDefaultBatchSize(), batchJobInstance.chainedBatchSize);
+        System.Assert.areEqual(LogBatchPurger.getDefaultBatchSize(), batchJobInstance.chainedBatchSize);
     }
 
     @IsTest
@@ -85,7 +85,7 @@ private class LogBatchPurger_Tests {
 
         batchJobInstance.setChainedBatchSize(specifiedBatchSize);
 
-        System.assertEquals(specifiedBatchSize, batchJobInstance.chainedBatchSize);
+        System.Assert.areEqual(specifiedBatchSize, batchJobInstance.chainedBatchSize);
     }
 
     @IsTest
@@ -95,17 +95,17 @@ private class LogBatchPurger_Tests {
         settings.LoggingLevel__c = LoggingLevel.FINEST.name();
         upsert settings;
         LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'EnableLoggerSystemMessages', Value__c = 'true'));
-        System.assertEquals(true, Logger.getUserSettings().IsEnabled__c);
-        System.assertEquals(true, LoggerParameter.getBoolean('EnableLoggerSystemMessages', null));
-        System.assertEquals(LoggingLevel.FINEST.name(), Logger.getUserSettings().LoggingLevel__c);
+        System.Assert.isTrue(Logger.getUserSettings().IsEnabled__c);
+        System.Assert.isTrue(LoggerParameter.getBoolean('EnableLoggerSystemMessages', null));
+        System.Assert.areEqual(LoggingLevel.FINEST.name(), Logger.getUserSettings().LoggingLevel__c);
         List<Log__c> logs = [SELECT Id, LogRetentionDate__c FROM Log__c];
         List<LogEntry__c> logEntries = [SELECT Id FROM LogEntry__c];
-        System.assertEquals(1, logs.size());
-        System.assertEquals(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logEntries.size());
+        System.Assert.areEqual(1, logs.size());
+        System.Assert.areEqual(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logEntries.size());
         // Verify assumption that the log in the database has a deletion date in the past
         Log__c log = logs.get(0);
-        System.assertNotEquals(null, log.LogRetentionDate__c);
-        System.assert(log.LogRetentionDate__c < System.today());
+        System.Assert.isNotNull(log.LogRetentionDate__c);
+        System.Assert.isTrue(log.LogRetentionDate__c < System.today());
         System.Test.startTest();
         LoggerSObjectHandler.shouldExecute(true);
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -115,8 +115,8 @@ private class LogBatchPurger_Tests {
         System.Test.stopTest();
         logs = [SELECT Id FROM Log__c WHERE Id IN :logs];
         logEntries = [SELECT Id FROM LogEntry__c WHERE Id IN :logEntries];
-        System.assertEquals(0, logs.size(), logs);
-        System.assertEquals(0, logEntries.size(), logEntries);
+        System.Assert.areEqual(0, logs.size(), JSON.serializePretty(logs));
+        System.Assert.areEqual(0, logEntries.size(), JSON.serializePretty(logEntries));
     }
 
     @IsTest
@@ -125,17 +125,17 @@ private class LogBatchPurger_Tests {
         settings.IsEnabled__c = true;
         upsert settings;
         LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'EnableLoggerSystemMessages', Value__c = String.valueOf(false)));
-        System.assertEquals(true, Logger.getUserSettings().IsEnabled__c);
-        System.assertEquals(false, LoggerParameter.getBoolean('EnableLoggerSystemMessages', null));
-        System.assertEquals(LoggingLevel.FINEST.name(), Logger.getUserSettings().LoggingLevel__c);
+        System.Assert.isTrue(Logger.getUserSettings().IsEnabled__c);
+        System.Assert.isFalse(LoggerParameter.getBoolean('EnableLoggerSystemMessages', null));
+        System.Assert.areEqual(LoggingLevel.FINEST.name(), Logger.getUserSettings().LoggingLevel__c);
         List<Log__c> logs = [SELECT Id, LogRetentionDate__c FROM Log__c];
         List<LogEntry__c> logEntries = [SELECT Id FROM LogEntry__c];
-        System.assertEquals(1, logs.size());
-        System.assertEquals(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logEntries.size());
+        System.Assert.areEqual(1, logs.size());
+        System.Assert.areEqual(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logEntries.size());
         // Verify assumption that the log in the database has a deletion date in the past
         Log__c log = logs.get(0);
-        System.assertNotEquals(null, log.LogRetentionDate__c);
-        System.assert(log.LogRetentionDate__c < System.today());
+        System.Assert.isNotNull(log.LogRetentionDate__c);
+        System.Assert.isTrue(log.LogRetentionDate__c < System.today());
         System.Test.startTest();
         LoggerSObjectHandler.shouldExecute(false);
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -145,8 +145,8 @@ private class LogBatchPurger_Tests {
         System.Test.stopTest();
         logs = [SELECT Id FROM Log__c WHERE Id IN :logs];
         logEntries = [SELECT Id FROM LogEntry__c WHERE Id IN :logEntries];
-        System.assertEquals(0, logs.size(), logs);
-        System.assertEquals(0, logEntries.size(), logEntries);
+        System.Assert.areEqual(0, logs.size(), JSON.serializePretty(logs));
+        System.Assert.areEqual(0, logEntries.size(), JSON.serializePretty(logEntries));
     }
 
     @IsTest
@@ -154,14 +154,14 @@ private class LogBatchPurger_Tests {
         LoggerSObjectHandler.shouldExecute(false);
         List<Log__c> logs = [SELECT Id, LogRetentionDate__c FROM Log__c];
         List<LogEntry__c> logEntries = [SELECT Id FROM LogEntry__c];
-        System.assertEquals(1, logs.size());
-        System.assertEquals(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logEntries.size());
+        System.Assert.areEqual(1, logs.size());
+        System.Assert.areEqual(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logEntries.size());
         // Set the log's deletion date to be in the future
         Log__c log = logs.get(0);
         log.LogRetentionDate__c = System.today().addDays(7);
         update log;
         log = [SELECT Id, LogRetentionDate__c FROM Log__c];
-        System.assert(log.LogRetentionDate__c > System.today());
+        System.Assert.isTrue(log.LogRetentionDate__c > System.today());
         System.Test.startTest();
         LoggerSObjectHandler.shouldExecute(false);
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -171,8 +171,8 @@ private class LogBatchPurger_Tests {
         System.Test.stopTest();
         logs = [SELECT Id FROM Log__c WHERE Id IN :logs];
         logEntries = [SELECT Id FROM LogEntry__c WHERE Id IN :logEntries];
-        System.assertEquals(1, logs.size());
-        System.assertEquals(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logEntries.size());
+        System.Assert.areEqual(1, logs.size());
+        System.Assert.areEqual(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logEntries.size());
     }
 
     @IsTest
@@ -180,15 +180,15 @@ private class LogBatchPurger_Tests {
         LoggerSObjectHandler.shouldExecute(false);
         List<Log__c> logs = [SELECT Id, TotalLogEntries__c, LogRetentionDate__c FROM Log__c];
         List<LogEntry__c> logEntries = [SELECT Id FROM LogEntry__c];
-        System.assertEquals(1, logs.size());
-        System.assertEquals(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logs.get(0).TotalLogEntries__c);
-        System.assertEquals(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logEntries.size());
+        System.Assert.areEqual(1, logs.size());
+        System.Assert.areEqual(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logs.get(0).TotalLogEntries__c);
+        System.Assert.areEqual(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logEntries.size());
         // Set the log's deletion date to be null
         Log__c log = logs.get(0);
         log.LogRetentionDate__c = null;
         update log;
         log = [SELECT Id, LogRetentionDate__c FROM Log__c];
-        System.assertEquals(null, log.LogRetentionDate__c);
+        System.Assert.isNull(log.LogRetentionDate__c);
         System.Test.startTest();
         LoggerSObjectHandler.shouldExecute(false);
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -198,8 +198,8 @@ private class LogBatchPurger_Tests {
         System.Test.stopTest();
         logs = [SELECT Id FROM Log__c WHERE Id IN :logs];
         logEntries = [SELECT Id FROM LogEntry__c WHERE Id IN :logEntries];
-        System.assertEquals(1, logs.size(), logs);
-        System.assertEquals(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logEntries.size(), logEntries);
+        System.Assert.areEqual(1, logs.size(), JSON.serializePretty(logs));
+        System.Assert.areEqual(NUMBER_OF_LOG_ENTRIES_TO_CREATE, logEntries.size(), JSON.serializePretty(logEntries));
     }
 
     @IsTest
@@ -211,8 +211,8 @@ private class LogBatchPurger_Tests {
         log.LogRetentionDate__c = retentionDate;
         update log;
         log = [SELECT Id, LogRetentionDate__c, TotalLogEntries__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(retentionDate, log.LogRetentionDate__c, 'Log should not have a retention date');
-        System.assertEquals(0, log.TotalLogEntries__c, 'Log should not have any related log entries');
+        System.Assert.areEqual(retentionDate, log.LogRetentionDate__c, 'Log should not have a retention date');
+        System.Assert.areEqual(0, log.TotalLogEntries__c, 'Log should not have any related log entries');
         System.Test.startTest();
         LoggerSObjectHandler.shouldExecute(false);
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -221,7 +221,7 @@ private class LogBatchPurger_Tests {
 
         System.Test.stopTest();
         List<Log__c> matchingLogs = [SELECT Id FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(0, matchingLogs.size(), 'Test log should have been deleted');
+        System.Assert.areEqual(0, matchingLogs.size(), 'Test log should have been deleted');
     }
 
     @IsTest
@@ -232,8 +232,8 @@ private class LogBatchPurger_Tests {
         log.LogRetentionDate__c = null;
         update log;
         log = [SELECT Id, LogRetentionDate__c, TotalLogEntries__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(null, log.LogRetentionDate__c, 'Log should not have a retention date');
-        System.assertEquals(0, log.TotalLogEntries__c, 'Log should not have any related log entries');
+        System.Assert.isNull(log.LogRetentionDate__c, 'Log should not have a retention date');
+        System.Assert.areEqual(0, log.TotalLogEntries__c, 'Log should not have any related log entries');
         System.Test.startTest();
         LoggerSObjectHandler.shouldExecute(false);
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -242,7 +242,7 @@ private class LogBatchPurger_Tests {
 
         System.Test.stopTest();
         List<Log__c> matchingLogs = [SELECT Id FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(0, matchingLogs.size(), 'Test log should have been deleted');
+        System.Assert.areEqual(0, matchingLogs.size(), 'Test log should have been deleted');
     }
 
     @IsTest
@@ -257,44 +257,44 @@ private class LogBatchPurger_Tests {
         LoggerTestConfigurator.setMock(mockPluginConfiguration);
         LogBatchPurger batchJobInstance = new LogBatchPurger();
         batchJobInstance.currentSObjectType = Schema.LogEntry__c.SObjectType;
-        System.assertEquals(false, ranPluginStart);
-        System.assertEquals(false, ranPluginExecute);
-        System.assertEquals(false, ranPluginFinish);
-        System.assertEquals(null, pluginConfiguration);
-        System.assertEquals(null, batchInput);
+        System.Assert.isFalse(ranPluginStart);
+        System.Assert.isFalse(ranPluginExecute);
+        System.Assert.isFalse(ranPluginFinish);
+        System.Assert.isNull(pluginConfiguration);
+        System.Assert.isNull(batchInput);
         Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
 
         batchJobInstance.start(mockBatchableContext);
 
         LoggerBatchableContext expectedInput = new LoggerBatchableContext(mockBatchableContext, batchJobInstance.currentSObjectType);
-        System.assertEquals(
+        System.Assert.areEqual(
             3,
             batchJobInstance.getExecutedApexPlugins().size(),
             'The map of executed Apex plugins should have 3 keys - one for each enum value in LogBatchPurger.BatchableMethod (START, EXECUTE, and FINISH)'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             1,
             batchJobInstance.getExecutedApexPlugins().get(LogBatchPurger.BatchableMethod.START).size(),
             'One Apex plugin should have run in the batch job\'s start method'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             batchJobInstance.getExecutedApexPlugins().get(LogBatchPurger.BatchableMethod.EXECUTE).size(),
             'No Apex plugins should have run in the batch job\'s execute method'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             batchJobInstance.getExecutedApexPlugins().get(LogBatchPurger.BatchableMethod.FINISH).size(),
             'No Apex plugins should have run in the batch job\'s finish method'
         );
         LoggerPlugin.Batchable apexStartPlugin = batchJobInstance.getExecutedApexPlugins().get(LogBatchPurger.BatchableMethod.START).get(0);
-        System.assertEquals(true, apexStartPlugin instanceof MockBatchPurgerPlugin, apexStartPlugin);
-        System.assertEquals(true, ranPluginStart);
-        System.assertEquals(false, ranPluginExecute);
-        System.assertEquals(false, ranPluginFinish);
-        System.assertEquals(mockPluginConfiguration, pluginConfiguration);
-        System.assertEquals(expectedInput.batchableContext, batchInput.batchableContext);
-        System.assertEquals(expectedInput.sobjectType, batchInput.sobjectType);
+        System.Assert.isInstanceOfType(apexStartPlugin, MockBatchPurgerPlugin.class, JSON.serializePretty(apexStartPlugin));
+        System.Assert.isTrue(ranPluginStart);
+        System.Assert.isFalse(ranPluginExecute);
+        System.Assert.isFalse(ranPluginFinish);
+        System.Assert.areEqual(mockPluginConfiguration, pluginConfiguration);
+        System.Assert.areEqual(expectedInput.batchableContext, batchInput.batchableContext);
+        System.Assert.areEqual(expectedInput.sobjectType, batchInput.sobjectType);
     }
 
     @IsTest
@@ -308,47 +308,47 @@ private class LogBatchPurger_Tests {
         LoggerTestConfigurator.setMock(mockPluginConfiguration);
         LogBatchPurger batchJobInstance = new LogBatchPurger();
         batchJobInstance.currentSObjectType = Schema.LogEntry__c.SObjectType;
-        System.assertEquals(false, ranPluginStart);
-        System.assertEquals(false, ranPluginExecute);
-        System.assertEquals(false, ranPluginFinish);
-        System.assertEquals(null, pluginConfiguration);
-        System.assertEquals(null, batchInput);
+        System.Assert.isFalse(ranPluginStart);
+        System.Assert.isFalse(ranPluginExecute);
+        System.Assert.isFalse(ranPluginFinish);
+        System.Assert.isNull(pluginConfiguration);
+        System.Assert.isNull(batchInput);
         List<Log__c> logsToDelete = [SELECT Id FROM Log__c];
-        System.assertNotEquals(0, logsToDelete.size());
+        System.Assert.areNotEqual(0, logsToDelete.size());
         Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
 
         batchJobInstance.execute(mockBatchableContext, logsToDelete);
 
         LoggerBatchableContext expectedInput = new LoggerBatchableContext(mockBatchableContext, batchJobInstance.currentSObjectType);
-        System.assertEquals(
+        System.Assert.areEqual(
             3,
             batchJobInstance.getExecutedApexPlugins().size(),
             'The map of executed Apex plugins should have 3 keys - one for each enum value in LogBatchPurger.BatchableMethod (START, EXECUTE, and FINISH)'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             batchJobInstance.getExecutedApexPlugins().get(LogBatchPurger.BatchableMethod.START).size(),
             'No Apex plugins should have run in the batch job\'s start method'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             1,
             batchJobInstance.getExecutedApexPlugins().get(LogBatchPurger.BatchableMethod.EXECUTE).size(),
             'One Apex plugin should have run in the batch job\'s execute method'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             batchJobInstance.getExecutedApexPlugins().get(LogBatchPurger.BatchableMethod.FINISH).size(),
             'No Apex plugins should have run in the batch job\'s finish method'
         );
         LoggerPlugin.Batchable apexExecutePlugin = batchJobInstance.getExecutedApexPlugins().get(LogBatchPurger.BatchableMethod.EXECUTE).get(0);
-        System.assertEquals(true, apexExecutePlugin instanceof MockBatchPurgerPlugin, apexExecutePlugin);
-        System.assertEquals(false, ranPluginStart);
-        System.assertEquals(true, ranPluginExecute);
-        System.assertEquals(false, ranPluginFinish);
-        System.assertEquals(mockPluginConfiguration, pluginConfiguration);
-        System.assertEquals(expectedInput.batchableContext, batchInput.batchableContext);
+        System.Assert.isInstanceOfType(apexExecutePlugin, MockBatchPurgerPlugin.class, JSON.serializePretty(apexExecutePlugin));
+        System.Assert.isFalse(ranPluginStart);
+        System.Assert.isTrue(ranPluginExecute);
+        System.Assert.isFalse(ranPluginFinish);
+        System.Assert.areEqual(mockPluginConfiguration, pluginConfiguration);
+        System.Assert.areEqual(expectedInput.batchableContext, batchInput.batchableContext);
         logsToDelete = [SELECT Id FROM Log__c WHERE Id IN :logsToDelete];
-        System.assertEquals(0, logsToDelete.size(), 'All logs should have still been deleted by LogBatchPurger after running plugins: ' + logsToDelete);
+        System.Assert.areEqual(0, logsToDelete.size(), 'All logs should have still been deleted by LogBatchPurger after running plugins: ' + logsToDelete);
     }
 
     @IsTest
@@ -362,43 +362,43 @@ private class LogBatchPurger_Tests {
         LoggerTestConfigurator.setMock(mockPluginConfiguration);
         LogBatchPurger batchJobInstance = new LogBatchPurger();
         batchJobInstance.currentSObjectType = Schema.LogEntry__c.SObjectType;
-        System.assertEquals(false, ranPluginStart);
-        System.assertEquals(false, ranPluginExecute);
-        System.assertEquals(false, ranPluginFinish);
-        System.assertEquals(null, pluginConfiguration);
-        System.assertEquals(null, batchInput);
+        System.Assert.isFalse(ranPluginStart);
+        System.Assert.isFalse(ranPluginExecute);
+        System.Assert.isFalse(ranPluginFinish);
+        System.Assert.isNull(pluginConfiguration);
+        System.Assert.isNull(batchInput);
         Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
 
         batchJobInstance.finish(mockBatchableContext);
 
         LoggerBatchableContext expectedInput = new LoggerBatchableContext(mockBatchableContext, batchJobInstance.currentSObjectType);
-        System.assertEquals(
+        System.Assert.areEqual(
             3,
             batchJobInstance.getExecutedApexPlugins().size(),
             'The map of executed Apex plugins should have 3 keys - one for each enum value in LogBatchPurger.BatchableMethod (START, EXECUTE, and FINISH)'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             batchJobInstance.getExecutedApexPlugins().get(LogBatchPurger.BatchableMethod.START).size(),
             'No Apex plugins should have run in the batch job\'s start method'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             batchJobInstance.getExecutedApexPlugins().get(LogBatchPurger.BatchableMethod.EXECUTE).size(),
             'No Apex plugins should have run in the batch job\'s execute method'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             1,
             batchJobInstance.getExecutedApexPlugins().get(LogBatchPurger.BatchableMethod.FINISH).size(),
             'One Apex plugin should have run in the batch job\'s finish method'
         );
         LoggerPlugin.Batchable apexFinishPlugin = batchJobInstance.getExecutedApexPlugins().get(LogBatchPurger.BatchableMethod.FINISH).get(0);
-        System.assertEquals(true, apexFinishPlugin instanceof MockBatchPurgerPlugin, apexFinishPlugin);
-        System.assertEquals(false, ranPluginStart);
-        System.assertEquals(false, ranPluginExecute);
-        System.assertEquals(true, ranPluginFinish);
-        System.assertEquals(mockPluginConfiguration, pluginConfiguration);
-        System.assertEquals(expectedInput.sobjectType, batchInput.sobjectType);
+        System.Assert.isInstanceOfType(apexFinishPlugin, MockBatchPurgerPlugin.class, JSON.serializePretty(apexFinishPlugin));
+        System.Assert.isFalse(ranPluginStart);
+        System.Assert.isFalse(ranPluginExecute);
+        System.Assert.isTrue(ranPluginFinish);
+        System.Assert.areEqual(mockPluginConfiguration, pluginConfiguration);
+        System.Assert.areEqual(expectedInput.sobjectType, batchInput.sobjectType);
     }
 
     public class MockBatchPurgerPlugin implements LoggerPlugin.Batchable {

--- a/nebula-logger/core/tests/log-management/classes/LogBatchPurger_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogBatchPurger_Tests.cls
@@ -20,7 +20,7 @@ private class LogBatchPurger_Tests {
         LoggerSObjectHandler.shouldExecute(false);
         LoggerSettings__c settings = Logger.getUserSettings();
         settings.IsEnabled__c = false;
-        settings.LoggingLevel__c = LoggingLevel.FINEST.name();
+        settings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
         insert settings;
 
         Date scheduledDeletionDate = System.today().addDays(-7);
@@ -30,7 +30,7 @@ private class LogBatchPurger_Tests {
 
         List<LogEntry__c> logEntries = new List<LogEntry__c>();
         for (Integer i = 0; i < NUMBER_OF_LOG_ENTRIES_TO_CREATE; i++) {
-            LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.INFO.name());
+            LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = System.LoggingLevel.INFO.name());
             LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
             logEntries.add(logEntry);
         }
@@ -92,12 +92,12 @@ private class LogBatchPurger_Tests {
     static void it_should_delete_a_log_after_scheduled_deletion_date_when_system_messages_enabled() {
         LoggerSettings__c settings = Logger.getUserSettings();
         settings.IsEnabled__c = true;
-        settings.LoggingLevel__c = LoggingLevel.FINEST.name();
+        settings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
         upsert settings;
         LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'EnableLoggerSystemMessages', Value__c = 'true'));
         System.Assert.isTrue(Logger.getUserSettings().IsEnabled__c);
         System.Assert.isTrue(LoggerParameter.getBoolean('EnableLoggerSystemMessages', null));
-        System.Assert.areEqual(LoggingLevel.FINEST.name(), Logger.getUserSettings().LoggingLevel__c);
+        System.Assert.areEqual(System.LoggingLevel.FINEST.name(), Logger.getUserSettings().LoggingLevel__c);
         List<Log__c> logs = [SELECT Id, LogRetentionDate__c FROM Log__c];
         List<LogEntry__c> logEntries = [SELECT Id FROM LogEntry__c];
         System.Assert.areEqual(1, logs.size());
@@ -127,7 +127,7 @@ private class LogBatchPurger_Tests {
         LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'EnableLoggerSystemMessages', Value__c = String.valueOf(false)));
         System.Assert.isTrue(Logger.getUserSettings().IsEnabled__c);
         System.Assert.isFalse(LoggerParameter.getBoolean('EnableLoggerSystemMessages', null));
-        System.Assert.areEqual(LoggingLevel.FINEST.name(), Logger.getUserSettings().LoggingLevel__c);
+        System.Assert.areEqual(System.LoggingLevel.FINEST.name(), Logger.getUserSettings().LoggingLevel__c);
         List<Log__c> logs = [SELECT Id, LogRetentionDate__c FROM Log__c];
         List<LogEntry__c> logEntries = [SELECT Id FROM LogEntry__c];
         System.Assert.areEqual(1, logs.size());

--- a/nebula-logger/core/tests/log-management/classes/LogBatchPurger_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogBatchPurger_Tests.cls
@@ -60,7 +60,7 @@ private class LogBatchPurger_Tests {
         batchJobInstance.currentSObjectType = Schema.Log__c.SObjectType;
         List<Log__c> nullLogsList = null;
         Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
-        Exception thrownNullPointerException;
+        System.Exception thrownNullPointerException;
 
         try {
             batchJobInstance.execute(mockBatchableContext, nullLogsList);

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -972,15 +972,15 @@ private class LogEntryEventHandler_Tests {
             .getRecord();
         logEntryEvent.ImpersonatedById__c = null;
         logEntryEvent.LoggedById__c = System.UserInfo.getUserId();
-        logEntryEvent.LoggingLevel__c = LoggingLevel.INFO.name();
-        logEntryEvent.LoggingLevelOrdinal__c = LoggingLevel.INFO.ordinal();
+        logEntryEvent.LoggingLevel__c = System.LoggingLevel.INFO.name();
+        logEntryEvent.LoggingLevelOrdinal__c = System.LoggingLevel.INFO.ordinal();
         logEntryEvent.ProfileId__c = System.UserInfo.getProfileId();
         logEntryEvent.RecordCollectionSize__c = 1;
         logEntryEvent.RecordCollectionType__c = 'Single';
         logEntryEvent.RecordId__c = System.UserInfo.getUserId();
         logEntryEvent.TimestampString__c = String.valueOf(logEntryEvent.Timestamp__c.getTime());
-        logEntryEvent.UserLoggingLevel__c = LoggingLevel.INFO.name();
-        logEntryEvent.UserLoggingLevelOrdinal__c = LoggingLevel.INFO.ordinal();
+        logEntryEvent.UserLoggingLevel__c = System.LoggingLevel.INFO.name();
+        logEntryEvent.UserLoggingLevelOrdinal__c = System.LoggingLevel.INFO.ordinal();
         logEntryEvent = (LogEntryEvent__e) LoggerMockDataCreator.setReadOnlyField(
             logEntryEvent,
             Schema.LogEntryEvent__e.EventUuid,

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -821,7 +821,10 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
-        System.Test.setMock(HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(200).setResponseBody(createStatusApiResponseJson()));
+        System.Test.setMock(
+            System.HttpCalloutMock.class,
+            LoggerMockDataCreator.createHttpCallout().setStatusCode(200).setResponseBody(createStatusApiResponseJson())
+        );
         LoggerParameter__mdt mockCallStatusApiParameter = new LoggerParameter__mdt(DeveloperName = 'CallStatusApi', Value__c = 'true');
         LoggerTestConfigurator.setMock(mockCallStatusApiParameter);
         System.Assert.isTrue(LoggerParameter.CALL_STATUS_API);
@@ -892,7 +895,10 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
-        System.Test.setMock(HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(400).setResponseBody(createStatusApiResponseJson()));
+        System.Test.setMock(
+            System.HttpCalloutMock.class,
+            LoggerMockDataCreator.createHttpCallout().setStatusCode(400).setResponseBody(createStatusApiResponseJson())
+        );
         LoggerParameter__mdt mockCallStatusApiParameter = new LoggerParameter__mdt(DeveloperName = 'CallStatusApi', Value__c = 'false');
         LoggerTestConfigurator.setMock(mockCallStatusApiParameter);
         LogEntryEvent__e logEntryEvent = createLogEntryEvent();
@@ -927,7 +933,10 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
-        System.Test.setMock(HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(400).setResponseBody(createStatusApiResponseJson()));
+        System.Test.setMock(
+            System.HttpCalloutMock.class,
+            LoggerMockDataCreator.createHttpCallout().setStatusCode(400).setResponseBody(createStatusApiResponseJson())
+        );
         LoggerParameter__mdt mockCallStatusApiParameter = new LoggerParameter__mdt(DeveloperName = 'CallStatusApi', Value__c = 'true');
         LoggerTestConfigurator.setMock(mockCallStatusApiParameter);
         LogEntryEvent__e logEntryEvent = createLogEntryEvent();
@@ -940,11 +949,11 @@ private class LogEntryEventHandler_Tests {
             saveResult = LoggerMockDataStore.getEventBus().publishRecord(logEntryEvent);
             LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
             System.Test.stopTest();
-            System.Assert.fail('Exception expected, this assert should not run');
-        } catch (Exception ex) {
-            System.Assert.areEqual(CalloutException.class.getName(), ex.getTypeName());
+            System.Assert.fail('System.Exception expected, this assert should not run');
+        } catch (System.Exception apexException) {
+            System.Assert.isInstanceOfType(apexException, System.CalloutException.class);
             String expectedErrorMessage = 'Callout failed for https://api.status.salesforce.com/v1/instances/';
-            System.Assert.isTrue(ex.getMessage().contains(expectedErrorMessage));
+            System.Assert.isTrue(apexException.getMessage().contains(expectedErrorMessage));
         }
 
         System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -11,7 +11,7 @@ private class LogEntryEventHandler_Tests {
 
     @IsTest
     static void it_should_return_the_logEntryEvent_sobjectType() {
-        System.assertEquals(Schema.LogEntryEvent__e.SObjectType, new LogEntryEventHandler().getSObjectType());
+        System.Assert.areEqual(Schema.LogEntryEvent__e.SObjectType, new LogEntryEventHandler().getSObjectType());
     }
 
     @IsTest
@@ -24,7 +24,7 @@ private class LogEntryEventHandler_Tests {
         LoggerDataStore.getEventBus().publishRecord(logEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should not have executed'
@@ -38,23 +38,23 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
         Integer countOfLogs = [SELECT COUNT() FROM Log__c];
-        System.assertEquals(0, countOfLogs);
+        System.Assert.areEqual(0, countOfLogs);
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         List<Database.SaveResult> saveResults = LoggerMockDataStore.getEventBus().publishRecords(new List<LogEntryEvent__e>());
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(true, saveResults.isEmpty());
-        System.assertEquals(
+        System.Assert.isTrue(saveResults.isEmpty());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
         countOfLogs = [SELECT COUNT() FROM Log__c];
-        System.assertEquals(0, countOfLogs);
+        System.Assert.areEqual(0, countOfLogs);
         countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
     }
 
     @IsTest
@@ -64,9 +64,9 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
         Integer countOfLogs = [SELECT COUNT() FROM Log__c];
-        System.assertEquals(0, countOfLogs);
+        System.Assert.areEqual(0, countOfLogs);
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
         LoggerSettings__c settings = Logger.getUserSettings();
         settings.IsEnabled__c = true;
         settings.IsSavingEnabled__c = true;
@@ -77,16 +77,16 @@ private class LogEntryEventHandler_Tests {
         Database.SaveResult saveResult = LoggerMockDataStore.getEventBus().publishRecord(logEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
         countOfLogs = [SELECT COUNT() FROM Log__c];
-        System.assertEquals(0, countOfLogs);
+        System.Assert.areEqual(0, countOfLogs);
         countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
     }
 
     @IsTest
@@ -96,9 +96,9 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
         Integer countOfLogs = [SELECT COUNT() FROM Log__c];
-        System.assertEquals(0, countOfLogs);
+        System.Assert.areEqual(0, countOfLogs);
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
         LoggerSettings__c settings = Logger.getUserSettings();
         settings.IsEnabled__c = true;
         settings.IsSavingEnabled__c = true;
@@ -118,16 +118,16 @@ private class LogEntryEventHandler_Tests {
         Database.SaveResult saveResult = LoggerMockDataStore.getEventBus().publishRecord(logEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
         countOfLogs = [SELECT COUNT() FROM Log__c];
-        System.assertEquals(0, countOfLogs);
+        System.Assert.areEqual(0, countOfLogs);
         countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
     }
 
     @IsTest
@@ -142,17 +142,17 @@ private class LogEntryEventHandler_Tests {
         Database.SaveResult saveResult = LoggerMockDataStore.getEventBus().publishRecord(logEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
         Log__c log = getLog();
-        System.assertEquals(null, log.TransactionScenario__c);
-        System.assertEquals(1, log.LogEntries__r.size());
+        System.Assert.isNull(log.TransactionScenario__c);
+        System.Assert.areEqual(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
-        System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c);
+        System.Assert.areEqual(logEntryEvent.TransactionId__c, log.TransactionId__c);
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
     }
@@ -164,7 +164,7 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
         List<String> transactionIds = new List<String>{ '123-456', '789-0' };
-        System.assertEquals(2, transactionIds.size());
+        System.Assert.areEqual(2, transactionIds.size());
         List<LogEntryEvent__e> logEntryEvents = new List<LogEntryEvent__e>();
         for (Integer i = 0; i < transactionIds.size(); i++) {
             LogEntryEvent__e logEntryEvent = createLogEntryEvent();
@@ -172,26 +172,26 @@ private class LogEntryEventHandler_Tests {
             logEntryEvent.TransactionId__c = transactionIds.get(i);
             logEntryEvents.add(logEntryEvent);
         }
-        System.assertEquals(transactionIds.size(), logEntryEvents.size());
+        System.Assert.areEqual(transactionIds.size(), logEntryEvents.size());
 
         List<Database.SaveResult> saveResults = LoggerMockDataStore.getEventBus().publishRecords(logEntryEvents);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(transactionIds.size(), saveResults.size());
+        System.Assert.areEqual(transactionIds.size(), saveResults.size());
         for (Database.SaveResult saveResult : saveResults) {
-            System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
+            System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
         }
-        System.assertEquals(
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
         List<Log__c> logs = [SELECT Id, TransactionId__c, (SELECT Id FROM LogEntries__r) FROM Log__c];
-        System.assertEquals(2, logs.size(), logs);
+        System.Assert.areEqual(2, logs.size(), JSON.serializePretty(logs));
         Set<String> uniqueTransactionIds = new Set<String>(transactionIds);
         for (Log__c log : logs) {
-            System.assert(uniqueTransactionIds.contains(log.TransactionId__c), log.TransactionId__c);
-            System.assertEquals(1, log.LogEntries__r.size());
+            System.Assert.isTrue(uniqueTransactionIds.contains(log.TransactionId__c), log.TransactionId__c);
+            System.Assert.areEqual(1, log.LogEntries__r.size());
         }
     }
 
@@ -208,18 +208,18 @@ private class LogEntryEventHandler_Tests {
         Database.SaveResult saveResult = LoggerMockDataStore.getEventBus().publishRecord(logEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
-        System.assertEquals(1, [SELECT COUNT() FROM LoggerScenario__c]);
+        System.Assert.areEqual(1, [SELECT COUNT() FROM LoggerScenario__c]);
         Log__c log = getLog();
-        System.assertNotEquals(null, log.TransactionScenario__c);
-        System.assertEquals(1, log.LogEntries__r.size());
+        System.Assert.isNotNull(log.TransactionScenario__c);
+        System.Assert.areEqual(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
-        System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c);
+        System.Assert.areEqual(logEntryEvent.TransactionId__c, log.TransactionId__c);
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
     }
@@ -232,7 +232,7 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
         LoggerScenario__c existingLogScenario = new LoggerScenario__c(UniqueId__c = 'hello, world');
         insert existingLogScenario;
-        System.assertEquals(1, [SELECT COUNT() FROM LoggerScenario__c]);
+        System.Assert.areEqual(1, [SELECT COUNT() FROM LoggerScenario__c]);
         LogEntryEvent__e firstLogEntryEvent = createLogEntryEvent();
         firstLogEntryEvent.EntryScenario__c = null;
         firstLogEntryEvent.TransactionScenario__c = existingLogScenario.UniqueId__c;
@@ -244,23 +244,23 @@ private class LogEntryEventHandler_Tests {
         List<Database.SaveResult> saveResults = LoggerMockDataStore.getEventBus().publishRecords(logEntryEvents);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(logEntryEvents.size(), saveResults.size());
+        System.Assert.areEqual(logEntryEvents.size(), saveResults.size());
         for (Database.SaveResult saveResult : saveResults) {
-            System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
+            System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
         }
-        System.assertEquals(
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
-        System.assertEquals(1, [SELECT COUNT() FROM LoggerScenario__c]);
+        System.Assert.areEqual(1, [SELECT COUNT() FROM LoggerScenario__c]);
         Log__c log = getLog();
-        System.assertEquals(existingLogScenario.Id, log.TransactionScenario__c);
-        System.assertEquals(logEntryEvents.size(), log.LogEntries__r.size());
+        System.Assert.areEqual(existingLogScenario.Id, log.TransactionScenario__c);
+        System.Assert.areEqual(logEntryEvents.size(), log.LogEntries__r.size());
         for (Integer i = 0; i < logEntryEvents.size(); i++) {
             LogEntryEvent__e logEntryEvent = logEntryEvents.get(i);
             LogEntry__c logEntry = log.LogEntries__r.get(i);
-            System.assertEquals(logEntryEvent.TransactionScenario__c, log.TransactionScenario__r.UniqueId__c);
+            System.Assert.areEqual(logEntryEvent.TransactionScenario__c, log.TransactionScenario__r.UniqueId__c);
             validateLogFields(logEntryEvent, log);
             validateLogEntryFields(logEntryEvent, logEntry);
         }
@@ -275,7 +275,7 @@ private class LogEntryEventHandler_Tests {
         LoggerScenario__c existingLoggerScenario = new LoggerScenario__c(UniqueId__c = 'hello, world');
         insert existingLoggerScenario;
         String newScenario = 'some new value';
-        System.assertEquals(1, [SELECT COUNT() FROM LoggerScenario__c]);
+        System.Assert.areEqual(1, [SELECT COUNT() FROM LoggerScenario__c]);
         LogEntryEvent__e firstLogEntryEvent = createLogEntryEvent();
         firstLogEntryEvent.EntryScenario__c = existingLoggerScenario.UniqueId__c;
         firstLogEntryEvent.TransactionScenario__c = null;
@@ -287,22 +287,22 @@ private class LogEntryEventHandler_Tests {
         List<Database.SaveResult> saveResults = LoggerMockDataStore.getEventBus().publishRecords(logEntryEvents);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(logEntryEvents.size(), saveResults.size());
+        System.Assert.areEqual(logEntryEvents.size(), saveResults.size());
         for (Database.SaveResult saveResult : saveResults) {
-            System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
+            System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
         }
-        System.assertEquals(
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
-        System.assertEquals(2, [SELECT COUNT() FROM LoggerScenario__c]);
+        System.Assert.areEqual(2, [SELECT COUNT() FROM LoggerScenario__c]);
         Log__c log = getLog();
-        System.assertEquals(logEntryEvents.size(), log.LogEntries__r.size());
+        System.Assert.areEqual(logEntryEvents.size(), log.LogEntries__r.size());
         for (Integer i = 0; i < logEntryEvents.size(); i++) {
             LogEntryEvent__e logEntryEvent = logEntryEvents.get(i);
             LogEntry__c logEntry = log.LogEntries__r.get(i);
-            System.assertEquals(logEntryEvent.EntryScenario__c, logEntry.EntryScenario__r.UniqueId__c);
+            System.Assert.areEqual(logEntryEvent.EntryScenario__c, logEntry.EntryScenario__r.UniqueId__c);
             validateLogFields(logEntryEvent, log);
             validateLogEntryFields(logEntryEvent, logEntry);
         }
@@ -318,7 +318,7 @@ private class LogEntryEventHandler_Tests {
         insert existingLoggerScenario;
         String newTransactionScenario = 'some new value';
         String newEntryScenario = 'some OTHER new value';
-        System.assertEquals(1, [SELECT COUNT() FROM LoggerScenario__c]);
+        System.Assert.areEqual(1, [SELECT COUNT() FROM LoggerScenario__c]);
         LogEntryEvent__e firstLogEntryEvent = createLogEntryEvent();
         firstLogEntryEvent.EntryScenario__c = existingLoggerScenario.UniqueId__c;
         firstLogEntryEvent.TransactionScenario__c = newTransactionScenario;
@@ -330,23 +330,23 @@ private class LogEntryEventHandler_Tests {
         List<Database.SaveResult> saveResults = LoggerMockDataStore.getEventBus().publishRecords(logEntryEvents);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(logEntryEvents.size(), saveResults.size());
+        System.Assert.areEqual(logEntryEvents.size(), saveResults.size());
         for (Database.SaveResult saveResult : saveResults) {
-            System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
+            System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
         }
-        System.assertEquals(
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
-        System.assertEquals(3, [SELECT COUNT() FROM LoggerScenario__c]);
+        System.Assert.areEqual(3, [SELECT COUNT() FROM LoggerScenario__c]);
         Log__c log = getLog();
-        System.assertEquals(logEntryEvents.size(), log.LogEntries__r.size());
+        System.Assert.areEqual(logEntryEvents.size(), log.LogEntries__r.size());
         for (Integer i = 0; i < logEntryEvents.size(); i++) {
             LogEntryEvent__e logEntryEvent = logEntryEvents.get(i);
             LogEntry__c logEntry = log.LogEntries__r.get(i);
-            System.assertEquals(logEntryEvent.TransactionScenario__c, log.TransactionScenario__r.UniqueId__c);
-            System.assertEquals(logEntryEvent.EntryScenario__c, logEntry.EntryScenario__r.UniqueId__c);
+            System.Assert.areEqual(logEntryEvent.TransactionScenario__c, log.TransactionScenario__r.UniqueId__c);
+            System.Assert.areEqual(logEntryEvent.EntryScenario__c, logEntry.EntryScenario__r.UniqueId__c);
             validateLogFields(logEntryEvent, log);
             validateLogEntryFields(logEntryEvent, logEntry);
         }
@@ -359,25 +359,25 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
         LogEntryEvent__e originalLogEntryEvent = createLogEntryEvent();
-        System.assertNotEquals(null, originalLogEntryEvent.EventUuid);
+        System.Assert.isNotNull(originalLogEntryEvent.EventUuid);
         LogEntryEvent__e duplicateLogEntryEvent = originalLogEntryEvent.clone();
 
         Database.SaveResult firstSaveResult = LoggerMockDataStore.getEventBus().publishRecord(originalLogEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
         List<LogEntry__c> logEntries = [SELECT Id FROM LogEntry__c WHERE EventUuid__c = :originalLogEntryEvent.EventUuid];
-        System.assertEquals(1, logEntries.size());
+        System.Assert.areEqual(1, logEntries.size());
         Database.SaveResult secondSaveResult = LoggerMockDataStore.getEventBus().publishRecord(duplicateLogEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(true, firstSaveResult.isSuccess(), firstSaveResult.getErrors());
-        System.assertEquals(true, secondSaveResult.isSuccess(), secondSaveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(firstSaveResult.isSuccess(), firstSaveResult.getErrors().toString());
+        System.Assert.isTrue(secondSaveResult.isSuccess(), secondSaveResult.getErrors().toString());
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed two times for AFTER_INSERT (once for each LogEntryEvent__e record'
         );
         logEntries = [SELECT Id FROM LogEntry__c WHERE EventUuid__c = :originalLogEntryEvent.EventUuid];
-        System.assertEquals(1, logEntries.size());
+        System.Assert.areEqual(1, logEntries.size());
     }
 
     @IsTest
@@ -399,7 +399,7 @@ private class LogEntryEventHandler_Tests {
         }
 
         Log__c log = getLog();
-        System.assertEquals(currentUser.Id, log.OwnerId);
+        System.Assert.areEqual(currentUser.Id, log.OwnerId);
     }
 
     @IsTest
@@ -421,7 +421,7 @@ private class LogEntryEventHandler_Tests {
         }
 
         Log__c log = getLog();
-        System.assertEquals(automatedProcessUser.Id, log.OwnerId);
+        System.Assert.areEqual(automatedProcessUser.Id, log.OwnerId);
     }
 
     @IsTest
@@ -449,7 +449,7 @@ private class LogEntryEventHandler_Tests {
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
         Log__c log = getLog();
-        System.assertEquals(loggerScenario.OwnerId, log.OwnerId);
+        System.Assert.areEqual(loggerScenario.OwnerId, log.OwnerId);
     }
 
     @IsTest
@@ -482,16 +482,16 @@ private class LogEntryEventHandler_Tests {
             .getAuthSessionProxies(userIds)
             .get(logEntryEvent.LoggedById__c);
         Log__c log = getLog();
-        System.assertEquals(expectedAuthSessionProxy?.LoginHistory.Application, log.LoginApplication__c);
-        System.assertEquals(expectedAuthSessionProxy?.LoginHistory.Browser, log.LoginBrowser__c);
-        System.assertEquals(expectedAuthSessionProxy?.LoginHistoryId, log.LoginHistoryId__c);
-        System.assertEquals(expectedAuthSessionProxy?.LoginHistory.Platform, log.LoginPlatform__c);
-        System.assertEquals(expectedAuthSessionProxy?.LoginType, log.LoginType__c);
-        System.assertEquals(expectedAuthSessionProxy?.LogoutUrl, log.LogoutUrl__c);
-        System.assertEquals(expectedAuthSessionProxy?.Id, log.SessionId__c);
-        System.assertEquals(expectedAuthSessionProxy?.SessionSecurityLevel, log.SessionSecurityLevel__c);
-        System.assertEquals(expectedAuthSessionProxy?.SessionType, log.SessionType__c);
-        System.assertEquals(expectedAuthSessionProxy?.SourceIp, log.SourceIp__c);
+        System.Assert.areEqual(expectedAuthSessionProxy?.LoginHistory.Application, log.LoginApplication__c);
+        System.Assert.areEqual(expectedAuthSessionProxy?.LoginHistory.Browser, log.LoginBrowser__c);
+        System.Assert.areEqual(expectedAuthSessionProxy?.LoginHistoryId, log.LoginHistoryId__c);
+        System.Assert.areEqual(expectedAuthSessionProxy?.LoginHistory.Platform, log.LoginPlatform__c);
+        System.Assert.areEqual(expectedAuthSessionProxy?.LoginType, log.LoginType__c);
+        System.Assert.areEqual(expectedAuthSessionProxy?.LogoutUrl, log.LogoutUrl__c);
+        System.Assert.areEqual(expectedAuthSessionProxy?.Id, log.SessionId__c);
+        System.Assert.areEqual(expectedAuthSessionProxy?.SessionSecurityLevel, log.SessionSecurityLevel__c);
+        System.Assert.areEqual(expectedAuthSessionProxy?.SessionType, log.SessionType__c);
+        System.Assert.areEqual(expectedAuthSessionProxy?.SourceIp, log.SourceIp__c);
     }
 
     @IsTest
@@ -509,11 +509,11 @@ private class LogEntryEventHandler_Tests {
 
         Organization expectedOrganization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
         Log__c log = getLog();
-        System.assertEquals(String.valueOf(expectedOrganization.Id), log.OrganizationId__c);
-        System.assertEquals(expectedOrganization.InstanceName, log.OrganizationInstanceName__c);
-        System.assertEquals(expectedOrganization.Name, log.OrganizationName__c);
-        System.assertEquals(expectedOrganization.NamespacePrefix, log.OrganizationNamespacePrefix__c);
-        System.assertEquals(expectedOrganization.OrganizationType, log.OrganizationType__c);
+        System.Assert.areEqual(String.valueOf(expectedOrganization.Id), log.OrganizationId__c);
+        System.Assert.areEqual(expectedOrganization.InstanceName, log.OrganizationInstanceName__c);
+        System.Assert.areEqual(expectedOrganization.Name, log.OrganizationName__c);
+        System.Assert.areEqual(expectedOrganization.NamespacePrefix, log.OrganizationNamespacePrefix__c);
+        System.Assert.areEqual(expectedOrganization.OrganizationType, log.OrganizationType__c);
     }
 
     @IsTest
@@ -532,12 +532,12 @@ private class LogEntryEventHandler_Tests {
         List<Id> userIds = new List<Id>{ logEntryEvent.LoggedById__c };
         User expectedUser = LoggerEngineDataSelector.getInstance().getUsers(userIds).get(logEntryEvent.LoggedById__c);
         Log__c log = getLog();
-        System.assertEquals(expectedUser.Username, log.LoggedByUsername__c);
-        System.assertEquals(expectedUser.Profile.Name, log.ProfileName__c);
-        System.assertEquals(expectedUser.Profile.UserLicense.LicenseDefinitionKey, log.UserLicenseDefinitionKey__c);
-        System.assertEquals(expectedUser.Profile.UserLicenseId, log.UserLicenseId__c);
-        System.assertEquals(expectedUser.Profile.UserLicense.Name, log.UserLicenseName__c);
-        System.assertEquals(expectedUser.UserRole?.Name, log.UserRoleName__c);
+        System.Assert.areEqual(expectedUser.Username, log.LoggedByUsername__c);
+        System.Assert.areEqual(expectedUser.Profile.Name, log.ProfileName__c);
+        System.Assert.areEqual(expectedUser.Profile.UserLicense.LicenseDefinitionKey, log.UserLicenseDefinitionKey__c);
+        System.Assert.areEqual(expectedUser.Profile.UserLicenseId, log.UserLicenseId__c);
+        System.Assert.areEqual(expectedUser.Profile.UserLicense.Name, log.UserLicenseName__c);
+        System.Assert.areEqual(expectedUser.UserRole?.Name, log.UserRoleName__c);
     }
 
     // TODO - testing topics is tricky. Within the unlocked package, we can test it,
@@ -563,20 +563,20 @@ private class LogEntryEventHandler_Tests {
     //     Database.SaveResult saveResult = EventBus.publish(logEntryEvent);
     //     System.Test.stopTest();
 
-    //     System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
+    //     System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
 
     //     Log__c log = getLog();
-    //     System.assertEquals(1, log.LogEntries__r.size());
+    //     System.Assert.areEqual(1, log.LogEntries__r.size());
     //     LogEntry__c logEntry = log.LogEntries__r.get(0);
 
-    //     System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c);
+    //     System.Assert.areEqual(logEntryEvent.TransactionId__c, log.TransactionId__c);
     //     validateLogFields(logEntryEvent, log);
     //     validateLogEntryFields(logEntryEvent, logEntry);
 
     //     Set<String> tagsSet = new Set<String>(tags);
     //     List<TopicAssignment> topicAssignments = [SELECT Id, EntityId, TopicId, Topic.Name FROM TopicAssignment WHERE EntityId = :logEntry.Id];
     //     for (TopicAssignment topicAssignment : topicAssignments) {
-    //         System.assert(tagsSet.contains(topicAssignment.Topic.Name));
+    //         System.Assert.isTrue(tagsSet.contains(topicAssignment.Topic.Name));
     //     }
     // }
 
@@ -586,32 +586,32 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
-        System.assertEquals(true, LoggerParameter.ENABLE_TAGGING, 'Tagging is not enabled within test context, cannot execute tagging test');
+        System.Assert.isTrue(LoggerParameter.ENABLE_TAGGING, 'Tagging is not enabled within test context, cannot execute tagging test');
         List<String> tags = new List<String>{ 'test-tag-1', 'test-tag-2' };
         LogEntryEvent__e logEntryEvent = createLogEntryEvent();
-        System.assertNotEquals(null, logEntryEvent.EventUuid);
+        System.Assert.isNotNull(logEntryEvent.EventUuid);
         logEntryEvent.Tags__c = String.join(tags, '\n');
 
         Database.SaveResult saveResult = LoggerMockDataStore.getEventBus().publishRecord(logEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
         Log__c log = getLog();
-        System.assertEquals(1, log.LogEntries__r.size());
+        System.Assert.areEqual(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
-        System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c);
+        System.Assert.areEqual(logEntryEvent.TransactionId__c, log.TransactionId__c);
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
         List<LogEntryTag__c> logEntryTags = [SELECT Id, LogEntry__c, Tag__c, Tag__r.Name FROM LogEntryTag__c WHERE LogEntry__c = :logEntry.Id];
-        System.assertEquals(tags.size(), logEntryTags.size());
+        System.Assert.areEqual(tags.size(), logEntryTags.size());
         Set<String> tagsSet = new Set<String>(tags);
         for (LogEntryTag__c logEntryTag : logEntryTags) {
-            System.assert(tagsSet.contains(logEntryTag.Tag__r.Name));
+            System.Assert.isTrue(tagsSet.contains(logEntryTag.Tag__r.Name));
         }
     }
 
@@ -621,34 +621,34 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
-        System.assertEquals(true, LoggerParameter.ENABLE_TAGGING, 'Tagging is not enabled within test context, cannot execute tagging test');
+        System.Assert.isTrue(LoggerParameter.ENABLE_TAGGING, 'Tagging is not enabled within test context, cannot execute tagging test');
         String testTagName = 'Some tag!';
         LoggerTag__c tag = new LoggerTag__c(Name = testTagName);
         insert tag;
         LogEntryEvent__e logEntryEvent = createLogEntryEvent();
-        System.assertNotEquals(null, logEntryEvent.EventUuid);
+        System.Assert.isNotNull(logEntryEvent.EventUuid);
         logEntryEvent.Tags__c = testTagName;
 
         Database.SaveResult saveResult = LoggerMockDataStore.getEventBus().publishRecord(logEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
         Log__c log = getLog();
-        System.assertEquals(1, log.LogEntries__r.size());
+        System.Assert.areEqual(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
-        System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c);
+        System.Assert.areEqual(logEntryEvent.TransactionId__c, log.TransactionId__c);
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
         Integer countOfTagsWithTagName = [SELECT COUNT() FROM LoggerTag__c WHERE Name = :testTagName];
-        System.assertEquals(1, countOfTagsWithTagName);
+        System.Assert.areEqual(1, countOfTagsWithTagName);
         LogEntryTag__c logEntryTag = [SELECT Id, LogEntry__c, Tag__c, Tag__r.Name FROM LogEntryTag__c WHERE LogEntry__c = :logEntry.Id];
-        System.assertEquals(tag.Id, logEntryTag.Tag__c);
-        System.assertEquals(tag.Name, logEntryTag.Tag__r.Name);
+        System.Assert.areEqual(tag.Id, logEntryTag.Tag__c);
+        System.Assert.areEqual(tag.Name, logEntryTag.Tag__r.Name);
     }
 
     @IsTest
@@ -657,7 +657,7 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
-        System.assertEquals(true, LoggerParameter.ENABLE_TAGGING, 'Tagging is not enabled within test context, cannot execute tagging test');
+        System.Assert.isTrue(LoggerParameter.ENABLE_TAGGING, 'Tagging is not enabled within test context, cannot execute tagging test');
         LogEntryEvent__e logEntryEvent = createLogEntryEvent();
         logEntryEvent.Message__c = 'my message';
         logEntryEvent.Tags__c = null;
@@ -674,22 +674,22 @@ private class LogEntryEventHandler_Tests {
         Database.SaveResult saveResult = LoggerMockDataStore.getEventBus().publishRecord(logEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
         Log__c log = getLog();
-        System.assertEquals(1, log.LogEntries__r.size());
+        System.Assert.areEqual(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
-        System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c);
+        System.Assert.areEqual(logEntryEvent.TransactionId__c, log.TransactionId__c);
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
         Integer countOfTagsWithTagName = [SELECT COUNT() FROM LoggerTag__c WHERE Name = :configuredTagName];
-        System.assertEquals(1, countOfTagsWithTagName);
+        System.Assert.areEqual(1, countOfTagsWithTagName);
         LogEntryTag__c logEntryTag = [SELECT Id, LogEntry__c, Tag__c, Tag__r.Name FROM LogEntryTag__c WHERE LogEntry__c = :logEntry.Id];
-        System.assertEquals(configuredTagName, logEntryTag.Tag__r.Name);
+        System.Assert.areEqual(configuredTagName, logEntryTag.Tag__r.Name);
     }
 
     @IsTest
@@ -698,7 +698,7 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
-        System.assertEquals(true, LoggerParameter.ENABLE_TAGGING, 'Tagging is not enabled within test context, cannot execute tagging test');
+        System.Assert.isTrue(LoggerParameter.ENABLE_TAGGING, 'Tagging is not enabled within test context, cannot execute tagging test');
         LogEntryEvent__e logEntryEvent = createLogEntryEvent();
         logEntryEvent.Tags__c = null;
         String configuredTagName = 'CMDT Tag';
@@ -714,22 +714,22 @@ private class LogEntryEventHandler_Tests {
         Database.SaveResult saveResult = LoggerMockDataStore.getEventBus().publishRecord(logEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
         Log__c log = getLog();
-        System.assertEquals(1, log.LogEntries__r.size());
+        System.Assert.areEqual(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
-        System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c);
+        System.Assert.areEqual(logEntryEvent.TransactionId__c, log.TransactionId__c);
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
         Integer countOfTagsWithTagName = [SELECT COUNT() FROM LoggerTag__c WHERE Name = :configuredTagName];
-        System.assertEquals(1, countOfTagsWithTagName);
+        System.Assert.areEqual(1, countOfTagsWithTagName);
         LogEntryTag__c logEntryTag = [SELECT Id, LogEntry__c, Tag__c, Tag__r.Name FROM LogEntryTag__c WHERE LogEntry__c = :logEntry.Id];
-        System.assertEquals(configuredTagName, logEntryTag.Tag__r.Name);
+        System.Assert.areEqual(configuredTagName, logEntryTag.Tag__r.Name);
     }
 
     @IsTest
@@ -738,7 +738,7 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
-        System.assertEquals(true, LoggerParameter.ENABLE_TAGGING, 'Tagging is not enabled within test context, cannot execute tagging test');
+        System.Assert.isTrue(LoggerParameter.ENABLE_TAGGING, 'Tagging is not enabled within test context, cannot execute tagging test');
         String zipCodeRegEx = '(^[0-9]{4}?[0-9]$|^[0-9]{4}?[0-9]-[0-9]{4}$)';
         LogEntryEvent__e logEntryEvent = createLogEntryEvent();
         logEntryEvent.Message__c = '94541';
@@ -756,22 +756,22 @@ private class LogEntryEventHandler_Tests {
         Database.SaveResult saveResult = LoggerMockDataStore.getEventBus().publishRecord(logEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
         Log__c log = getLog();
-        System.assertEquals(1, log.LogEntries__r.size());
+        System.Assert.areEqual(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
-        System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c);
+        System.Assert.areEqual(logEntryEvent.TransactionId__c, log.TransactionId__c);
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
         Integer countOfTagsWithTagName = [SELECT COUNT() FROM LoggerTag__c WHERE Name = :configuredTagName];
-        System.assertEquals(1, countOfTagsWithTagName);
+        System.Assert.areEqual(1, countOfTagsWithTagName);
         LogEntryTag__c logEntryTag = [SELECT Id, LogEntry__c, Tag__c, Tag__r.Name FROM LogEntryTag__c WHERE LogEntry__c = :logEntry.Id];
-        System.assertEquals(configuredTagName, logEntryTag.Tag__r.Name);
+        System.Assert.areEqual(configuredTagName, logEntryTag.Tag__r.Name);
     }
 
     @IsTest
@@ -780,7 +780,7 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
-        System.assertEquals(true, LoggerParameter.ENABLE_TAGGING, 'Tagging is not enabled within test context, cannot execute tagging test');
+        System.Assert.isTrue(LoggerParameter.ENABLE_TAGGING, 'Tagging is not enabled within test context, cannot execute tagging test');
         LogEntryEvent__e logEntryEvent = createLogEntryEvent();
         logEntryEvent.Message__c = 'my message';
         logEntryEvent.Tags__c = null;
@@ -797,22 +797,22 @@ private class LogEntryEventHandler_Tests {
         Database.SaveResult saveResult = LoggerMockDataStore.getEventBus().publishRecord(logEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
         Log__c log = getLog();
-        System.assertEquals(1, log.LogEntries__r.size());
+        System.Assert.areEqual(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
-        System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c);
+        System.Assert.areEqual(logEntryEvent.TransactionId__c, log.TransactionId__c);
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
         Integer countOfTagsWithTagName = [SELECT COUNT() FROM LoggerTag__c WHERE Name = :configuredTagName];
-        System.assertEquals(1, countOfTagsWithTagName);
+        System.Assert.areEqual(1, countOfTagsWithTagName);
         LogEntryTag__c logEntryTag = [SELECT Id, LogEntry__c, Tag__c, Tag__r.Name FROM LogEntryTag__c WHERE LogEntry__c = :logEntry.Id];
-        System.assertEquals(configuredTagName, logEntryTag.Tag__r.Name);
+        System.Assert.areEqual(configuredTagName, logEntryTag.Tag__r.Name);
     }
 
     @IsTest
@@ -824,7 +824,7 @@ private class LogEntryEventHandler_Tests {
         System.Test.setMock(HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(200).setResponseBody(createStatusApiResponseJson()));
         LoggerParameter__mdt mockCallStatusApiParameter = new LoggerParameter__mdt(DeveloperName = 'CallStatusApi', Value__c = 'true');
         LoggerTestConfigurator.setMock(mockCallStatusApiParameter);
-        System.assertEquals(true, LoggerParameter.CALL_STATUS_API);
+        System.Assert.isTrue(LoggerParameter.CALL_STATUS_API);
         LogEntryEvent__e logEntryEvent = createLogEntryEvent();
 
         // TODO System.Test.startTest() & stopTest() are still being used so that the callout in LogEntryEventHandler executes,
@@ -834,17 +834,17 @@ private class LogEntryEventHandler_Tests {
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
         System.Test.stopTest();
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
         Log__c log = getLog();
-        System.assertEquals(1, log.LogEntries__r.size());
+        System.Assert.areEqual(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
-        System.assertEquals(MOCK_RELEASE_NUMBER, log.ApiReleaseNumber__c);
-        System.assertEquals(MOCK_RELEASE_VERSION, log.ApiReleaseVersion__c);
+        System.Assert.areEqual(MOCK_RELEASE_NUMBER, log.ApiReleaseNumber__c);
+        System.Assert.areEqual(MOCK_RELEASE_VERSION, log.ApiReleaseVersion__c);
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
     }
@@ -869,19 +869,19 @@ private class LogEntryEventHandler_Tests {
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
         System.Test.stopTest();
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
-        System.assertEquals(0, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
         Log__c log = getLog();
-        System.assertNotEquals(recentLog.Id, log.Id, log.StartTime__c);
-        System.assertEquals(1, log.LogEntries__r.size());
+        System.Assert.areNotEqual(recentLog.Id, log.Id);
+        System.Assert.areEqual(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
-        System.assertEquals(recentLog.ApiReleaseNumber__c, log.ApiReleaseNumber__c);
-        System.assertEquals(recentLog.ApiReleaseVersion__c, log.ApiReleaseVersion__c);
+        System.Assert.areEqual(recentLog.ApiReleaseNumber__c, log.ApiReleaseNumber__c);
+        System.Assert.areEqual(recentLog.ApiReleaseVersion__c, log.ApiReleaseVersion__c);
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
     }
@@ -904,19 +904,19 @@ private class LogEntryEventHandler_Tests {
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
         System.Test.stopTest();
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
-        System.assertEquals(0, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
         Log__c log = getLog();
-        System.assertEquals(1, log.LogEntries__r.size());
+        System.Assert.areEqual(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
-        System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c);
-        System.assertEquals(null, log.ApiReleaseNumber__c);
-        System.assertEquals(null, log.ApiReleaseVersion__c);
+        System.Assert.areEqual(logEntryEvent.TransactionId__c, log.TransactionId__c);
+        System.Assert.isNull(log.ApiReleaseNumber__c);
+        System.Assert.isNull(log.ApiReleaseVersion__c);
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
     }
@@ -940,25 +940,25 @@ private class LogEntryEventHandler_Tests {
             saveResult = LoggerMockDataStore.getEventBus().publishRecord(logEntryEvent);
             LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
             System.Test.stopTest();
-            System.assert(false, 'Exception expected, this assert should not run');
+            System.Assert.fail('Exception expected, this assert should not run');
         } catch (Exception ex) {
-            System.assertEquals(CalloutException.class.getName(), ex.getTypeName());
+            System.Assert.areEqual(CalloutException.class.getName(), ex.getTypeName());
             String expectedErrorMessage = 'Callout failed for https://api.status.salesforce.com/v1/instances/';
-            System.assert(ex.getMessage().contains(expectedErrorMessage));
+            System.Assert.isTrue(ex.getMessage().contains(expectedErrorMessage));
         }
 
-        System.assertEquals(true, saveResult.isSuccess(), saveResult.getErrors());
-        System.assertEquals(
+        System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        System.Assert.areEqual(
             1,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed one time for AFTER_INSERT'
         );
         Log__c log = getLog();
-        System.assertEquals(1, log.LogEntries__r.size());
+        System.Assert.areEqual(1, log.LogEntries__r.size());
         LogEntry__c logEntry = log.LogEntries__r.get(0);
-        System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c);
-        System.assertEquals(null, log.ApiReleaseNumber__c);
-        System.assertEquals(null, log.ApiReleaseVersion__c);
+        System.Assert.areEqual(logEntryEvent.TransactionId__c, log.TransactionId__c);
+        System.Assert.isNull(log.ApiReleaseNumber__c);
+        System.Assert.isNull(log.ApiReleaseVersion__c);
         validateLogFields(logEntryEvent, log);
         validateLogEntryFields(logEntryEvent, logEntry);
     }
@@ -1149,274 +1149,306 @@ private class LogEntryEventHandler_Tests {
 
         Id logOwnerId = logEntryEvent.LoggedById__c == null ? UserInfo.getUserId() : logEntryEvent.LoggedById__c;
 
-        System.assertEquals(logEntryEvent.ApiVersion__c, log.ApiVersion__c, 'log.ApiVersion__c was not properly set');
-        System.assertEquals(logEntryEvent.Locale__c, log.Locale__c, 'log.Locale__c was not properly set');
-        System.assertEquals(logEntryEvent.LoggedById__c, log.LoggedBy__c, 'log.LoggedBy__c was not properly set');
-        System.assertEquals(logEntryEvent.LoggedByUsername__c, log.LoggedByUsername__c, 'log.LoggedByUsername__c was not properly set');
-        System.assertEquals(logEntryEvent.LoggerVersionNumber__c, log.LoggerVersionNumber__c, 'log.LoggerVersionNumber__c was not properly set');
-        System.assertEquals(logEntryEvent.LoginDomain__c, log.LoginDomain__c, 'log.LoginDomain__c was not properly set');
-        System.assertEquals(logEntryEvent.LoginHistoryId__c, log.LoginHistoryId__c, 'log.LoginHistoryId__c was not properly set');
-        System.assertEquals(logEntryEvent.LoginType__c, log.LoginType__c, 'log.LoginType__c was not properly set');
-        System.assertEquals(logEntryEvent.LogoutUrl__c, log.LogoutUrl__c, 'log.LogoutUrl__c was not properly set');
-        System.assertEquals(logEntryEvent.NetworkId__c, log.NetworkId__c, 'log.NetworkId__c was not properly set');
-        System.assertEquals(logOwnerId, log.OwnerId, 'log.OwnerId was not properly set');
-        System.assertEquals(logEntryEvent.ParentLogTransactionId__c, log.ParentLogTransactionId__c, 'log.ParentLogTransactionId__c was not properly set');
-        System.assertEquals(logEntryEvent.ProfileId__c, log.ProfileId__c, 'log.ProfileId__c was not properly set');
-        System.assertEquals(logEntryEvent.ProfileName__c, log.ProfileName__c, 'log.ProfileName__c was not properly set');
-        System.assertEquals(logEntryEvent.RequestId__c, log.RequestId__c, 'log.RequestId__c was not properly set');
-        System.assertEquals(logEntryEvent.SessionId__c, log.SessionId__c, 'log.SessionId__c was not properly set');
-        System.assertEquals(logEntryEvent.SessionId__c, log.SessionId__c, 'log.SessionId__c was not properly set');
-        System.assertEquals(logEntryEvent.SessionSecurityLevel__c, log.SessionSecurityLevel__c, 'log.SessionSecurityLevel__c was not properly set');
-        System.assertEquals(logEntryEvent.SessionType__c, log.SessionType__c, 'log.SessionType__c was not properly set');
-        System.assertEquals(logEntryEvent.SourceIp__c, log.SourceIp__c, 'log.SourceIp__c was not properly set');
-        System.assertEquals(logEntryEvent.SystemMode__c, log.SystemMode__c, 'log.SystemMode__c was not properly set');
-        System.assertEquals(logEntryEvent.ThemeDisplayed__c, log.ThemeDisplayed__c, 'log.ThemeDisplayed__c was not properly set');
-        System.assertEquals(logEntryEvent.TimeZoneId__c, log.TimeZoneId__c, 'log.TimeZoneId__c was not properly set');
-        System.assertEquals(logEntryEvent.TimeZoneName__c, log.TimeZoneName__c, 'log.TimeZoneName__c was not properly set');
-        System.assertEquals(logEntryEvent.TransactionId__c, log.TransactionId__c, 'log.TransactionId__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.ApiVersion__c, log.ApiVersion__c, 'log.ApiVersion__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.Locale__c, log.Locale__c, 'log.Locale__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LoggedById__c, log.LoggedBy__c, 'log.LoggedBy__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LoggedByUsername__c, log.LoggedByUsername__c, 'log.LoggedByUsername__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LoggerVersionNumber__c, log.LoggerVersionNumber__c, 'log.LoggerVersionNumber__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LoginDomain__c, log.LoginDomain__c, 'log.LoginDomain__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LoginHistoryId__c, log.LoginHistoryId__c, 'log.LoginHistoryId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LoginType__c, log.LoginType__c, 'log.LoginType__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LogoutUrl__c, log.LogoutUrl__c, 'log.LogoutUrl__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.NetworkId__c, log.NetworkId__c, 'log.NetworkId__c was not properly set');
+        System.Assert.areEqual(logOwnerId, log.OwnerId, 'log.OwnerId was not properly set');
+        System.Assert.areEqual(logEntryEvent.ParentLogTransactionId__c, log.ParentLogTransactionId__c, 'log.ParentLogTransactionId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.ProfileId__c, log.ProfileId__c, 'log.ProfileId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.ProfileName__c, log.ProfileName__c, 'log.ProfileName__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.RequestId__c, log.RequestId__c, 'log.RequestId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.SessionId__c, log.SessionId__c, 'log.SessionId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.SessionId__c, log.SessionId__c, 'log.SessionId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.SessionSecurityLevel__c, log.SessionSecurityLevel__c, 'log.SessionSecurityLevel__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.SessionType__c, log.SessionType__c, 'log.SessionType__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.SourceIp__c, log.SourceIp__c, 'log.SourceIp__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.SystemMode__c, log.SystemMode__c, 'log.SystemMode__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.ThemeDisplayed__c, log.ThemeDisplayed__c, 'log.ThemeDisplayed__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.TimeZoneId__c, log.TimeZoneId__c, 'log.TimeZoneId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.TimeZoneName__c, log.TimeZoneName__c, 'log.TimeZoneName__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.TransactionId__c, log.TransactionId__c, 'log.TransactionId__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.TransactionScenario__c?.left(Schema.LoggerScenario__c.Name.getDescribe().getLength()),
             log.TransactionScenario__r?.Name,
             'log.TransactionScenario__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.TransactionScenario__c,
             log.TransactionScenario__r.UniqueId__c,
             'log.TransactionScenario__r.UniqueId__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.UserLoggingLevel__c, log.UserLoggingLevel__c, 'log.UserLoggingLevel__c was not properly set');
-        System.assertEquals(logEntryEvent.UserLoggingLevelOrdinal__c, log.UserLoggingLevelOrdinal__c, 'log.UserLoggingLevelOrdinal__c was not properly set');
-        // System.assertEquals(currentUser.UserRoleId, log.UserRoleId__c, 'log.UserRoleId__c was not properly set');
-        // System.assertEquals(currentUser.UserRoleId == null ? null : currentUser.UserRole.Name, log.UserRoleName__c, 'log.UserRoleName__c was not properly set');
-        System.assertEquals(logEntryEvent.UserType__c, log.UserType__c, 'log.UserType__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.UserLoggingLevel__c, log.UserLoggingLevel__c, 'log.UserLoggingLevel__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.UserLoggingLevelOrdinal__c, log.UserLoggingLevelOrdinal__c, 'log.UserLoggingLevelOrdinal__c was not properly set');
+        // System.Assert.areEqual(currentUser.UserRoleId, log.UserRoleId__c, 'log.UserRoleId__c was not properly set');
+        // System.Assert.areEqual(currentUser.UserRoleId == null ? null : currentUser.UserRole.Name, log.UserRoleName__c, 'log.UserRoleName__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.UserType__c, log.UserType__c, 'log.UserType__c was not properly set');
 
         // Org fields
-        System.assertEquals(logEntryEvent.OrganizationDomainUrl__c, log.OrganizationDomainUrl__c, 'log.OrganizationDomainUrl__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.OrganizationDomainUrl__c, log.OrganizationDomainUrl__c, 'log.OrganizationDomainUrl__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.OrganizationEnvironmentType__c,
             log.OrganizationEnvironmentType__c,
             'log.OrganizationEnvironmentType__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.OrganizationId__c, log.OrganizationId__c, 'log.OrganizationId__c was not properly set');
-        System.assertEquals(logEntryEvent.OrganizationInstanceName__c, log.OrganizationInstanceName__c, 'log.OrganizationInstanceName__c was not properly set');
-        System.assertEquals(logEntryEvent.OrganizationName__c, log.OrganizationName__c, 'log.OrganizationName__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.OrganizationId__c, log.OrganizationId__c, 'log.OrganizationId__c was not properly set');
+        System.Assert.areEqual(
+            logEntryEvent.OrganizationInstanceName__c,
+            log.OrganizationInstanceName__c,
+            'log.OrganizationInstanceName__c was not properly set'
+        );
+        System.Assert.areEqual(logEntryEvent.OrganizationName__c, log.OrganizationName__c, 'log.OrganizationName__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.OrganizationNamespacePrefix__c,
             log.OrganizationNamespacePrefix__c,
             'log.OrganizationNamespacePrefix__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.OrganizationType__c, log.OrganizationType__c, 'log.OrganizationType__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.OrganizationType__c, log.OrganizationType__c, 'log.OrganizationType__c was not properly set');
 
         // Profile fields
-        System.assertEquals(logEntryEvent.UserLicenseDefinitionKey__c, log.UserLicenseDefinitionKey__c, 'log.UserLicenseDefinitionKey__c was not properly set');
-        System.assertEquals(logEntryEvent.UserLicenseId__c, log.UserLicenseId__c, 'log.UserLicenseId__c was not properly set');
-        System.assertEquals(logEntryEvent.UserLicenseName__c, log.UserLicenseName__c, 'log.UserLicenseName__c was not properly set');
+        System.Assert.areEqual(
+            logEntryEvent.UserLicenseDefinitionKey__c,
+            log.UserLicenseDefinitionKey__c,
+            'log.UserLicenseDefinitionKey__c was not properly set'
+        );
+        System.Assert.areEqual(logEntryEvent.UserLicenseId__c, log.UserLicenseId__c, 'log.UserLicenseId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.UserLicenseName__c, log.UserLicenseName__c, 'log.UserLicenseName__c was not properly set');
     }
 
     private static void validateLogEntryFields(LogEntryEvent__e logEntryEvent, LogEntry__c logEntry) {
-        System.assertEquals(logEntryEvent.ComponentType__c, logEntry.ComponentType__c, 'logEntry.ComponentType__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.ComponentType__c, logEntry.ComponentType__c, 'logEntry.ComponentType__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.DatabaseResultCollectionSize__c,
             logEntry.DatabaseResultCollectionSize__c,
             'logEntry.DatabaseResultCollectionSize__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.DatabaseResultCollectionType__c,
             logEntry.DatabaseResultCollectionType__c,
             'logEntry.DatabaseResultCollectionType__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.DatabaseResultJson__c, logEntry.DatabaseResultJson__c, 'logEntry.DatabaseResultJson__c was not properly set');
-        System.assertEquals(logEntryEvent.DatabaseResultType__c, logEntry.DatabaseResultType__c, 'logEntry.DatabaseResultType__c was not properly set');
-        System.assertEquals(logEntryEvent.EpochTimestamp__c, logEntry.EpochTimestamp__c, 'logEntry.EpochTimestamp__c was not properly set');
-        System.assertEquals(logEntryEvent.ExceptionStackTrace__c, logEntry.ExceptionStackTrace__c, 'logEntry.ExceptionStackTrace__c was not properly set');
-        System.assertEquals(logEntryEvent.ExceptionType__c, logEntry.ExceptionType__c, 'logEntry.ExceptionType__c was not properly set');
-        System.assertEquals(logEntryEvent.HttpRequestBody__c, logEntry.HttpRequestBody__c, 'logEntry.HttpRequestBody__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.DatabaseResultJson__c, logEntry.DatabaseResultJson__c, 'logEntry.DatabaseResultJson__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.DatabaseResultType__c, logEntry.DatabaseResultType__c, 'logEntry.DatabaseResultType__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.EpochTimestamp__c, logEntry.EpochTimestamp__c, 'logEntry.EpochTimestamp__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.ExceptionStackTrace__c, logEntry.ExceptionStackTrace__c, 'logEntry.ExceptionStackTrace__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.ExceptionType__c, logEntry.ExceptionType__c, 'logEntry.ExceptionType__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.HttpRequestBody__c, logEntry.HttpRequestBody__c, 'logEntry.HttpRequestBody__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.HttpRequestBodyMasked__c,
             logEntry.HttpRequestBodyMasked__c,
             'logEntry.HttpRequestBodyMasked__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.HttpRequestCompressed__c,
             logEntry.HttpRequestCompressed__c,
             'logEntry.HttpRequestCompressed__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.HttpRequestEndpoint__c, logEntry.HttpRequestEndpoint__c, 'logEntry.HttpRequestEndpoint__c was not properly set');
-        System.assertEquals(logEntryEvent.HttpRequestMethod__c, logEntry.HttpRequestMethod__c, 'logEntry.HttpRequestMethod__c was not properly set');
-        System.assertEquals(logEntryEvent.HttpResponseBody__c, logEntry.HttpResponseBody__c, 'logEntry.HttpResponseBody__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.HttpRequestEndpoint__c, logEntry.HttpRequestEndpoint__c, 'logEntry.HttpRequestEndpoint__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.HttpRequestMethod__c, logEntry.HttpRequestMethod__c, 'logEntry.HttpRequestMethod__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.HttpResponseBody__c, logEntry.HttpResponseBody__c, 'logEntry.HttpResponseBody__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.HttpResponseBodyMasked__c,
             logEntry.HttpResponseBodyMasked__c,
             'logEntry.HttpResponseBodyMasked__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.HttpResponseHeaderKeys__c,
             logEntry.HttpResponseHeaderKeys__c,
             'logEntry.HttpResponseHeaderKeys__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.HttpResponseStatus__c, logEntry.HttpResponseStatus__c, 'logEntry.HttpResponseStatus__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.HttpResponseStatus__c, logEntry.HttpResponseStatus__c, 'logEntry.HttpResponseStatus__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.HttpResponseStatusCode__c,
             logEntry.HttpResponseStatusCode__c,
             'logEntry.HttpResponseStatusCode__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsAggregateQueriesMax__c,
             logEntry.LimitsAggregateQueriesMax__c,
             'logEntry.LimitsAggregateQueriesMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsAggregateQueriesUsed__c,
             logEntry.LimitsAggregateQueriesUsed__c,
             'logEntry.LimitsAggregateQueriesUsed__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.LimitsAsyncCallsMax__c, logEntry.LimitsAsyncCallsMax__c, 'logEntry.LimitsAsyncCallsMax__c was not properly set');
-        System.assertEquals(logEntryEvent.LimitsAsyncCallsUsed__c, logEntry.LimitsAsyncCallsUsed__c, 'logEntry.LimitsAsyncCallsUsed__c was not properly set');
-        System.assertEquals(logEntryEvent.LimitsCalloutsMax__c, logEntry.LimitsCalloutsMax__c, 'logEntry.LimitsCalloutsMax__c was not properly set');
-        System.assertEquals(logEntryEvent.LimitsCalloutsUsed__c, logEntry.LimitsCalloutsUsed__c, 'logEntry.LimitsCalloutsUsed__c was not properly set');
-        System.assertEquals(logEntryEvent.LimitsCpuTimeMax__c, logEntry.LimitsCpuTimeMax__c, 'logEntry.LimitsCpuTimeMax__c was not properly set');
-        System.assertEquals(logEntryEvent.LimitsCpuTimeUsed__c, logEntry.LimitsCpuTimeUsed__c, 'logEntry.LimitsCpuTimeUsed__c was not properly set');
-        System.assertEquals(logEntryEvent.LimitsDmlRowsMax__c, logEntry.LimitsDmlRowsMax__c, 'logEntry.LimitsDmlRowsMax__c was not properly set');
-        System.assertEquals(logEntryEvent.LimitsDmlRowsUsed__c, logEntry.LimitsDmlRowsUsed__c, 'logEntry.LimitsDmlRowsUsed__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.LimitsAsyncCallsMax__c, logEntry.LimitsAsyncCallsMax__c, 'logEntry.LimitsAsyncCallsMax__c was not properly set');
+        System.Assert.areEqual(
+            logEntryEvent.LimitsAsyncCallsUsed__c,
+            logEntry.LimitsAsyncCallsUsed__c,
+            'logEntry.LimitsAsyncCallsUsed__c was not properly set'
+        );
+        System.Assert.areEqual(logEntryEvent.LimitsCalloutsMax__c, logEntry.LimitsCalloutsMax__c, 'logEntry.LimitsCalloutsMax__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LimitsCalloutsUsed__c, logEntry.LimitsCalloutsUsed__c, 'logEntry.LimitsCalloutsUsed__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LimitsCpuTimeMax__c, logEntry.LimitsCpuTimeMax__c, 'logEntry.LimitsCpuTimeMax__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LimitsCpuTimeUsed__c, logEntry.LimitsCpuTimeUsed__c, 'logEntry.LimitsCpuTimeUsed__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LimitsDmlRowsMax__c, logEntry.LimitsDmlRowsMax__c, 'logEntry.LimitsDmlRowsMax__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LimitsDmlRowsUsed__c, logEntry.LimitsDmlRowsUsed__c, 'logEntry.LimitsDmlRowsUsed__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.LimitsDmlStatementsMax__c,
             logEntry.LimitsDmlStatementsMax__c,
             'logEntry.LimitsDmlStatementsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsDmlStatementsUsed__c,
             logEntry.LimitsDmlStatementsUsed__c,
             'logEntry.LimitsDmlStatementsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsEmailInvocationsMax__c,
             logEntry.LimitsEmailInvocationsMax__c,
             'logEntry.LimitsEmailInvocationsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsEmailInvocationsUsed__c,
             logEntry.LimitsEmailInvocationsUsed__c,
             'logEntry.LimitsEmailInvocationsUsed__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.LimitsFutureCallsMax__c, logEntry.LimitsFutureCallsMax__c, 'logEntry.LimitsFutureCallsMax__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(
+            logEntryEvent.LimitsFutureCallsMax__c,
+            logEntry.LimitsFutureCallsMax__c,
+            'logEntry.LimitsFutureCallsMax__c was not properly set'
+        );
+        System.Assert.areEqual(
             logEntryEvent.LimitsFutureCallsUsed__c,
             logEntry.LimitsFutureCallsUsed__c,
             'logEntry.LimitsFutureCallsUsed__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.LimitsHeapSizeMax__c, logEntry.LimitsHeapSizeMax__c, 'logEntry.LimitsHeapSizeMax__c was not properly set');
-        System.assertEquals(logEntryEvent.LimitsHeapSizeUsed__c, logEntry.LimitsHeapSizeUsed__c, 'logEntry.LimitsHeapSizeUsed__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.LimitsHeapSizeMax__c, logEntry.LimitsHeapSizeMax__c, 'logEntry.LimitsHeapSizeMax__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LimitsHeapSizeUsed__c, logEntry.LimitsHeapSizeUsed__c, 'logEntry.LimitsHeapSizeUsed__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.LimitsMobilePushApexCallsMax__c,
             logEntry.LimitsMobilePushApexCallsMax__c,
             'logEntry.LimitsMobilePushApexCallsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsMobilePushApexCallsUsed__c,
             logEntry.LimitsMobilePushApexCallsUsed__c,
             'logEntry.LimitsMobilePushApexCallsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsPublishImmediateDmlStatementsMax__c,
             logEntry.LimitsPublishImmediateDmlStatementsMax__c,
             'logEntry.LimitsPublishImmediateDmlStatementsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsPublishImmediateDmlStatementsUsed__c,
             logEntry.LimitsPublishImmediateDmlStatementsUsed__c,
             'logEntry.LimitsPublishImmediateDmlStatementsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsQueueableJobsMax__c,
             logEntry.LimitsQueueableJobsMax__c,
             'logEntry.LimitsQueueableJobsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsQueueableJobsUsed__c,
             logEntry.LimitsQueueableJobsUsed__c,
             'logEntry.LimitsQueueableJobsUsed__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.LimitsSoqlQueriesMax__c, logEntry.LimitsSoqlQueriesMax__c, 'logEntry.LimitsSoqlQueriesMax__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(
+            logEntryEvent.LimitsSoqlQueriesMax__c,
+            logEntry.LimitsSoqlQueriesMax__c,
+            'logEntry.LimitsSoqlQueriesMax__c was not properly set'
+        );
+        System.Assert.areEqual(
             logEntryEvent.LimitsSoqlQueriesUsed__c,
             logEntry.LimitsSoqlQueriesUsed__c,
             'logEntry.LimitsSoqlQueriesUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsSoqlQueryLocatorRowsMax__c,
             logEntry.LimitsSoqlQueryLocatorRowsMax__c,
             'logEntry.LimitsSoqlQueryLocatorRowsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsSoqlQueryLocatorRowsUsed__c,
             logEntry.LimitsSoqlQueryLocatorRowsUsed__c,
             'logEntry.LimitsSoqlQueryLocatorRowsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsSoqlQueryRowsMax__c,
             logEntry.LimitsSoqlQueryRowsMax__c,
             'logEntry.LimitsSoqlQueryRowsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsSoqlQueryRowsUsed__c,
             logEntry.LimitsSoqlQueryRowsUsed__c,
             'logEntry.LimitsSoqlQueryRowsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsSoslSearchesUsed__c,
             logEntry.LimitsSoslSearchesUsed__c,
             'logEntry.LimitsSoslSearchesUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntryEvent.LimitsSoslSearchesMax__c,
             logEntry.LimitsSoslSearchesMax__c,
             'logEntry.LimitsSoslSearchesMax__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.LoggingLevel__c, logEntry.LoggingLevel__c, 'logEntry.LoggingLevel__c was not properly set');
-        System.assertEquals(logEntryEvent.LoggingLevelOrdinal__c, logEntry.LoggingLevelOrdinal__c, 'logEntry.LoggingLevelOrdinal__c was not properly set');
-        System.assertEquals(logEntryEvent.Message__c, logEntry.Message__c, 'logEntry.Message__c was not properly set');
-        System.assertEquals(logEntryEvent.MessageTruncated__c, logEntry.MessageTruncated__c, 'logEntry.MessageTruncated__c was not properly set');
-        System.assertEquals(logEntry.Id, logEntry.Name, 'logEntry.Name was not properly set');
-        System.assertEquals(logEntryEvent.OriginType__c, logEntry.OriginType__c, 'logEntry.OriginType__c was not properly set');
-        System.assertEquals(logEntryEvent.OriginLocation__c, logEntry.OriginLocation__c, 'logEntry.OriginLocation__c was not properly set');
-        System.assertEquals(logEntryEvent.RecordCollectionSize__c, logEntry.RecordCollectionSize__c, 'logEntry.RecordCollectionSize__c was not properly set');
-        System.assertEquals(logEntryEvent.RecordCollectionType__c, logEntry.RecordCollectionType__c, 'logEntry.RecordCollectionType__c was not properly set');
-        System.assertEquals(logEntryEvent.RecordId__c, logEntry.RecordId__c, 'logEntry.RecordId__c was not properly set');
-        System.assertEquals(logEntryEvent.RecordJson__c, logEntry.RecordJson__c, 'logEntry.RecordJson__c was not properly set');
-        System.assertEquals(logEntryEvent.RecordJsonMasked__c, logEntry.RecordJsonMasked__c, 'logEntry.RecordJsonMasked__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.LoggingLevel__c, logEntry.LoggingLevel__c, 'logEntry.LoggingLevel__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.LoggingLevelOrdinal__c, logEntry.LoggingLevelOrdinal__c, 'logEntry.LoggingLevelOrdinal__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.Message__c, logEntry.Message__c, 'logEntry.Message__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.MessageTruncated__c, logEntry.MessageTruncated__c, 'logEntry.MessageTruncated__c was not properly set');
+        System.Assert.areEqual(logEntry.Id, logEntry.Name, 'logEntry.Name was not properly set');
+        System.Assert.areEqual(logEntryEvent.OriginType__c, logEntry.OriginType__c, 'logEntry.OriginType__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.OriginLocation__c, logEntry.OriginLocation__c, 'logEntry.OriginLocation__c was not properly set');
+        System.Assert.areEqual(
+            logEntryEvent.RecordCollectionSize__c,
+            logEntry.RecordCollectionSize__c,
+            'logEntry.RecordCollectionSize__c was not properly set'
+        );
+        System.Assert.areEqual(
+            logEntryEvent.RecordCollectionType__c,
+            logEntry.RecordCollectionType__c,
+            'logEntry.RecordCollectionType__c was not properly set'
+        );
+        System.Assert.areEqual(logEntryEvent.RecordId__c, logEntry.RecordId__c, 'logEntry.RecordId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.RecordJson__c, logEntry.RecordJson__c, 'logEntry.RecordJson__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.RecordJsonMasked__c, logEntry.RecordJsonMasked__c, 'logEntry.RecordJsonMasked__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.RecordSObjectClassification__c,
             logEntry.RecordSObjectClassification__c,
             'logEntry.RecordSObjectClassification__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.RecordSObjectType__c, logEntry.RecordSObjectType__c, 'logEntry.RecordSObjectType__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.RecordSObjectType__c, logEntry.RecordSObjectType__c, 'logEntry.RecordSObjectType__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.RecordSObjectTypeNamespace__c,
             logEntry.RecordSObjectTypeNamespace__c,
             'logEntry.RecordSObjectTypeNamespace__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.RecordId__c, logEntry.RecordId__c, 'logEntry.RecordId__c was not properly set');
-        System.assertEquals(logEntryEvent.RecordJson__c, logEntry.RecordJson__c, 'logEntry.RecordJson__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.RecordId__c, logEntry.RecordId__c, 'logEntry.RecordId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.RecordJson__c, logEntry.RecordJson__c, 'logEntry.RecordJson__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.RecordSObjectClassification__c,
             logEntry.RecordSObjectClassification__c,
             'logEntry.RecordSObjectClassification__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.RecordSObjectType__c, logEntry.RecordSObjectType__c, 'logEntry.RecordSObjectType__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.RecordSObjectType__c, logEntry.RecordSObjectType__c, 'logEntry.RecordSObjectType__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.RecordSObjectTypeNamespace__c,
             logEntry.RecordSObjectTypeNamespace__c,
             'logEntry.RecordSObjectTypeNamespace__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.StackTrace__c, logEntry.StackTrace__c, 'logEntry.StackTrace__c was not properly set');
-        System.assertEquals(logEntryEvent.Timestamp__c, logEntry.Timestamp__c, 'logEntry.Timestamp__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntryEvent.StackTrace__c, logEntry.StackTrace__c, 'logEntry.StackTrace__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.Timestamp__c, logEntry.Timestamp__c, 'logEntry.Timestamp__c was not properly set');
+        System.Assert.areEqual(
             logEntryEvent.TransactionEntryNumber__c,
             logEntry.TransactionEntryNumber__c,
             'logEntry.TransactionEntryNumber__c was not properly set'
         );
-        System.assertEquals(logEntryEvent.TriggerIsExecuting__c, logEntry.TriggerIsExecuting__c, 'logEntry.TriggerIsExecuting__c was not properly set');
-        System.assertEquals(logEntryEvent.TriggerOperationType__c, logEntry.TriggerOperationType__c, 'logEntry.TriggerOperationType__c was not properly set');
-        System.assertEquals(logEntryEvent.TriggerSObjectType__c, logEntry.TriggerSObjectType__c, 'logEntry.TriggerSObjectType__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.TriggerIsExecuting__c, logEntry.TriggerIsExecuting__c, 'logEntry.TriggerIsExecuting__c was not properly set');
+        System.Assert.areEqual(
+            logEntryEvent.TriggerOperationType__c,
+            logEntry.TriggerOperationType__c,
+            'logEntry.TriggerOperationType__c was not properly set'
+        );
+        System.Assert.areEqual(logEntryEvent.TriggerSObjectType__c, logEntry.TriggerSObjectType__c, 'logEntry.TriggerSObjectType__c was not properly set');
     }
 }

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -387,7 +387,7 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
         User automatedProcessUser = [SELECT Id, TimeZoneSidKey FROM User WHERE Name = 'Automated Process' AND Profile.Name = NULL];
-        User currentUser = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User currentUser = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         LoggerSettings__c currentUserSettings = Logger.getUserSettings(currentUser);
         currentUserSettings.IsAnonymousModeEnabled__c = false;
         insert currentUserSettings;
@@ -409,7 +409,7 @@ private class LogEntryEventHandler_Tests {
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
         LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
         User automatedProcessUser = [SELECT Id, TimeZoneSidKey FROM User WHERE Name = 'Automated Process' AND Profile.Name = NULL];
-        User currentUser = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User currentUser = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         LoggerSettings__c currentUserSettings = Logger.getUserSettings(currentUser);
         currentUserSettings.IsAnonymousModeEnabled__c = true;
         insert currentUserSettings;
@@ -971,13 +971,13 @@ private class LogEntryEventHandler_Tests {
             .populateAllFields()
             .getRecord();
         logEntryEvent.ImpersonatedById__c = null;
-        logEntryEvent.LoggedById__c = UserInfo.getUserId();
+        logEntryEvent.LoggedById__c = System.UserInfo.getUserId();
         logEntryEvent.LoggingLevel__c = LoggingLevel.INFO.name();
         logEntryEvent.LoggingLevelOrdinal__c = LoggingLevel.INFO.ordinal();
-        logEntryEvent.ProfileId__c = UserInfo.getProfileId();
+        logEntryEvent.ProfileId__c = System.UserInfo.getProfileId();
         logEntryEvent.RecordCollectionSize__c = 1;
         logEntryEvent.RecordCollectionType__c = 'Single';
-        logEntryEvent.RecordId__c = UserInfo.getUserId();
+        logEntryEvent.RecordId__c = System.UserInfo.getUserId();
         logEntryEvent.TimestampString__c = String.valueOf(logEntryEvent.Timestamp__c.getTime());
         logEntryEvent.UserLoggingLevel__c = LoggingLevel.INFO.name();
         logEntryEvent.UserLoggingLevelOrdinal__c = LoggingLevel.INFO.ordinal();
@@ -1147,7 +1147,7 @@ private class LogEntryEventHandler_Tests {
             orgEnvironmentType = 'Production';
         }
 
-        Id logOwnerId = logEntryEvent.LoggedById__c == null ? UserInfo.getUserId() : logEntryEvent.LoggedById__c;
+        Id logOwnerId = logEntryEvent.LoggedById__c == null ? System.UserInfo.getUserId() : logEntryEvent.LoggedById__c;
 
         System.Assert.areEqual(logEntryEvent.ApiVersion__c, log.ApiVersion__c, 'log.ApiVersion__c was not properly set');
         System.Assert.areEqual(logEntryEvent.Locale__c, log.Locale__c, 'log.Locale__c was not properly set');

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventStreamController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventStreamController_Tests.cls
@@ -16,17 +16,17 @@ private class LogEntryEventStreamController_Tests {
         List<String> displayFields = LogEntryEventStreamController.getDatatableDisplayFields();
 
         System.Assert.areEqual(mockDisplayFields.size(), displayFields.size(), 'fields count mismatch');
-        for (String aField : mockDisplayFields) {
-            System.Assert.areEqual(true, displayFields.contains(aField), 'field not found');
+        for (String fieldName : mockDisplayFields) {
+            System.Assert.areEqual(true, displayFields.contains(fieldName), 'field not found: ' + fieldName);
         }
     }
     @isTest
     static void it_should_return_default_fields_when_List_of_Fields_not_configured_in_logParameters() {
         List<String> displayFields = LogEntryEventStreamController.getDatatableDisplayFields();
 
-        System.assertEquals(LogEntryEventStreamController.DEFAULT_DISPLAY_FIELDS.size(), displayFields.size(), 'fields count mismatch');
-        for (String aField : LogEntryEventStreamController.DEFAULT_DISPLAY_FIELDS) {
-            System.assertEquals(true, displayFields.contains(aField), 'field not found');
+        System.Assert.areEqual(LogEntryEventStreamController.DEFAULT_DISPLAY_FIELDS.size(), displayFields.size(), 'fields count mismatch');
+        for (String fieldName : LogEntryEventStreamController.DEFAULT_DISPLAY_FIELDS) {
+            System.Assert.isTrue(displayFields.contains(fieldName), 'field not found: ' + fieldName);
         }
     }
 }

--- a/nebula-logger/core/tests/log-management/classes/LogEntryFieldSetPicklist_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryFieldSetPicklist_Tests.cls
@@ -13,7 +13,7 @@ private class LogEntryFieldSetPicklist_Tests {
         LogEntryFieldSetPicklist instance = new LogEntryFieldSetPicklist();
         System.Test.stopTest();
 
-        System.assertEquals(null, instance.getDefaultValue());
+        System.Assert.isNull(instance.getDefaultValue());
     }
 
     @IsTest
@@ -25,15 +25,15 @@ private class LogEntryFieldSetPicklist_Tests {
         System.Test.stopTest();
 
         List<VisualEditor.DataRow> dataRows = instance.getValues().getDataRows();
-        System.assertEquals(expectedFieldSets.size(), dataRows.size());
+        System.Assert.areEqual(expectedFieldSets.size(), dataRows.size());
         for (VisualEditor.DataRow dataRow : dataRows) {
             String fieldSetName = (String) dataRow.getValue();
             String fieldSetLabel = (String) dataRow.getLabel();
 
-            System.assert(expectedFieldSets.containsKey(fieldSetName));
+            System.Assert.isTrue(expectedFieldSets.containsKey(fieldSetName));
 
             Schema.FieldSet fieldSet = expectedFieldSets.get(fieldSetName);
-            System.assertEquals(fieldSet.getLabel(), fieldSetLabel);
+            System.Assert.areEqual(fieldSet.getLabel(), fieldSetLabel);
         }
     }
 }

--- a/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
@@ -16,7 +16,7 @@ private class LogEntryHandler_Tests {
 
     @IsTest
     static void it_should_return_the_logEntry_sobjectType() {
-        System.assertEquals(Schema.LogEntry__c.SObjectType, new LogEntryHandler().getSObjectType());
+        System.Assert.areEqual(Schema.LogEntry__c.SObjectType, new LogEntryHandler().getSObjectType());
     }
 
     @IsTest
@@ -29,7 +29,11 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(0, LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(), 'Handler class should not have executed');
+        System.Assert.areEqual(
+            0,
+            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
+            'Handler class should not have executed'
+        );
     }
 
     @IsTest
@@ -39,13 +43,13 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         logEntry = [SELECT Id, RecordId__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertEquals(null, logEntry.RecordId__c);
+        System.Assert.isNull(logEntry.RecordId__c);
     }
 
     @IsTest
@@ -56,14 +60,14 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         logEntry = [SELECT Id, RecordId__c, RecordName__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertEquals(currentUser.Id, logEntry.RecordId__c);
-        System.assertEquals(currentUser.Username, logEntry.RecordName__c);
+        System.Assert.areEqual(currentUser.Id, logEntry.RecordId__c);
+        System.Assert.areEqual(currentUser.Username, logEntry.RecordName__c);
     }
 
     @IsTest
@@ -74,14 +78,14 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         logEntry = [SELECT Id, RecordId__c, RecordName__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertEquals(currentProfile.Id, logEntry.RecordId__c);
-        System.assertEquals(currentProfile.Name, logEntry.RecordName__c);
+        System.Assert.areEqual(currentProfile.Id, logEntry.RecordId__c);
+        System.Assert.areEqual(currentProfile.Name, logEntry.RecordName__c);
     }
 
     @IsTest
@@ -111,14 +115,14 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         logEntry = [SELECT Id, RecordId__c, RecordName__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertEquals(currentUser.Id, logEntry.RecordId__c);
-        System.assertEquals(null, logEntry.RecordName__c);
+        System.Assert.areEqual(currentUser.Id, logEntry.RecordId__c);
+        System.Assert.isNull(logEntry.RecordName__c);
     }
 
     @IsTest
@@ -130,14 +134,14 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         logEntry = [SELECT Id, HasRecordJson__c, RecordJson__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertEquals(true, logEntry.HasRecordJson__c);
-        System.assertEquals(recordJson, logEntry.RecordJson__c);
+        System.Assert.areEqual(true, logEntry.HasRecordJson__c);
+        System.Assert.areEqual(recordJson, logEntry.RecordJson__c);
     }
 
     @IsTest
@@ -149,14 +153,14 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         logEntry = [SELECT Id, HasRecordJson__c, RecordJson__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertEquals(false, logEntry.HasRecordJson__c);
-        System.assertEquals(null, logEntry.RecordJson__c);
+        System.Assert.areEqual(false, logEntry.HasRecordJson__c);
+        System.Assert.isNull(logEntry.RecordJson__c);
     }
 
     @IsTest
@@ -166,20 +170,20 @@ private class LogEntryHandler_Tests {
         LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
         LoggerDataStore.getDatabase().insertRecord(logEntry);
         logEntry = [SELECT Id, RecordJson__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertEquals(null, logEntry.RecordJson__c);
+        System.Assert.isNull(logEntry.RecordJson__c);
         String recordJson = '{}';
         logEntry.RecordJson__c = recordJson;
 
         update logEntry;
 
-        System.assertEquals(
+        System.Assert.areEqual(
             4,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed four times - two times for BEFORE_INSERT/AFTER_INSERT' + ' and two more times for BEFORE_UPDATE/AFTER_UPDATE'
         );
         logEntry = [SELECT Id, HasRecordJson__c, RecordJson__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertEquals(true, logEntry.HasRecordJson__c);
-        System.assertEquals(recordJson, logEntry.RecordJson__c);
+        System.Assert.areEqual(true, logEntry.HasRecordJson__c);
+        System.Assert.areEqual(recordJson, logEntry.RecordJson__c);
     }
 
     @IsTest
@@ -190,19 +194,19 @@ private class LogEntryHandler_Tests {
         LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
         LoggerDataStore.getDatabase().insertRecord(logEntry);
         logEntry = [SELECT Id, RecordJson__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertNotEquals(null, logEntry.RecordJson__c);
+        System.Assert.isNotNull(logEntry.RecordJson__c);
         logEntry.RecordJson__c = null;
 
         update logEntry;
 
-        System.assertEquals(
+        System.Assert.areEqual(
             4,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed four times - two times for BEFORE_INSERT/AFTER_INSERT' + ' and two more times for BEFORE_UPDATE/AFTER_UPDATE'
         );
         logEntry = [SELECT Id, HasRecordJson__c, RecordJson__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertEquals(false, logEntry.HasRecordJson__c);
-        System.assertEquals(null, logEntry.RecordJson__c);
+        System.Assert.areEqual(false, logEntry.HasRecordJson__c);
+        System.Assert.isNull(logEntry.RecordJson__c);
     }
 
     @IsTest
@@ -213,14 +217,14 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         logEntry = [SELECT Id, HasExceptionStackTrace__c, ExceptionStackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assert(!logEntry.HasExceptionStackTrace__c);
-        System.assertEquals(null, logEntry.ExceptionStackTrace__c);
+        System.Assert.isTrue(!logEntry.HasExceptionStackTrace__c);
+        System.Assert.isNull(logEntry.ExceptionStackTrace__c);
     }
 
     @IsTest
@@ -232,14 +236,14 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         logEntry = [SELECT Id, HasExceptionStackTrace__c, ExceptionStackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assert(logEntry.HasExceptionStackTrace__c);
-        System.assertEquals(stackTrace, logEntry.ExceptionStackTrace__c);
+        System.Assert.isTrue(logEntry.HasExceptionStackTrace__c);
+        System.Assert.areEqual(stackTrace, logEntry.ExceptionStackTrace__c);
     }
 
     @IsTest
@@ -249,20 +253,20 @@ private class LogEntryHandler_Tests {
         LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
         LoggerDataStore.getDatabase().insertRecord(logEntry);
         logEntry = [SELECT Id, ExceptionStackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertEquals(null, logEntry.ExceptionStackTrace__c);
+        System.Assert.isNull(logEntry.ExceptionStackTrace__c);
 
         String stackTrace = 'something';
         logEntry.ExceptionStackTrace__c = stackTrace;
         update logEntry;
 
-        System.assertEquals(
+        System.Assert.areEqual(
             4,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed four times - two times for BEFORE_INSERT/AFTER_INSERT' + ' and two more times for BEFORE_UPDATE/AFTER_UPDATE'
         );
         logEntry = [SELECT Id, HasExceptionStackTrace__c, ExceptionStackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assert(logEntry.HasExceptionStackTrace__c);
-        System.assertEquals(stackTrace, logEntry.ExceptionStackTrace__c);
+        System.Assert.isTrue(logEntry.HasExceptionStackTrace__c);
+        System.Assert.areEqual(stackTrace, logEntry.ExceptionStackTrace__c);
     }
 
     @IsTest
@@ -273,14 +277,14 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         logEntry = [SELECT Id, HasStackTrace__c, StackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assert(!logEntry.HasStackTrace__c);
-        System.assertEquals(null, logEntry.StackTrace__c);
+        System.Assert.isTrue(!logEntry.HasStackTrace__c);
+        System.Assert.isNull(logEntry.StackTrace__c);
     }
 
     @IsTest
@@ -292,14 +296,14 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         logEntry = [SELECT Id, HasStackTrace__c, StackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assert(logEntry.HasStackTrace__c);
-        System.assertEquals(stackTrace, logEntry.StackTrace__c);
+        System.Assert.isTrue(logEntry.HasStackTrace__c);
+        System.Assert.areEqual(stackTrace, logEntry.StackTrace__c);
     }
 
     @IsTest
@@ -309,20 +313,20 @@ private class LogEntryHandler_Tests {
         LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
         LoggerDataStore.getDatabase().insertRecord(logEntry);
         logEntry = [SELECT Id, StackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertEquals(null, logEntry.StackTrace__c);
+        System.Assert.isNull(logEntry.StackTrace__c);
 
         String stackTrace = 'something';
         logEntry.StackTrace__c = stackTrace;
         update logEntry;
 
-        System.assertEquals(
+        System.Assert.areEqual(
             4,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed four times - two times for BEFORE_INSERT/AFTER_INSERT' + ' and two more times for BEFORE_UPDATE/AFTER_UPDATE'
         );
         logEntry = [SELECT Id, HasStackTrace__c, StackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assert(logEntry.HasStackTrace__c);
-        System.assertEquals(stackTrace, logEntry.StackTrace__c);
+        System.Assert.isTrue(logEntry.HasStackTrace__c);
+        System.Assert.areEqual(stackTrace, logEntry.StackTrace__c);
     }
 
     @IsTest
@@ -333,7 +337,7 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
@@ -353,15 +357,15 @@ private class LogEntryHandler_Tests {
             FROM LogEntry__c
             WHERE Id = :logEntry.Id
         ];
-        System.assertEquals('Apex', logEntry.OriginType__c);
-        System.assertEquals(null, logEntry.OriginLocation__c);
-        System.assertEquals(null, logEntry.ApexClassApiVersion__c);
-        System.assertEquals(null, logEntry.ApexClassCreatedDate__c);
-        System.assertEquals(null, logEntry.ApexClassId__c);
-        System.assertEquals(null, logEntry.ApexClassLastModifiedDate__c);
-        System.assertEquals(null, logEntry.ApexClassName__c);
-        System.assertEquals(null, logEntry.ApexInnerClassName__c);
-        System.assertEquals(null, logEntry.ApexMethodName__c);
+        System.Assert.areEqual('Apex', logEntry.OriginType__c);
+        System.Assert.isNull(logEntry.OriginLocation__c);
+        System.Assert.isNull(logEntry.ApexClassApiVersion__c);
+        System.Assert.isNull(logEntry.ApexClassCreatedDate__c);
+        System.Assert.isNull(logEntry.ApexClassId__c);
+        System.Assert.isNull(logEntry.ApexClassLastModifiedDate__c);
+        System.Assert.isNull(logEntry.ApexClassName__c);
+        System.Assert.isNull(logEntry.ApexInnerClassName__c);
+        System.Assert.isNull(logEntry.ApexMethodName__c);
     }
 
     @IsTest
@@ -387,7 +391,7 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
@@ -406,14 +410,14 @@ private class LogEntryHandler_Tests {
             FROM LogEntry__c
             WHERE Id = :logEntry.Id
         ];
-        System.assertEquals(exampleTopLevelClassMethodName, logEntry.OriginLocation__c);
-        System.assertEquals('v' + apexClass.ApiVersion, logEntry.ApexClassApiVersion__c);
-        System.assertEquals(apexClass.CreatedDate, logEntry.ApexClassCreatedDate__c);
-        System.assertEquals(apexClass.Id, logEntry.ApexClassId__c);
-        System.assertEquals(apexClass.LastModifiedDate, logEntry.ApexClassLastModifiedDate__c);
-        System.assertEquals(exampleTopLevelClassName, logEntry.ApexClassName__c);
-        System.assertEquals(null, logEntry.ApexInnerClassName__c);
-        System.assertEquals(methodName, logEntry.ApexMethodName__c);
+        System.Assert.areEqual(exampleTopLevelClassMethodName, logEntry.OriginLocation__c);
+        System.Assert.areEqual('v' + apexClass.ApiVersion, logEntry.ApexClassApiVersion__c);
+        System.Assert.areEqual(apexClass.CreatedDate, logEntry.ApexClassCreatedDate__c);
+        System.Assert.areEqual(apexClass.Id, logEntry.ApexClassId__c);
+        System.Assert.areEqual(apexClass.LastModifiedDate, logEntry.ApexClassLastModifiedDate__c);
+        System.Assert.areEqual(exampleTopLevelClassName, logEntry.ApexClassName__c);
+        System.Assert.isNull(logEntry.ApexInnerClassName__c);
+        System.Assert.areEqual(methodName, logEntry.ApexMethodName__c);
     }
 
     @IsTest
@@ -440,7 +444,7 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
@@ -459,14 +463,14 @@ private class LogEntryHandler_Tests {
             FROM LogEntry__c
             WHERE Id = :logEntry.Id
         ];
-        System.assertEquals(exampleInnerClassMethodName, logEntry.OriginLocation__c);
-        System.assertEquals('v' + apexClass.ApiVersion, logEntry.ApexClassApiVersion__c);
-        System.assertEquals(apexClass.CreatedDate, logEntry.ApexClassCreatedDate__c);
-        System.assertEquals(apexClass.Id, logEntry.ApexClassId__c);
-        System.assertEquals(apexClass.LastModifiedDate, logEntry.ApexClassLastModifiedDate__c);
-        System.assertEquals(exampleTopLevelClassName, logEntry.ApexClassName__c);
-        System.assertEquals(exampleInnerClassName, logEntry.ApexInnerClassName__c);
-        System.assertEquals(methodName, logEntry.ApexMethodName__c);
+        System.Assert.areEqual(exampleInnerClassMethodName, logEntry.OriginLocation__c);
+        System.Assert.areEqual('v' + apexClass.ApiVersion, logEntry.ApexClassApiVersion__c);
+        System.Assert.areEqual(apexClass.CreatedDate, logEntry.ApexClassCreatedDate__c);
+        System.Assert.areEqual(apexClass.Id, logEntry.ApexClassId__c);
+        System.Assert.areEqual(apexClass.LastModifiedDate, logEntry.ApexClassLastModifiedDate__c);
+        System.Assert.areEqual(exampleTopLevelClassName, logEntry.ApexClassName__c);
+        System.Assert.areEqual(exampleInnerClassName, logEntry.ApexInnerClassName__c);
+        System.Assert.areEqual(methodName, logEntry.ApexMethodName__c);
     }
 
     private static String getNamespacePrefix() {

--- a/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
@@ -55,7 +55,7 @@ private class LogEntryHandler_Tests {
     @IsTest
     static void it_should_populate_related_record_fields_on_log_entry_with_related_user_record_id() {
         Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        User currentUser = [SELECT Id, Username FROM User WHERE Id = :UserInfo.getUserId()];
+        User currentUser = [SELECT Id, Username FROM User WHERE Id = :System.UserInfo.getUserId()];
         LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, RecordId__c = currentUser.Id);
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
@@ -73,7 +73,7 @@ private class LogEntryHandler_Tests {
     @IsTest
     static void it_should_populate_related_record_fields_on_log_entry_with_related_profile_record_id() {
         Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        Profile currentProfile = [SELECT Id, Name FROM Profile WHERE Id = :UserInfo.getProfileId()];
+        Profile currentProfile = [SELECT Id, Name FROM Profile WHERE Id = :System.UserInfo.getProfileId()];
         LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, RecordId__c = currentProfile.Id);
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
@@ -109,7 +109,7 @@ private class LogEntryHandler_Tests {
     @IsTest
     static void it_should_not_populate_related_record_fields_on_log_entry_when_disabled_via_logger_parameter() {
         Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        User currentUser = [SELECT Id, Username FROM User WHERE Id = :UserInfo.getUserId()];
+        User currentUser = [SELECT Id, Username FROM User WHERE Id = :System.UserInfo.getUserId()];
         LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, RecordId__c = currentUser.Id);
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryRelatedRecordData', Value__c = String.valueOf(false)));
 

--- a/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
@@ -96,14 +96,14 @@ private class LogEntryHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntry);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         logEntry = [SELECT Id, RecordId__c, RecordName__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertEquals(templateSObjectRecordId, logEntry.RecordId__c);
-        System.assertEquals(null, logEntry.RecordName__c);
+        System.Assert.areEqual(templateSObjectRecordId, logEntry.RecordId__c);
+        System.Assert.isNull(logEntry.RecordName__c);
     }
 
     @IsTest

--- a/nebula-logger/core/tests/log-management/classes/LogEntryTagHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryTagHandler_Tests.cls
@@ -104,12 +104,12 @@ private class LogEntryTagHandler_Tests {
         LogEntryTag__c logEntryTag = new LogEntryTag__c(LogEntry__c = logEntry.Id, Tag__c = tag.Id);
         LoggerDataStore.getDatabase().insertRecord(logEntryTag);
         LogEntryTag__c duplicateLogEntryTag = new LogEntryTag__c(LogEntry__c = logEntry.Id, Tag__c = tag.Id);
-        Exception thrownException;
+        System.Exception thrownException;
 
         try {
             insert duplicateLogEntryTag;
-            System.Assert.fail('Exception expected on previous line');
-        } catch (Exception ex) {
+            System.Assert.fail('System.Exception expected on previous line');
+        } catch (System.Exception ex) {
             thrownException = ex;
         }
 

--- a/nebula-logger/core/tests/log-management/classes/LogEntryTagHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryTagHandler_Tests.cls
@@ -33,12 +33,12 @@ private class LogEntryTagHandler_Tests {
 
         String generatedUniqueId = LogEntryTagHandler.generateUniqueId(logEntryTag);
 
-        System.assertEquals(expectedUniqueId, generatedUniqueId);
+        System.Assert.areEqual(expectedUniqueId, generatedUniqueId);
     }
 
     @IsTest
     static void it_should_return_the_logEntryTag_sobjectType() {
-        System.assertEquals(Schema.LogEntryTag__c.SObjectType, new LogEntryTagHandler().getSObjectType());
+        System.Assert.areEqual(Schema.LogEntryTag__c.SObjectType, new LogEntryTagHandler().getSObjectType());
     }
 
     @IsTest
@@ -52,7 +52,7 @@ private class LogEntryTagHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntryTag);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryTag__c.SObjectType).size(),
             'Handler class should not have executed'
@@ -67,13 +67,13 @@ private class LogEntryTagHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(logEntryTag);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryTag__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         logEntryTag = [SELECT Id, LogEntry__c, Tag__c, UniqueId__c FROM LogEntryTag__c WHERE Id = :logEntryTag.Id];
-        System.assertEquals(logEntry.Id + '' + tag.Id, logEntryTag.UniqueId__c);
+        System.Assert.areEqual(logEntry.Id + '' + tag.Id, logEntryTag.UniqueId__c);
     }
 
     @IsTest
@@ -83,18 +83,18 @@ private class LogEntryTagHandler_Tests {
         LogEntryTag__c logEntryTag = new LogEntryTag__c(LogEntry__c = logEntry.Id, Tag__c = tag.Id);
         LoggerDataStore.getDatabase().insertRecord(logEntryTag);
         logEntryTag = [SELECT Id, LogEntry__c, Tag__c, UniqueId__c FROM LogEntryTag__c WHERE Id = :logEntryTag.Id];
-        System.assertEquals(logEntry.Id + '' + tag.Id, logEntryTag.UniqueId__c);
+        System.Assert.areEqual(logEntry.Id + '' + tag.Id, logEntryTag.UniqueId__c);
         logEntryTag.UniqueId__c = 'something else';
 
         update logEntryTag;
 
-        System.assertEquals(
+        System.Assert.areEqual(
             4,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryTag__c.SObjectType).size(),
             'Handler class should have executed four times - two times for BEFORE_INSERT/AFTER_INSERT' + ' and two more times for BEFORE_UPDATE/AFTER_UPDATE'
         );
         logEntryTag = [SELECT Id, LogEntry__c, Tag__c, UniqueId__c FROM LogEntryTag__c WHERE Id = :logEntryTag.Id];
-        System.assertEquals(logEntry.Id + '' + tag.Id, logEntryTag.UniqueId__c);
+        System.Assert.areEqual(logEntry.Id + '' + tag.Id, logEntryTag.UniqueId__c);
     }
 
     @IsTest
@@ -108,19 +108,19 @@ private class LogEntryTagHandler_Tests {
 
         try {
             insert duplicateLogEntryTag;
-            System.assert(false, 'Exception expected on previous line');
+            System.Assert.fail('Exception expected on previous line');
         } catch (Exception ex) {
             thrownException = ex;
         }
 
-        System.assertEquals(
+        System.Assert.areEqual(
             3,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryTag__c.SObjectType).size(),
             'Handler class should have executed three times - once for BEFORE_INSERT and once for AFTER_INSERT for the first record,' +
             ' and once for BEFORE_INSERT on the errored duplicate'
         );
-        System.assertNotEquals(null, thrownException, 'An exception should have been thrown');
+        System.Assert.isNotNull(thrownException, 'An exception should have been thrown');
         String expectedDuplicateError = 'DUPLICATE_VALUE';
-        System.assert(thrownException.getMessage().contains(expectedDuplicateError), thrownException.getMessage());
+        System.Assert.isTrue(thrownException.getMessage().contains(expectedDuplicateError), thrownException.getMessage());
     }
 }

--- a/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls
@@ -23,7 +23,7 @@ private class LogHandler_Tests {
         setupConfigurations();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations(false);
         Log__c log = new Log__c(
-            ClosedBy__c = UserInfo.getUserId(),
+            ClosedBy__c = System.UserInfo.getUserId(),
             ClosedDate__c = System.now(),
             IsClosed__c = true,
             IsResolved__c = true,
@@ -40,7 +40,7 @@ private class LogHandler_Tests {
     static void it_should_clear_closed_status_fields_when_open() {
         setupConfigurations();
         Log__c log = new Log__c(
-            ClosedBy__c = UserInfo.getUserId(),
+            ClosedBy__c = System.UserInfo.getUserId(),
             ClosedDate__c = System.now(),
             IsClosed__c = true,
             IsResolved__c = true,
@@ -82,7 +82,7 @@ private class LogHandler_Tests {
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         log = [SELECT Id, ClosedBy__c, ClosedDate__c, IsClosed__c, IsResolved__c, Status__c FROM Log__c WHERE Id = :log.Id];
-        System.Assert.areEqual(UserInfo.getUserId(), log.ClosedBy__c);
+        System.Assert.areEqual(System.UserInfo.getUserId(), log.ClosedBy__c);
         System.Assert.areEqual(System.today(), log.ClosedDate__c.date());
         System.Assert.isTrue(log.IsClosed__c);
     }
@@ -90,7 +90,7 @@ private class LogHandler_Tests {
     @IsTest
     static void it_should_set_owner_when_default_configured_with_user_id() {
         setupConfigurations();
-        User currentUser = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User currentUser = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         User expectedLogOwnerUser = LoggerMockDataCreator.createUser();
         insert expectedLogOwnerUser;
         LoggerSettings__c currentUserSettings = Logger.getUserSettings(currentUser);
@@ -112,7 +112,7 @@ private class LogHandler_Tests {
     @IsTest
     static void it_should_set_owner_when_default_configured_with_username() {
         setupConfigurations();
-        User currentUser = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User currentUser = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         User expectedLogOwnerUser = LoggerMockDataCreator.createUser();
         insert expectedLogOwnerUser;
         LoggerSettings__c currentUserSettings = Logger.getUserSettings(currentUser);
@@ -134,7 +134,7 @@ private class LogHandler_Tests {
     @IsTest
     static void it_should_set_owner_when_default_configured_with_queue_id() {
         setupConfigurations();
-        User currentUser = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User currentUser = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         Group expectedLogOwnerQueue = LoggerMockDataCreator.insertQueue('Some_Log_Queue', Schema.Log__c.SObjectType);
         LoggerSettings__c currentUserSettings = Logger.getUserSettings(currentUser);
         currentUserSettings.DefaultLogOwner__c = expectedLogOwnerQueue.Id;
@@ -155,7 +155,7 @@ private class LogHandler_Tests {
     @IsTest
     static void it_should_set_owner_when_default_configured_with_queue_developer_name() {
         setupConfigurations();
-        User currentUser = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User currentUser = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         Group expectedLogOwnerQueue = LoggerMockDataCreator.insertQueue('Some_Log_Queue', Schema.Log__c.SObjectType);
         LoggerSettings__c currentUserSettings = Logger.getUserSettings(currentUser);
         currentUserSettings.DefaultLogOwner__c = expectedLogOwnerQueue.DeveloperName;
@@ -176,7 +176,7 @@ private class LogHandler_Tests {
     @IsTest
     static void it_should_use_current_user_as_owner_when_no_default_configured() {
         setupConfigurations();
-        User currentUser = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User currentUser = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         LoggerSettings__c currentUserSettings = Logger.getUserSettings(currentUser);
         currentUserSettings.DefaultLogOwner__c = null;
         insert currentUserSettings;
@@ -190,7 +190,7 @@ private class LogHandler_Tests {
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         log = [SELECT Id, OwnerId FROM Log__c WHERE Id = :log.Id];
-        System.Assert.areEqual(UserInfo.getUserId(), log.OwnerId, JSON.serializePretty(log));
+        System.Assert.areEqual(System.UserInfo.getUserId(), log.OwnerId, JSON.serializePretty(log));
     }
 
     @IsTest
@@ -232,7 +232,7 @@ private class LogHandler_Tests {
         Date retentionDate = System.today().addDays(specifiedDaysToRetainLog);
         String specifiedLogPurgeAction = 'A Different Action';
         Log__c log = new Log__c(
-            LoggedBy__c = UserInfo.getUserId(),
+            LoggedBy__c = System.UserInfo.getUserId(),
             LogPurgeAction__c = specifiedLogPurgeAction,
             LogRetentionDate__c = retentionDate,
             TransactionId__c = '1234'
@@ -261,7 +261,7 @@ private class LogHandler_Tests {
         Logger.getUserSettings().DefaultNumberOfDaysToRetainLogs__c = daysToRetainLog;
         Logger.getUserSettings().DefaultLogPurgeAction__c = expectedLogPurgeAction;
         upsert Logger.getUserSettings();
-        Log__c log = (Log__c) LoggerMockDataCreator.createDataBuilder(new Log__c(LoggedBy__c = UserInfo.getUserId())).populateRequiredFields().getRecord();
+        Log__c log = (Log__c) LoggerMockDataCreator.createDataBuilder(new Log__c(LoggedBy__c = System.UserInfo.getUserId())).populateRequiredFields().getRecord();
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
@@ -320,8 +320,8 @@ private class LogHandler_Tests {
         settings = [SELECT Id, DefaultLogPurgeAction__c FROM LoggerSettings__c WHERE Id = :settings.Id];
         System.Assert.isNull(settings.DefaultLogPurgeAction__c);
         Log__c log = (Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord();
-        log.LoggedBy__c = UserInfo.getUserId();
-        log.ProfileId__c = UserInfo.getProfileId();
+        log.LoggedBy__c = System.UserInfo.getUserId();
+        log.ProfileId__c = System.UserInfo.getProfileId();
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
@@ -385,7 +385,7 @@ private class LogHandler_Tests {
         LoggerSettings__c settings = Logger.getUserSettings();
         settings.DefaultLogShareAccessLevel__c = 'Read';
         upsert settings;
-        Log__c log = new Log__c(LoggedBy__c = UserInfo.getUserId(), TransactionId__c = '1234');
+        Log__c log = new Log__c(LoggedBy__c = System.UserInfo.getUserId(), TransactionId__c = '1234');
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
@@ -408,7 +408,7 @@ private class LogHandler_Tests {
         LoggerSettings__c settings = Logger.getUserSettings();
         settings.DefaultLogShareAccessLevel__c = 'Edit';
         upsert settings;
-        Log__c log = new Log__c(LoggedBy__c = UserInfo.getUserId(), TransactionId__c = '1234');
+        Log__c log = new Log__c(LoggedBy__c = System.UserInfo.getUserId(), TransactionId__c = '1234');
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
@@ -431,7 +431,7 @@ private class LogHandler_Tests {
         LoggerSettings__c settings = Logger.getUserSettings();
         settings.DefaultLogShareAccessLevel__c = null;
         upsert settings;
-        Log__c log = new Log__c(LoggedBy__c = UserInfo.getUserId(), TransactionId__c = '1234');
+        Log__c log = new Log__c(LoggedBy__c = System.UserInfo.getUserId(), TransactionId__c = '1234');
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
@@ -450,7 +450,7 @@ private class LogHandler_Tests {
         LoggerSettings__c settings = Logger.getUserSettings();
         settings.DefaultLogShareAccessLevel__c = 'FAKE LEVEL';
         upsert settings;
-        Log__c log = new Log__c(LoggedBy__c = UserInfo.getUserId(), TransactionId__c = '1234');
+        Log__c log = new Log__c(LoggedBy__c = System.UserInfo.getUserId(), TransactionId__c = '1234');
 
         LoggerDataStore.getDatabase().insertRecord(log);
 

--- a/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls
@@ -261,7 +261,9 @@ private class LogHandler_Tests {
         Logger.getUserSettings().DefaultNumberOfDaysToRetainLogs__c = daysToRetainLog;
         Logger.getUserSettings().DefaultLogPurgeAction__c = expectedLogPurgeAction;
         upsert Logger.getUserSettings();
-        Log__c log = (Log__c) LoggerMockDataCreator.createDataBuilder(new Log__c(LoggedBy__c = System.UserInfo.getUserId())).populateRequiredFields().getRecord();
+        Log__c log = (Log__c) LoggerMockDataCreator.createDataBuilder(new Log__c(LoggedBy__c = System.UserInfo.getUserId()))
+            .populateRequiredFields()
+            .getRecord();
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
@@ -345,7 +347,7 @@ private class LogHandler_Tests {
         log = [SELECT Id, Priority__c FROM Log__c WHERE Id = :log.Id];
         System.Assert.areEqual(LOW_PRIORITY, log.Priority__c);
 
-        insert LoggerMockDataCreator.createDataBuilder(new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name()))
+        insert LoggerMockDataCreator.createDataBuilder(new LogEntry__c(Log__c = log.Id, LoggingLevel__c = System.LoggingLevel.ERROR.name()))
             .populateRequiredFields()
             .getRecord();
 

--- a/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls
@@ -15,7 +15,7 @@ private class LogHandler_Tests {
 
     @IsTest
     static void it_should_return_the_log_sobjectType() {
-        System.assertEquals(Schema.Log__c.SObjectType, new LogHandler().getSObjectType());
+        System.Assert.areEqual(Schema.Log__c.SObjectType, new LogHandler().getSObjectType());
     }
 
     @IsTest
@@ -33,7 +33,7 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(0, LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(), 'Handler class should not have executed');
+        System.Assert.areEqual(0, LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(), 'Handler class should not have executed');
     }
 
     @IsTest
@@ -50,16 +50,16 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         log = [SELECT Id, ClosedBy__c, ClosedDate__c, IsClosed__c, IsResolved__c, Status__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(null, log.ClosedBy__c);
-        System.assertEquals(null, log.ClosedDate__c);
-        System.assertEquals(false, log.IsClosed__c);
-        System.assertEquals(false, log.IsResolved__c);
+        System.Assert.isNull(log.ClosedBy__c);
+        System.Assert.isNull(log.ClosedDate__c);
+        System.Assert.isFalse(log.IsClosed__c);
+        System.Assert.isFalse(log.IsResolved__c);
     }
 
     @IsTest
@@ -76,15 +76,15 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         log = [SELECT Id, ClosedBy__c, ClosedDate__c, IsClosed__c, IsResolved__c, Status__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(UserInfo.getUserId(), log.ClosedBy__c);
-        System.assertEquals(System.today(), log.ClosedDate__c.date());
-        System.assertEquals(true, log.IsClosed__c);
+        System.Assert.areEqual(UserInfo.getUserId(), log.ClosedBy__c);
+        System.Assert.areEqual(System.today(), log.ClosedDate__c.date());
+        System.Assert.isTrue(log.IsClosed__c);
     }
 
     @IsTest
@@ -100,13 +100,13 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         log = [SELECT Id, OwnerId FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(expectedLogOwnerUser.Id, log.OwnerId, log);
+        System.Assert.areEqual(expectedLogOwnerUser.Id, log.OwnerId, JSON.serializePretty(log));
     }
 
     @IsTest
@@ -122,13 +122,13 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         log = [SELECT Id, OwnerId FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(expectedLogOwnerUser.Id, log.OwnerId, log);
+        System.Assert.areEqual(expectedLogOwnerUser.Id, log.OwnerId, JSON.serializePretty(log));
     }
 
     @IsTest
@@ -143,13 +143,13 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         log = [SELECT Id, OwnerId FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(expectedLogOwnerQueue.Id, log.OwnerId, log);
+        System.Assert.areEqual(expectedLogOwnerQueue.Id, log.OwnerId, JSON.serializePretty(log));
     }
 
     @IsTest
@@ -164,13 +164,13 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         log = [SELECT Id, OwnerId FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(expectedLogOwnerQueue.Id, log.OwnerId, log);
+        System.Assert.areEqual(expectedLogOwnerQueue.Id, log.OwnerId, JSON.serializePretty(log));
     }
 
     @IsTest
@@ -184,13 +184,13 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         log = [SELECT Id, OwnerId FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(UserInfo.getUserId(), log.OwnerId, log);
+        System.Assert.areEqual(UserInfo.getUserId(), log.OwnerId, JSON.serializePretty(log));
     }
 
     @IsTest
@@ -201,8 +201,8 @@ private class LogHandler_Tests {
         insert log;
 
         log = [SELECT Id, ParentLogTransactionId__c, ParentLog__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(parentLogTransactionId, log.ParentLogTransactionId__c, log);
-        System.assertEquals(null, log.ParentLog__c, log);
+        System.Assert.areEqual(parentLogTransactionId, log.ParentLogTransactionId__c, JSON.serializePretty(log));
+        System.Assert.isNull(log.ParentLog__c, JSON.serializePretty(log));
     }
 
     @IsTest
@@ -215,8 +215,8 @@ private class LogHandler_Tests {
         insert log;
 
         log = [SELECT Id, ParentLogTransactionId__c, ParentLog__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(parentLogTransactionId, log.ParentLogTransactionId__c, log);
-        System.assertEquals(parentLog.Id, log.ParentLog__c, log);
+        System.Assert.areEqual(parentLogTransactionId, log.ParentLogTransactionId__c, JSON.serializePretty(log));
+        System.Assert.areEqual(parentLog.Id, log.ParentLog__c, JSON.serializePretty(log));
     }
 
     @IsTest
@@ -240,16 +240,16 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         log = [SELECT Id, LogPurgeAction__c, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
-        System.assertNotEquals(defaultDaysToRetainLog, specifiedDaysToRetainLog);
-        System.assertNotEquals(defaultLogPurgeAction, specifiedLogPurgeAction);
-        System.assertEquals(specifiedLogPurgeAction, log.LogPurgeAction__c);
-        System.assertEquals(retentionDate, log.LogRetentionDate__c);
+        System.Assert.areNotEqual(defaultDaysToRetainLog, specifiedDaysToRetainLog);
+        System.Assert.areNotEqual(defaultLogPurgeAction, specifiedLogPurgeAction);
+        System.Assert.areEqual(specifiedLogPurgeAction, log.LogPurgeAction__c);
+        System.Assert.areEqual(retentionDate, log.LogRetentionDate__c);
     }
 
     @IsTest
@@ -265,14 +265,14 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         log = [SELECT Id, LogPurgeAction__c, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(expectedLogPurgeAction, log.LogPurgeAction__c);
-        System.assertEquals(expectedRetentionDate, log.LogRetentionDate__c);
+        System.Assert.areEqual(expectedLogPurgeAction, log.LogPurgeAction__c);
+        System.Assert.areEqual(expectedRetentionDate, log.LogRetentionDate__c);
     }
 
     @IsTest
@@ -300,13 +300,13 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         log = [SELECT Id, Scenario__c, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(expectedRetentionDate, log.LogRetentionDate__c);
+        System.Assert.areEqual(expectedRetentionDate, log.LogRetentionDate__c);
     }
 
     @IsTest
@@ -318,22 +318,22 @@ private class LogHandler_Tests {
         settings.DefaultLogPurgeAction__c = null;
         upsert settings;
         settings = [SELECT Id, DefaultLogPurgeAction__c FROM LoggerSettings__c WHERE Id = :settings.Id];
-        System.assertEquals(null, settings.DefaultLogPurgeAction__c);
+        System.Assert.isNull(settings.DefaultLogPurgeAction__c);
         Log__c log = (Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord();
         log.LoggedBy__c = UserInfo.getUserId();
         log.ProfileId__c = UserInfo.getProfileId();
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         String defaultLogPurgeActionPicklistValue = getDefaultPicklistValue(Schema.Log__c.LogPurgeAction__c);
         log = [SELECT Id, LogPurgeAction__c, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(defaultLogPurgeActionPicklistValue, log.LogPurgeAction__c);
-        System.assertEquals(null, log.LogRetentionDate__c);
+        System.Assert.areEqual(defaultLogPurgeActionPicklistValue, log.LogPurgeAction__c);
+        System.Assert.isNull(log.LogRetentionDate__c);
     }
 
     @IsTest
@@ -343,20 +343,20 @@ private class LogHandler_Tests {
         log.Priority__c = LOW_PRIORITY;
         LoggerDataStore.getDatabase().insertRecord(log);
         log = [SELECT Id, Priority__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(LOW_PRIORITY, log.Priority__c);
+        System.Assert.areEqual(LOW_PRIORITY, log.Priority__c);
 
         insert LoggerMockDataCreator.createDataBuilder(new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name()))
             .populateRequiredFields()
             .getRecord();
 
-        System.assertEquals(
+        System.Assert.areEqual(
             4,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed four times - two times for BEFORE_INSERT/AFTER_INSERT' +
             ' and two more times for BEFORE_UPDATE/AFTER_UPDATE (triggered indirectly by the insert of a related LogEntry__c record)'
         );
         log = [SELECT Id, Priority__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(HIGH_PRIORITY, log.Priority__c);
+        System.Assert.areEqual(HIGH_PRIORITY, log.Priority__c);
     }
 
     @IsTest
@@ -365,18 +365,18 @@ private class LogHandler_Tests {
         Log__c log = new Log__c(Priority__c = LOW_PRIORITY, TransactionId__c = '1234');
         LoggerDataStore.getDatabase().insertRecord(log);
         log = [SELECT Id, Priority__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(LOW_PRIORITY, log.Priority__c);
+        System.Assert.areEqual(LOW_PRIORITY, log.Priority__c);
 
         insert new LogEntry__c(Log__c = log.Id, LoggingLevel__c = 'WARN');
 
-        System.assertEquals(
+        System.Assert.areEqual(
             4,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed four times - two times for BEFORE_INSERT/AFTER_INSERT' +
             ' and two more times for BEFORE_UPDATE/AFTER_UPDATE (triggered indirectly by the insert of a related LogEntry__c record)'
         );
         log = [SELECT Id, Priority__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(MEDIUM_PRIORITY, log.Priority__c);
+        System.Assert.areEqual(MEDIUM_PRIORITY, log.Priority__c);
     }
 
     @IsTest
@@ -389,17 +389,17 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         List<Log__Share> logShares = [SELECT AccessLevel, ParentId, RowCause, UserOrGroupId FROM Log__Share WHERE ParentId = :log.Id AND AccessLevel != 'All'];
-        System.assertEquals(1, logShares.size(), logShares);
-        System.assertEquals('Read', logShares.get(0).AccessLevel);
-        System.assertEquals(log.Id, logShares.get(0).ParentId);
-        System.assertEquals(Schema.Log__Share.RowCause.LoggedByUser__c, logShares.get(0).RowCause);
-        System.assertEquals(log.LoggedBy__c, logShares.get(0).UserOrGroupId);
+        System.Assert.areEqual(1, logShares.size(), JSON.serializePretty(logShares));
+        System.Assert.areEqual('Read', logShares.get(0).AccessLevel);
+        System.Assert.areEqual(log.Id, logShares.get(0).ParentId);
+        System.Assert.areEqual(Schema.Log__Share.RowCause.LoggedByUser__c, logShares.get(0).RowCause);
+        System.Assert.areEqual(log.LoggedBy__c, logShares.get(0).UserOrGroupId);
     }
 
     @IsTest
@@ -412,17 +412,17 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         List<Log__Share> logShares = [SELECT AccessLevel, ParentId, RowCause, UserOrGroupId FROM Log__Share WHERE ParentId = :log.Id AND AccessLevel != 'All'];
-        System.assertEquals(1, logShares.size(), logShares);
-        System.assertEquals('Edit', logShares.get(0).AccessLevel);
-        System.assertEquals(log.Id, logShares.get(0).ParentId);
-        System.assertEquals(Schema.Log__Share.RowCause.LoggedByUser__c, logShares.get(0).RowCause);
-        System.assertEquals(log.LoggedBy__c, logShares.get(0).UserOrGroupId);
+        System.Assert.areEqual(1, logShares.size(), JSON.serializePretty(logShares));
+        System.Assert.areEqual('Edit', logShares.get(0).AccessLevel);
+        System.Assert.areEqual(log.Id, logShares.get(0).ParentId);
+        System.Assert.areEqual(Schema.Log__Share.RowCause.LoggedByUser__c, logShares.get(0).RowCause);
+        System.Assert.areEqual(log.LoggedBy__c, logShares.get(0).UserOrGroupId);
     }
 
     @IsTest
@@ -435,13 +435,13 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         List<Log__Share> logShares = [SELECT AccessLevel, ParentId, RowCause, UserOrGroupId FROM Log__Share WHERE ParentId = :log.Id AND AccessLevel != 'All'];
-        System.assertEquals(0, logShares.size(), logShares);
+        System.Assert.areEqual(0, logShares.size(), JSON.serializePretty(logShares));
     }
 
     @IsTest
@@ -454,13 +454,13 @@ private class LogHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         List<Log__Share> logShares = [SELECT AccessLevel, ParentId, RowCause, UserOrGroupId FROM Log__Share WHERE ParentId = :log.Id AND AccessLevel != 'All'];
-        System.assertEquals(0, logShares.size(), logShares);
+        System.Assert.areEqual(0, logShares.size(), JSON.serializePretty(logShares));
     }
 
     private static String getDefaultPicklistValue(Schema.SObjectField field) {

--- a/nebula-logger/core/tests/log-management/classes/LogManagementDataSelector_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogManagementDataSelector_Tests.cls
@@ -131,7 +131,7 @@ private class LogManagementDataSelector_Tests {
 
     @IsTest
     static void it_returns_count_of_related_record_log_entries() {
-        Id targetRecordId = UserInfo.getUserId();
+        Id targetRecordId = System.UserInfo.getUserId();
         LoggerSObjectHandler.shouldExecute(false);
         Log__c log = (Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord();
         insert log;
@@ -155,7 +155,7 @@ private class LogManagementDataSelector_Tests {
         LoggerSObjectHandler.shouldExecute(false);
         Log__c deleteableRecord = (Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord();
         insert deleteableRecord;
-        User undeleteableRecord = new User(Id = UserInfo.getUserId());
+        User undeleteableRecord = new User(Id = System.UserInfo.getUserId());
         List<Id> recordIds = new List<Id>{ deleteableRecord.Id, undeleteableRecord.Id };
 
         List<UserRecordAccess> returnedResults = LogManagementDataSelector.getInstance().getDeleteableUserRecordAccess(recordIds);
@@ -255,7 +255,7 @@ private class LogManagementDataSelector_Tests {
 
     @IsTest
     static void it_returns_related_log_entries_for_specified_record_id() {
-        Id targetRecordId = UserInfo.getUserId();
+        Id targetRecordId = System.UserInfo.getUserId();
         LoggerSObjectHandler.shouldExecute(false);
         Log__c log = (Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord();
         insert log;
@@ -329,7 +329,7 @@ private class LogManagementDataSelector_Tests {
 
     @IsTest
     static void it_returns_user_for_specified_search_term() {
-        String searchTerm = UserInfo.getLastName();
+        String searchTerm = System.UserInfo.getLastName();
         List<User> expectedResults = [SELECT Id, Name, Username, SmallPhotoUrl FROM User WHERE Name LIKE :searchTerm OR Username LIKE :searchTerm];
 
         List<User> returnedResults = LogManagementDataSelector.getInstance().getUsersByNameSearch(searchTerm);

--- a/nebula-logger/core/tests/log-management/classes/LogManagementDataSelector_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogManagementDataSelector_Tests.cls
@@ -14,7 +14,7 @@ private class LogManagementDataSelector_Tests {
 
         List<SObject> returnedResults = LogManagementDataSelector.getInstance().getAll(targetSObjectType, targetFieldNames);
 
-        System.assertEquals(expectedResults, returnedResults);
+        System.Assert.areEqual(expectedResults, returnedResults);
     }
 
     @IsTest
@@ -32,7 +32,7 @@ private class LogManagementDataSelector_Tests {
 
         List<SObject> returnedResults = LogManagementDataSelector.getInstance().getById(targetSObjectType, targetFieldNames, targetIds);
 
-        System.assertEquals(expectedResults, returnedResults);
+        System.Assert.areEqual(expectedResults, returnedResults);
     }
 
     @IsTest
@@ -47,7 +47,7 @@ private class LogManagementDataSelector_Tests {
 
         List<ApexClass> returnedResults = LogManagementDataSelector.getInstance().getApexClasses(targetApexClassNames);
 
-        System.assertEquals(expectedResults, returnedResults);
+        System.Assert.areEqual(expectedResults, returnedResults);
     }
 
     @IsTest
@@ -59,21 +59,21 @@ private class LogManagementDataSelector_Tests {
 
         List<ApexClass> returnedResults = LogManagementDataSelector.getInstance().getApexClasses(targetApexClassNames);
 
-        System.assertEquals(originalQueryCount, System.Limits.getQueries());
-        System.assertEquals(0, returnedResults.size());
+        System.Assert.areEqual(originalQueryCount, System.Limits.getQueries());
+        System.Assert.areEqual(0, returnedResults.size());
     }
 
     @IsTest
     static void it_returns_cached_apex_email_notifications() {
         List<ApexEmailNotification> expectedResults = [SELECT Email, UserId FROM ApexEmailNotification WHERE Email != NULL OR User.IsActive = TRUE];
-        System.assertEquals(1, System.Limits.getQueries());
+        System.Assert.areEqual(1, System.Limits.getQueries());
 
         List<ApexEmailNotification> returnedResults = LogManagementDataSelector.getInstance().getCachedApexEmailNotifications();
 
-        System.assertEquals(2, System.Limits.getQueries());
+        System.Assert.areEqual(2, System.Limits.getQueries());
         LogManagementDataSelector.getInstance().getCachedApexEmailNotifications();
-        System.assertEquals(2, System.Limits.getQueries());
-        System.assertEquals(expectedResults, returnedResults);
+        System.Assert.areEqual(2, System.Limits.getQueries());
+        System.Assert.areEqual(expectedResults, returnedResults);
     }
 
     // FIXME Querying AsyncApexJob in a test context doesn't seem to return results for @future methods,
@@ -84,16 +84,16 @@ private class LogManagementDataSelector_Tests {
     //     String apexClassName = LogManagementDataSelector_Tests.class.getName();
     //     String apexMethodName = 'executeSomeFutureMethod';
     //     List<String> jobStatuses = new List<String>{ 'Holding', 'Queued', 'Preparing', 'Processing' };
-    //     System.assertEquals(0, LogManagementDataSelector.getInstance().getCountOfAsyncApexJobs(apexClassName, apexMethodName, jobStatuses));
+    //     System.Assert.areEqual(0, LogManagementDataSelector.getInstance().getCountOfAsyncApexJobs(apexClassName, apexMethodName, jobStatuses));
 
     //     System.Test.startTest();
     //     executeSomeFutureMethod();
     //     System.Test.stopTest();
 
-    //     System.assert(false, [SELECT status FROM asyncapexjob]);
+    //     System.Assert.fail([SELECT status FROM asyncapexjob]);
     //     Integer returnedCount = LogManagementDataSelector.getInstance().getCountOfAsyncApexJobs(apexClassName, apexMethodName, jobStatuses);
 
-    //     System.assertEquals(1, returnedCount);
+    //     System.Assert.areEqual(1, returnedCount);
     // }
 
     @IsTest
@@ -104,29 +104,29 @@ private class LogManagementDataSelector_Tests {
         Log__c expectedLog = new Log__c(ApiReleaseNumber__c = 'QWERTY', ApiReleaseVersion__c = 'ASDF', TransactionId__c = 'XYZ');
         insert new List<Log__c>{ olderLog, expectedLog };
         System.Test.setCreatedDate(olderLog.Id, System.now().addMinutes(-5));
-        System.assertEquals(1, System.Limits.getQueries());
+        System.Assert.areEqual(1, System.Limits.getQueries());
 
         for (Integer i = 0; i < 5; i++) {
             Log__c returnedLog = LogManagementDataSelector.getInstance().getCachedRecentLogWithApiReleaseDetails();
 
-            System.assertEquals(expectedLog.Id, returnedLog.Id);
+            System.Assert.areEqual(expectedLog.Id, returnedLog.Id);
         }
 
-        System.assertEquals(2, System.Limits.getQueries());
+        System.Assert.areEqual(2, System.Limits.getQueries());
     }
 
     @IsTest
     static void it_returns_null_when_no_recent_log_with_api_release_details_is_found() {
-        System.assertEquals(0, [SELECT COUNT() FROM Log__c]);
-        System.assertEquals(1, System.Limits.getQueries());
+        System.Assert.areEqual(0, [SELECT COUNT() FROM Log__c]);
+        System.Assert.areEqual(1, System.Limits.getQueries());
 
         for (Integer i = 0; i < 5; i++) {
             Log__c returnedLog = LogManagementDataSelector.getInstance().getCachedRecentLogWithApiReleaseDetails();
 
-            System.assertEquals(null, returnedLog);
+            System.Assert.isNull(returnedLog);
         }
 
-        System.assertEquals(2, System.Limits.getQueries());
+        System.Assert.areEqual(2, System.Limits.getQueries());
     }
 
     @IsTest
@@ -147,7 +147,7 @@ private class LogManagementDataSelector_Tests {
 
         Integer returnedCount = LogManagementDataSelector.getInstance().getCountOfRelatedRecordLogEntries(targetRecordId);
 
-        System.assertEquals(1, returnedCount);
+        System.Assert.areEqual(1, returnedCount);
     }
 
     @IsTest
@@ -160,8 +160,8 @@ private class LogManagementDataSelector_Tests {
 
         List<UserRecordAccess> returnedResults = LogManagementDataSelector.getInstance().getDeleteableUserRecordAccess(recordIds);
 
-        System.assertEquals(1, returnedResults.size());
-        System.assertEquals(deleteableRecord.Id, returnedResults.get(0).RecordId);
+        System.Assert.areEqual(1, returnedResults.size());
+        System.Assert.areEqual(deleteableRecord.Id, returnedResults.get(0).RecordId);
     }
 
     @IsTest
@@ -172,7 +172,7 @@ private class LogManagementDataSelector_Tests {
 
         Log__c returnedLog = LogManagementDataSelector.getInstance().getLogById(log.Id);
 
-        System.assertEquals(log.Id, returnedLog.Id);
+        System.Assert.areEqual(log.Id, returnedLog.Id);
     }
 
     @IsTest
@@ -189,7 +189,7 @@ private class LogManagementDataSelector_Tests {
 
         List<Log__c> returnedResults = LogManagementDataSelector.getInstance().getLogsById(logIds);
 
-        System.assertEquals(logs.size(), returnedResults.size());
+        System.Assert.areEqual(logs.size(), returnedResults.size());
     }
 
     @IsTest
@@ -207,7 +207,7 @@ private class LogManagementDataSelector_Tests {
 
         List<Log__c> returnedResults = LogManagementDataSelector.getInstance().getLogsByTransactionId(logTransactionIds);
 
-        System.assertEquals(logs.size(), returnedResults.size());
+        System.Assert.areEqual(logs.size(), returnedResults.size());
     }
 
     @IsTest
@@ -219,7 +219,7 @@ private class LogManagementDataSelector_Tests {
 
         expectedResults.sort();
         returnedResults.sort();
-        System.assertEquals(expectedResults, returnedResults);
+        System.Assert.areEqual(expectedResults, returnedResults);
     }
 
     @IsTest
@@ -231,7 +231,7 @@ private class LogManagementDataSelector_Tests {
 
         expectedResults.sort();
         returnedResults.sort();
-        System.assertEquals(expectedResults, returnedResults);
+        System.Assert.areEqual(expectedResults, returnedResults);
     }
 
     @IsTest
@@ -250,7 +250,7 @@ private class LogManagementDataSelector_Tests {
 
         List<Group> returnedResults = LogManagementDataSelector.getInstance().getQueuesByDeveloperName(targetQueueNames);
 
-        System.assertEquals(expectedResults, returnedResults);
+        System.Assert.areEqual(expectedResults, returnedResults);
     }
 
     @IsTest
@@ -277,8 +277,8 @@ private class LogManagementDataSelector_Tests {
 
         List<LogEntry__c> returnedResults = LogManagementDataSelector.getInstance().getRecordLogEntries(targetRecordId, fieldsClause, orderByClause, rowLimit);
 
-        System.assertEquals(1, returnedResults.size());
-        System.assertEquals(matchingLogEntry.Id, returnedResults.get(0).Id);
+        System.Assert.areEqual(1, returnedResults.size());
+        System.Assert.areEqual(matchingLogEntry.Id, returnedResults.get(0).Id);
     }
 
     @IsTest
@@ -291,11 +291,11 @@ private class LogManagementDataSelector_Tests {
         insert tags;
         Set<String> targetTagNames = new Set<String>{ matchingTag.Name };
         List<LoggerTag__c> expectedResults = [SELECT Id, Name FROM LoggerTag__c WHERE Name IN :targetTagNames];
-        System.assertEquals(1, expectedResults.size());
+        System.Assert.areEqual(1, expectedResults.size());
 
         List<LoggerTag__c> returnedResults = LogManagementDataSelector.getInstance().getTagsByName(targetTagNames);
 
-        System.assertEquals(expectedResults, returnedResults);
+        System.Assert.areEqual(expectedResults, returnedResults);
     }
 
     @IsTest
@@ -308,11 +308,11 @@ private class LogManagementDataSelector_Tests {
         insert topics;
         Set<String> targetTopicNames = new Set<String>{ matchingTopic.Name };
         List<Topic> expectedResults = [SELECT Id, Name FROM Topic WHERE Name IN :targetTopicNames];
-        System.assertEquals(1, expectedResults.size());
+        System.Assert.areEqual(1, expectedResults.size());
 
         List<Topic> returnedResults = LogManagementDataSelector.getInstance().getTopicsByName(targetTopicNames);
 
-        System.assertEquals(expectedResults, returnedResults);
+        System.Assert.areEqual(expectedResults, returnedResults);
     }
 
     @IsTest
@@ -324,7 +324,7 @@ private class LogManagementDataSelector_Tests {
 
         expectedResults.sort();
         returnedResults.sort();
-        System.assertEquals(expectedResults, returnedResults);
+        System.Assert.areEqual(expectedResults, returnedResults);
     }
 
     @IsTest
@@ -336,7 +336,7 @@ private class LogManagementDataSelector_Tests {
 
         expectedResults.sort();
         returnedResults.sort();
-        System.assertEquals(expectedResults, returnedResults);
+        System.Assert.areEqual(expectedResults, returnedResults);
     }
 
     @IsTest
@@ -351,17 +351,17 @@ private class LogManagementDataSelector_Tests {
 
         expectedResults.sort();
         returnedResults.sort();
-        System.assertEquals(expectedResults, returnedResults);
+        System.Assert.areEqual(expectedResults, returnedResults);
     }
 
     @IsTest
     static void it_loads_mock_instance() {
         MockLogManagementDataSelector mockSelector = new MockLogManagementDataSelector();
-        System.assertNotEquals(mockSelector, LogManagementDataSelector.getInstance());
+        System.Assert.areNotEqual(mockSelector, LogManagementDataSelector.getInstance());
 
         LogManagementDataSelector.setMock(mockSelector);
 
-        System.assertEquals(mockSelector, LogManagementDataSelector.getInstance());
+        System.Assert.areEqual(mockSelector, LogManagementDataSelector.getInstance());
     }
 
     @SuppressWarnings('PMD.EmptyStatementBlock')

--- a/nebula-logger/core/tests/log-management/classes/LogMassDeleteExtension_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogMassDeleteExtension_Tests.cls
@@ -30,7 +30,7 @@ private class LogMassDeleteExtension_Tests {
         for (UserRecordAccess recordAccess : [
             SELECT RecordId
             FROM UserRecordAccess
-            WHERE UserId = :UserInfo.getUserId() AND RecordId IN :logIds AND HasDeleteAccess = TRUE
+            WHERE UserId = :System.UserInfo.getUserId() AND RecordId IN :logIds AND HasDeleteAccess = TRUE
         ]) {
             expectedDeletableLogs.add(new Log__c(Id = recordAccess.RecordId));
         }

--- a/nebula-logger/core/tests/log-management/classes/LogMassDeleteExtension_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogMassDeleteExtension_Tests.cls
@@ -42,7 +42,7 @@ private class LogMassDeleteExtension_Tests {
         LogMassDeleteExtension extension = new LogMassDeleteExtension(controller);
         List<Log__c> returnedDeletableLogs = extension.getDeletableLogs();
 
-        System.assertEquals(expectedDeletableLogs.size(), returnedDeletableLogs.size());
+        System.Assert.areEqual(expectedDeletableLogs.size(), returnedDeletableLogs.size());
     }
 
     @IsTest
@@ -68,11 +68,11 @@ private class LogMassDeleteExtension_Tests {
 
         logsToDelete = [SELECT Id, IsDeleted FROM Log__c WHERE Id IN :logsToDelete ALL ROWS];
         for (Log__c log : logsToDelete) {
-            System.assertEquals(true, log.IsDeleted, log);
+            System.Assert.isTrue(log.IsDeleted, JSON.serializePretty(log));
         }
         logsToKeep = [SELECT Id, IsDeleted FROM Log__c WHERE Id IN :logsToKeep ALL ROWS];
         for (Log__c log : logsToKeep) {
-            System.assertEquals(false, log.IsDeleted, log);
+            System.Assert.isFalse(log.IsDeleted, JSON.serializePretty(log));
         }
     }
 }

--- a/nebula-logger/core/tests/log-management/classes/LogViewerController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogViewerController_Tests.cls
@@ -24,6 +24,6 @@ private class LogViewerController_Tests {
 
         Log__c returnedLog = LogViewerController.getLog(log.Id);
 
-        System.assertEquals(log.Id, returnedLog.Id);
+        System.Assert.areEqual(log.Id, returnedLog.Id);
     }
 }

--- a/nebula-logger/core/tests/log-management/classes/LoggerBatchableContext_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerBatchableContext_Tests.cls
@@ -13,9 +13,9 @@ private class LoggerBatchableContext_Tests {
 
         LoggerBatchableContext context = new LoggerBatchableContext(mockBatchableContext, sobjectType);
 
-        System.assertEquals(mockBatchableContext, context.batchableContext);
-        System.assertEquals(sobjectType, context.sobjectType);
-        System.assertEquals(sobjectType.getDescribe().getName(), context.sobjectTypeName);
+        System.Assert.areEqual(mockBatchableContext, context.batchableContext);
+        System.Assert.areEqual(sobjectType, context.sobjectType);
+        System.Assert.areEqual(sobjectType.getDescribe().getName(), context.sobjectTypeName);
     }
 
     @IsTest
@@ -25,8 +25,8 @@ private class LoggerBatchableContext_Tests {
 
         LoggerBatchableContext context = new LoggerBatchableContext(nullBatchableContext, nullSObjectType);
 
-        System.assertEquals(null, context.batchableContext);
-        System.assertEquals(null, context.sobjectType);
-        System.assertEquals(null, context.sobjectTypeName);
+        System.Assert.isNull(context.batchableContext);
+        System.Assert.isNull(context.sobjectType);
+        System.Assert.isNull(context.sobjectTypeName);
     }
 }

--- a/nebula-logger/core/tests/log-management/classes/LoggerEmailSender_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerEmailSender_Tests.cls
@@ -15,11 +15,11 @@ private class LoggerEmailSender_Tests {
 
         List<String> returnedRecipients = LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS;
 
-        System.assertEquals(3, returnedRecipients.size(), 'Should have returned 3 recipients: 1 for the user ID, and 2 for the email addresses');
+        System.Assert.areEqual(3, returnedRecipients.size(), 'Should have returned 3 recipients: 1 for the user ID, and 2 for the email addresses');
         for (String recipient : returnedRecipients) {
             Boolean matchesUserNotification = String.valueOf(userNotification.UserId) == recipient;
             Boolean matchesEmailListNotification = new Set<String>(emailListNotification.Email.split(';')).contains(recipient.trim());
-            System.assertEquals(
+            System.Assert.areEqual(
                 true,
                 matchesUserNotification || matchesEmailListNotification,
                 'Returned recipient ' +
@@ -33,102 +33,102 @@ private class LoggerEmailSender_Tests {
     @IsTest
     static void it_should_send_email_notification_for_saveResult_errors_when_enabled() {
         LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.add(UserInfo.getUserId());
-        System.assertEquals(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
+        System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
 
         // LogEntry__c requires a Log__c parent record, so inserting a LogEntry__c with no fields set will (intentionally) fail
         List<Database.SaveResult> saveResultsWithErrors = new List<Database.SaveResult>{ LoggerMockDataCreator.createDatabaseSaveResult(false) };
         LoggerEmailSender.sendErrorEmail(Schema.LogEntry__c.SObjectType, saveResultsWithErrors);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             true,
             LoggerEmailSender.SENT_EMAILS.get(0).getHtmlBody().contains(saveResultsWithErrors.get(0).errors.get(0).getMessage()),
             'Email message should contain SaveResult error message'
         );
         if (LoggerEmailSender.IS_EMAIL_DELIVERABILITY_ENABLED == true) {
-            System.assertEquals(1, System.Limits.getEmailInvocations(), 'Email should have been sent');
+            System.Assert.areEqual(1, System.Limits.getEmailInvocations(), 'Email should have been sent');
         } else {
-            System.assertEquals(0, System.Limits.getEmailInvocations(), 'Deliverability is not currently enabled');
+            System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'Deliverability is not currently enabled');
         }
     }
 
     @IsTest
     static void it_should_not_send_email_notification_for_saveResult_errors_when_no_recipients_configured() {
         LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'SendErrorEmailNotifications', Value__c = 'true'));
-        System.assertEquals(true, LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS);
+        System.Assert.isTrue(LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS);
         LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.clear();
-        System.assertEquals(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
+        System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
 
         // LogEntry__c requires a Log__c parent record, so inserting a LogEntry__c with no fields set will (intentionally) fail
         List<Database.SaveResult> saveResultsWithErrors = new List<Database.SaveResult>{ LoggerMockDataCreator.createDatabaseSaveResult(false) };
         LoggerEmailSender.sendErrorEmail(Schema.LogEntry__c.SObjectType, saveResultsWithErrors);
 
-        System.assertEquals(true, LoggerEmailSender.SENT_EMAILS.isEmpty(), 'No email messages should have been generated');
-        System.assertEquals(0, System.Limits.getEmailInvocations(), 'No emails should have been sent');
+        System.Assert.isTrue(LoggerEmailSender.SENT_EMAILS.isEmpty(), 'No email messages should have been generated');
+        System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent');
     }
 
     @IsTest
     static void it_should_not_send_email_notification_for_saveResult_errors_when_disabled() {
         LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'SendErrorEmailNotifications', Value__c = 'false'));
-        System.assertEquals(false, LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS);
+        System.Assert.isFalse(LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS);
         LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.add(UserInfo.getUserId());
-        System.assertEquals(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
+        System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
 
         // LogEntry__c requires a Log__c parent record, so inserting a LogEntry__c with no fields set will (intentionally) fail
         List<Database.SaveResult> saveResultsWithErrors = new List<Database.SaveResult>{ LoggerMockDataCreator.createDatabaseSaveResult(false) };
         LoggerEmailSender.sendErrorEmail(Schema.LogEntry__c.SObjectType, saveResultsWithErrors);
 
-        System.assertEquals(true, LoggerEmailSender.SENT_EMAILS.isEmpty(), 'No email messages should have been generated');
-        System.assertEquals(0, System.Limits.getEmailInvocations(), 'No emails should have been sent');
+        System.Assert.isTrue(LoggerEmailSender.SENT_EMAILS.isEmpty(), 'No email messages should have been generated');
+        System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent');
     }
 
     @IsTest
     static void it_should_send_email_notification_for_upsertResult_errors_when_enabled() {
         LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.add(UserInfo.getUserId());
-        System.assertEquals(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
+        System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
 
         // LogEntry__c requires a Log__c parent record, so inserting a LogEntry__c with no fields set will (intentionally) fail
         List<Database.UpsertResult> upsertResultsWithErrors = Database.upsert(new List<LogEntry__c>{ new LogEntry__c() }, false);
         LoggerEmailSender.sendErrorEmail(Schema.LogEntry__c.SObjectType, upsertResultsWithErrors);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             true,
             LoggerEmailSender.SENT_EMAILS.get(0).getHtmlBody().contains(upsertResultsWithErrors.get(0).errors.get(0).getMessage()),
             'Email message should contain UpsertResult error message'
         );
         if (LoggerEmailSender.IS_EMAIL_DELIVERABILITY_ENABLED == true) {
-            System.assertEquals(1, System.Limits.getEmailInvocations(), 'Email should have been sent');
+            System.Assert.areEqual(1, System.Limits.getEmailInvocations(), 'Email should have been sent');
         } else {
-            System.assertEquals(0, System.Limits.getEmailInvocations(), 'Deliverability is not currently enabled');
+            System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'Deliverability is not currently enabled');
         }
     }
 
     @IsTest
     static void it_should_not_send_email_notification_for_upsertResult_errors_when_no_recipients_configured() {
         LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'SendErrorEmailNotifications', Value__c = 'true'));
-        System.assertEquals(true, LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS);
+        System.Assert.isTrue(LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS);
         LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.clear();
-        System.assertEquals(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
+        System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
 
         // LogEntry__c requires a Log__c parent record, so inserting a LogEntry__c with no fields set will (intentionally) fail
         List<Database.UpsertResult> upsertResultsWithErrors = Database.upsert(new List<LogEntry__c>{ new LogEntry__c() }, false);
         LoggerEmailSender.sendErrorEmail(Schema.LogEntry__c.SObjectType, upsertResultsWithErrors);
 
-        System.assertEquals(true, LoggerEmailSender.SENT_EMAILS.isEmpty(), 'No email messages should have been generated');
-        System.assertEquals(0, System.Limits.getEmailInvocations(), 'No emails should have been sent');
+        System.Assert.isTrue(LoggerEmailSender.SENT_EMAILS.isEmpty(), 'No email messages should have been generated');
+        System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent');
     }
 
     @IsTest
     static void it_should_not_send_email_notification_for_upsertResult_errors_when_disabled() {
         LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'SendErrorEmailNotifications', Value__c = 'false'));
-        System.assertEquals(false, LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS);
+        System.Assert.isFalse(LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS);
         LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.add(UserInfo.getUserId());
-        System.assertEquals(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
+        System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
 
         // LogEntry__c requires a Log__c parent record, so inserting a LogEntry__c with no fields set will (intentionally) fail
         List<Database.UpsertResult> upsertResultsWithErrors = Database.upsert(new List<LogEntry__c>{ new LogEntry__c() }, false);
         LoggerEmailSender.sendErrorEmail(Schema.LogEntry__c.SObjectType, upsertResultsWithErrors);
 
-        System.assertEquals(0, System.Limits.getEmailInvocations(), 'No emails should have been sent');
-        System.assertEquals(true, LoggerEmailSender.SENT_EMAILS.isEmpty(), 'No email messages should have been generated');
+        System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent');
+        System.Assert.isTrue(LoggerEmailSender.SENT_EMAILS.isEmpty(), 'No email messages should have been generated');
     }
 }

--- a/nebula-logger/core/tests/log-management/classes/LoggerEmailSender_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerEmailSender_Tests.cls
@@ -9,7 +9,7 @@ private class LoggerEmailSender_Tests {
     @IsTest
     static void it_should_filter_apex_error_recipients() {
         ApexEmailNotification emailListNotification = new ApexEmailNotification(Email = 'hello@test.com;fake.person@not.real.com.biz', UserId = null);
-        ApexEmailNotification userNotification = new ApexEmailNotification(Email = null, UserId = UserInfo.getUserId());
+        ApexEmailNotification userNotification = new ApexEmailNotification(Email = null, UserId = System.UserInfo.getUserId());
         ApexEmailNotification invalidNotification = new ApexEmailNotification(Email = null, UserId = null);
         LoggerEmailSender.MOCK_NOTIFICATIONS.addAll(new List<ApexEmailNotification>{ emailListNotification, userNotification, invalidNotification });
 
@@ -32,7 +32,7 @@ private class LoggerEmailSender_Tests {
 
     @IsTest
     static void it_should_send_email_notification_for_saveResult_errors_when_enabled() {
-        LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.add(UserInfo.getUserId());
+        LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.add(System.UserInfo.getUserId());
         System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
 
         // LogEntry__c requires a Log__c parent record, so inserting a LogEntry__c with no fields set will (intentionally) fail
@@ -70,7 +70,7 @@ private class LoggerEmailSender_Tests {
     static void it_should_not_send_email_notification_for_saveResult_errors_when_disabled() {
         LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'SendErrorEmailNotifications', Value__c = 'false'));
         System.Assert.isFalse(LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS);
-        LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.add(UserInfo.getUserId());
+        LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.add(System.UserInfo.getUserId());
         System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
 
         // LogEntry__c requires a Log__c parent record, so inserting a LogEntry__c with no fields set will (intentionally) fail
@@ -83,7 +83,7 @@ private class LoggerEmailSender_Tests {
 
     @IsTest
     static void it_should_send_email_notification_for_upsertResult_errors_when_enabled() {
-        LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.add(UserInfo.getUserId());
+        LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.add(System.UserInfo.getUserId());
         System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
 
         // LogEntry__c requires a Log__c parent record, so inserting a LogEntry__c with no fields set will (intentionally) fail
@@ -121,7 +121,7 @@ private class LoggerEmailSender_Tests {
     static void it_should_not_send_email_notification_for_upsertResult_errors_when_disabled() {
         LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'SendErrorEmailNotifications', Value__c = 'false'));
         System.Assert.isFalse(LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS);
-        LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.add(UserInfo.getUserId());
+        LoggerEmailSender.CACHED_APEX_ERROR_RECIPIENTS.add(System.UserInfo.getUserId());
         System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'No emails should have been sent yet');
 
         // LogEntry__c requires a Log__c parent record, so inserting a LogEntry__c with no fields set will (intentionally) fail

--- a/nebula-logger/core/tests/log-management/classes/LoggerSObjectMetadata_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerSObjectMetadata_Tests.cls
@@ -29,22 +29,22 @@ private class LoggerSObjectMetadata_Tests {
 
     private static void validateSObjectDetails(Schema.SObjectType sobjectType, LoggerSObjectMetadata.SObjectSchema sobjectSchema) {
         // SObject details
-        System.assertEquals(sobjectType.getDescribe().getLabel(), sobjectSchema.label);
-        System.assertEquals(sobjectType.getDescribe().getLabelPlural(), sobjectSchema.labelPlural);
-        System.assertEquals(sobjectType.getDescribe().getLocalName(), sobjectSchema.localApiName);
-        System.assertEquals(sobjectType.getDescribe().getName(), sobjectSchema.apiName);
-        System.assertEquals(sobjectType.getDescribe().fields.getMap().size(), sobjectSchema.fields.size());
+        System.Assert.areEqual(sobjectType.getDescribe().getLabel(), sobjectSchema.label);
+        System.Assert.areEqual(sobjectType.getDescribe().getLabelPlural(), sobjectSchema.labelPlural);
+        System.Assert.areEqual(sobjectType.getDescribe().getLocalName(), sobjectSchema.localApiName);
+        System.Assert.areEqual(sobjectType.getDescribe().getName(), sobjectSchema.apiName);
+        System.Assert.areEqual(sobjectType.getDescribe().fields.getMap().size(), sobjectSchema.fields.size());
 
         // Field details
         for (Schema.SObjectField field : sobjectType.getDescribe().fields.getMap().values()) {
-            System.assert(sobjectSchema.fields.containsKey(field.getDescribe().getLocalName()));
+            System.Assert.isTrue(sobjectSchema.fields.containsKey(field.getDescribe().getLocalName()));
         }
         for (LoggerSObjectMetadata.FieldSchema fieldSchema : sobjectSchema.fields.values()) {
             Schema.SObjectField matchingField = sobjectType.getDescribe().fields.getMap().get(fieldSchema.apiName);
-            System.assertEquals(matchingField.getDescribe().getLocalName(), fieldSchema.localApiName);
-            System.assertEquals(matchingField.getDescribe().getInlineHelpText(), fieldSchema.inlineHelpText);
-            System.assertEquals(matchingField.getDescribe().getLabel(), fieldSchema.label);
-            System.assertEquals(matchingField.getDescribe().getType().name().toLowerCase(), fieldSchema.type);
+            System.Assert.areEqual(matchingField.getDescribe().getLocalName(), fieldSchema.localApiName);
+            System.Assert.areEqual(matchingField.getDescribe().getInlineHelpText(), fieldSchema.inlineHelpText);
+            System.Assert.areEqual(matchingField.getDescribe().getLabel(), fieldSchema.label);
+            System.Assert.areEqual(matchingField.getDescribe().getType().name().toLowerCase(), fieldSchema.type);
         }
     }
 }

--- a/nebula-logger/core/tests/log-management/classes/LoggerScenarioHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerScenarioHandler_Tests.cls
@@ -8,7 +8,7 @@
 private class LoggerScenarioHandler_Tests {
     @IsTest
     static void it_should_return_the_loggerScenario_sobjectType() {
-        System.assertEquals(Schema.LoggerScenario__c.SObjectType, new LoggerScenarioHandler().getSObjectType());
+        System.Assert.areEqual(Schema.LoggerScenario__c.SObjectType, new LoggerScenarioHandler().getSObjectType());
     }
 
     @IsTest
@@ -21,7 +21,7 @@ private class LoggerScenarioHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(loggerScenario);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LoggerScenario__c.SObjectType).size(),
             'Handler class should not have executed'
@@ -38,7 +38,7 @@ private class LoggerScenarioHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(loggerScenario);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LoggerScenario__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
@@ -59,19 +59,19 @@ private class LoggerScenarioHandler_Tests {
 
         try {
             insert duplicateScenario;
-            System.assert(false, 'Exception expected on previous line');
+            System.Assert.fail('Exception expected on previous line');
         } catch (Exception ex) {
             thrownException = ex;
         }
 
-        System.assertEquals(
+        System.Assert.areEqual(
             3,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LoggerScenario__c.SObjectType).size(),
             'Handler class should have executed three times - once for BEFORE_INSERT and once for AFTER_INSERT for the first record,' +
             ' and once for BEFORE_INSERT on the errored duplicate'
         );
-        System.assertNotEquals(null, thrownException, 'An exception should have been thrown');
+        System.Assert.isNotNull(thrownException, 'An exception should have been thrown');
         String expectedDuplicateError = 'DUPLICATE_VALUE';
-        System.assert(thrownException.getMessage().contains(expectedDuplicateError), thrownException.getMessage());
+        System.Assert.isTrue(thrownException.getMessage().contains(expectedDuplicateError), thrownException.getMessage());
     }
 }

--- a/nebula-logger/core/tests/log-management/classes/LoggerScenarioHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerScenarioHandler_Tests.cls
@@ -55,12 +55,12 @@ private class LoggerScenarioHandler_Tests {
         LoggerScenario__c duplicateScenario = (LoggerScenario__c) LoggerMockDataCreator.createDataBuilder(new LoggerScenario__c(Name = loggerScenario.Name))
             .populateRequiredFields()
             .getRecord();
-        Exception thrownException;
+        System.Exception thrownException;
 
         try {
             insert duplicateScenario;
-            System.Assert.fail('Exception expected on previous line');
-        } catch (Exception ex) {
+            System.Assert.fail('System.Exception expected on previous line');
+        } catch (System.Exception ex) {
             thrownException = ex;
         }
 

--- a/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
@@ -231,8 +231,8 @@ private class LoggerSettingsController_Tests {
         try {
             LoggerSettingsController.saveRecord(invalidRecord);
             System.Assert.fail('Expected exception from previous line, this assert should not run');
-        } catch (Exception ex) {
-            System.Assert.areEqual(AuraHandledException.class.getName(), ex.getTypeName());
+        } catch (System.Exception apexException) {
+            System.Assert.isInstanceOfType(apexException, System.AuraHandledException.class);
         }
     }
 
@@ -255,17 +255,17 @@ private class LoggerSettingsController_Tests {
         String expectedExceptionMessage;
         try {
             LoggerDataStore.getDatabase().deleteRecord(invalidRecord);
-        } catch (Exception ex) {
+        } catch (System.Exception ex) {
             expectedExceptionMessage = ex.getMessage();
         }
 
         try {
             LoggerSettingsController.deleteRecord(invalidRecord);
             System.Assert.fail('Expected exception from previous line, this assert should not run');
-        } catch (Exception ex) {
+        } catch (System.Exception ex) {
             System.Assert.isTrue(
                 ex.getMessage().contains(expectedExceptionMessage),
-                'Exception did not contain expected message, received: ' + ex.getMessage()
+                'System.Exception did not contain expected message, received: ' + ex.getMessage()
             );
         }
     }
@@ -341,10 +341,10 @@ private class LoggerSettingsController_Tests {
         try {
             LoggerSettingsController.searchForSetupOwner(invalidSetupOwnerType, searchTerm);
             System.Assert.fail('Expected exception from previous line, this assert should not run');
-        } catch (Exception ex) {
+        } catch (System.Exception ex) {
             System.Assert.isTrue(
                 ex.getMessage().contains(expectedExceptionMessage),
-                'Exception did not contain expected message, received: ' + ex.getMessage()
+                'System.Exception did not contain expected message, received: ' + ex.getMessage()
             );
         }
     }

--- a/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
@@ -171,8 +171,8 @@ private class LoggerSettingsController_Tests {
     static void it_should_return_settings_records_when_configured() {
         System.Assert.areEqual(0, [SELECT COUNT() FROM LoggerSettings__c]);
         LoggerSettings__c orgDefaultSettingsRecord = LoggerSettings__c.getOrgDefaults();
-        LoggerSettings__c profileSettingsRecord = LoggerSettings__c.getInstance(UserInfo.getProfileId());
-        LoggerSettings__c userSettingsRecord = LoggerSettings__c.getInstance(UserInfo.getUserId());
+        LoggerSettings__c profileSettingsRecord = LoggerSettings__c.getInstance(System.UserInfo.getProfileId());
+        LoggerSettings__c userSettingsRecord = LoggerSettings__c.getInstance(System.UserInfo.getUserId());
         List<LoggerSettings__c> testSettingsRecords = new List<LoggerSettings__c>{ orgDefaultSettingsRecord, profileSettingsRecord, userSettingsRecord };
         insert testSettingsRecords;
         Map<Id, LoggerSettings__c> testSettingsRecordsById = queryLoggerSettingsRecords(testSettingsRecords);
@@ -201,7 +201,7 @@ private class LoggerSettingsController_Tests {
     @IsTest
     static void it_should_save_new_record() {
         LoggerSettings__c newRecord = LoggerSettingsController.createRecord();
-        newRecord.SetupOwnerId = UserInfo.getUserId();
+        newRecord.SetupOwnerId = System.UserInfo.getUserId();
         System.Assert.isNull(newRecord.Id);
 
         LoggerSettingsController.saveRecord(newRecord);
@@ -287,7 +287,7 @@ private class LoggerSettingsController_Tests {
 
     @IsTest
     static void it_should_return_profile_search_results_list_when_matches_found() {
-        Profile currentProfile = [SELECT Id, Name FROM Profile WHERE Id = :UserInfo.getProfileId()];
+        Profile currentProfile = [SELECT Id, Name FROM Profile WHERE Id = :System.UserInfo.getProfileId()];
         String searchTerm = '%' + currentProfile.Name.left(4) + '%';
         Map<Id, Profile> expectedResultsById = new Map<Id, Profile>([SELECT Id, Name, UserLicense.Name FROM Profile WHERE Name LIKE :searchTerm]);
         List<LoggerSettingsController.SetupOwnerSearchResult> results = LoggerSettingsController.searchForSetupOwner('Profile', searchTerm);
@@ -313,7 +313,7 @@ private class LoggerSettingsController_Tests {
 
     @IsTest
     static void it_should_return_user_search_results_list_when_matches_found() {
-        String searchTerm = '%' + UserInfo.getFirstName() + '%';
+        String searchTerm = '%' + System.UserInfo.getFirstName() + '%';
         Map<Id, User> expectedResultsById = new Map<Id, User>(
             [SELECT Id, Name, Username, SmallPhotoUrl FROM User WHERE Name LIKE :searchTerm OR Username LIKE :searchTerm]
         );

--- a/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
@@ -8,7 +8,8 @@
 private class LoggerSettingsController_Tests {
     @IsTest
     static void it_should_return_loggingLevel_picklist_options() {
-        Integer expectedLoggingLevelSize = LoggingLevel.values().size() - 1; // LoggingLEVEL.NONE and LoggingLevel.INTERNAL are ignored, '--NONE--' is automatically included
+        //
+        Integer expectedLoggingLevelSize = System.LoggingLevel.values().size() - 1; // LoggingLEVEL.NONE and System.LoggingLevel.INTERNAL are ignored, '--NONE--' is automatically included
         List<LoggerSettingsController.PicklistOption> picklistOptions = LoggerSettingsController.getPicklistOptions().loggingLevelOptions;
         System.Assert.areEqual(expectedLoggingLevelSize, picklistOptions.size());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
@@ -16,7 +17,7 @@ private class LoggerSettingsController_Tests {
                 System.Assert.areEqual('--None--', picklistOption.label);
             } else {
                 System.Assert.areEqual(picklistOption.value, picklistOption.label);
-                LoggingLevel matchingLoggingLevel = LoggingLevel.valueOf(picklistOption.value);
+                System.LoggingLevel matchingLoggingLevel = System.LoggingLevel.valueOf(picklistOption.value);
                 System.Assert.areEqual(matchingLoggingLevel.name(), picklistOption.label);
             }
         }

--- a/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
@@ -10,14 +10,14 @@ private class LoggerSettingsController_Tests {
     static void it_should_return_loggingLevel_picklist_options() {
         Integer expectedLoggingLevelSize = LoggingLevel.values().size() - 1; // LoggingLEVEL.NONE and LoggingLevel.INTERNAL are ignored, '--NONE--' is automatically included
         List<LoggerSettingsController.PicklistOption> picklistOptions = LoggerSettingsController.getPicklistOptions().loggingLevelOptions;
-        System.assertEquals(expectedLoggingLevelSize, picklistOptions.size());
+        System.Assert.areEqual(expectedLoggingLevelSize, picklistOptions.size());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
             if (String.isBlank(picklistOption.value) == true) {
-                System.assertEquals('--None--', picklistOption.label);
+                System.Assert.areEqual('--None--', picklistOption.label);
             } else {
-                System.assertEquals(picklistOption.value, picklistOption.label);
+                System.Assert.areEqual(picklistOption.value, picklistOption.label);
                 LoggingLevel matchingLoggingLevel = LoggingLevel.valueOf(picklistOption.value);
-                System.assertEquals(matchingLoggingLevel.name(), picklistOption.label);
+                System.Assert.areEqual(matchingLoggingLevel.name(), picklistOption.label);
             }
         }
     }
@@ -39,13 +39,13 @@ private class LoggerSettingsController_Tests {
         Set<String> expectedLogPurgeActions = new Set<String>{ LoggerSettingsController.DELETE_LOG_PURGE_ACTION };
         expectedLogPurgeActions.addAll(fakeLogPurgeActions);
         Integer expectedLogPurgeActionsSize = expectedLogPurgeActions.size() + 1; // '--NONE--' is automatically included
-        System.assertEquals(expectedLogPurgeActionsSize, picklistOptions.size());
+        System.Assert.areEqual(expectedLogPurgeActionsSize, picklistOptions.size());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
             if (String.isBlank(picklistOption.value) == true) {
-                System.assertEquals('--None--', picklistOption.label);
+                System.Assert.areEqual('--None--', picklistOption.label);
             } else {
-                System.assertEquals(picklistOption.value, picklistOption.label);
-                System.assertEquals(true, expectedLogPurgeActions.contains(picklistOption.value));
+                System.Assert.areEqual(picklistOption.value, picklistOption.label);
+                System.Assert.areEqual(true, expectedLogPurgeActions.contains(picklistOption.value));
             }
         }
     }
@@ -54,14 +54,14 @@ private class LoggerSettingsController_Tests {
     static void it_should_return_loggerSaveMethod_picklist_options() {
         Integer expectedLoggerSaveMethodSize = Logger.SaveMethod.values().size() + 1; // '--NONE--' is automatically included
         List<LoggerSettingsController.PicklistOption> picklistOptions = LoggerSettingsController.getPicklistOptions().saveMethodOptions;
-        System.assertEquals(expectedLoggerSaveMethodSize, picklistOptions.size());
+        System.Assert.areEqual(expectedLoggerSaveMethodSize, picklistOptions.size());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
             if (String.isBlank(picklistOption.value) == true) {
-                System.assertEquals('--None--', picklistOption.label);
+                System.Assert.areEqual('--None--', picklistOption.label);
             } else {
-                System.assertEquals(picklistOption.value, picklistOption.label);
+                System.Assert.areEqual(picklistOption.value, picklistOption.label);
                 Logger.SaveMethod matchingLoggerSaveMethod = Logger.SaveMethod.valueOf(picklistOption.value);
-                System.assertEquals(matchingLoggerSaveMethod.name(), picklistOption.value);
+                System.Assert.areEqual(matchingLoggerSaveMethod.name(), picklistOption.value);
             }
         }
     }
@@ -83,13 +83,13 @@ private class LoggerSettingsController_Tests {
         Set<String> expectedSaveMethods = new Set<String>{ LoggerSettingsController.CUSTOM_OBJECTS_STORAGE_LOCATION };
         expectedSaveMethods.addAll(fakeStorageLocations);
         Integer expectedPlatformEventStorageLocationSize = expectedSaveMethods.size() + 1; // '--NONE--' is automatically included
-        System.assertEquals(expectedPlatformEventStorageLocationSize, picklistOptions.size(), picklistOptions);
+        System.Assert.areEqual(expectedPlatformEventStorageLocationSize, picklistOptions.size(), picklistOptions.toString());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
             if (String.isBlank(picklistOption.value) == true) {
-                System.assertEquals('--None--', picklistOption.label);
+                System.Assert.areEqual('--None--', picklistOption.label);
             } else {
-                System.assertEquals(picklistOption.value, picklistOption.label, 'picklistOption==' + picklistOption);
-                System.assertEquals(true, expectedSaveMethods.contains(picklistOption.value), 'picklistOption==' + picklistOption);
+                System.Assert.areEqual(picklistOption.value, picklistOption.label, 'picklistOption==' + picklistOption);
+                System.Assert.areEqual(true, expectedSaveMethods.contains(picklistOption.value), 'picklistOption==' + picklistOption);
             }
         }
     }
@@ -111,13 +111,13 @@ private class LoggerSettingsController_Tests {
             expectedSaveMethods.add(saveMethod.name());
         }
         Integer expectedLoggerSaveMethodSize = expectedSaveMethods.size() + 1; // '--NONE--' is automatically included
-        System.assertEquals(expectedLoggerSaveMethodSize, picklistOptions.size(), picklistOptions);
+        System.Assert.areEqual(expectedLoggerSaveMethodSize, picklistOptions.size(), picklistOptions.toString());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
             if (String.isBlank(picklistOption.value) == true) {
-                System.assertEquals('--None--', picklistOption.label);
+                System.Assert.areEqual('--None--', picklistOption.label);
             } else {
-                System.assertEquals(picklistOption.value, picklistOption.label, 'picklistOption==' + picklistOption);
-                System.assertEquals(true, expectedSaveMethods.contains(picklistOption.value), 'picklistOption==' + picklistOption);
+                System.Assert.areEqual(picklistOption.value, picklistOption.label, 'picklistOption==' + picklistOption);
+                System.Assert.areEqual(true, expectedSaveMethods.contains(picklistOption.value), 'picklistOption==' + picklistOption);
             }
         }
     }
@@ -127,13 +127,13 @@ private class LoggerSettingsController_Tests {
         Set<String> expectedSetupOwnerType = new Set<String>{ 'Organization', 'Profile', 'User' };
         Integer expectedSetupOwnerTypeSize = 4; // Options are org, profile, and user, and '--NONE--' is automatically included
         List<LoggerSettingsController.PicklistOption> picklistOptions = LoggerSettingsController.getPicklistOptions().setupOwnerTypeOptions;
-        System.assertEquals(expectedSetupOwnerTypeSize, picklistOptions.size());
+        System.Assert.areEqual(expectedSetupOwnerTypeSize, picklistOptions.size());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
             if (String.isBlank(picklistOption.value) == true) {
-                System.assertEquals('--None--', picklistOption.label);
+                System.Assert.areEqual('--None--', picklistOption.label);
             } else {
-                System.assertEquals(picklistOption.value, picklistOption.label);
-                System.assertEquals(true, expectedSetupOwnerType.contains(picklistOption.value));
+                System.Assert.areEqual(picklistOption.value, picklistOption.label);
+                System.Assert.areEqual(true, expectedSetupOwnerType.contains(picklistOption.value));
             }
         }
     }
@@ -149,27 +149,27 @@ private class LoggerSettingsController_Tests {
         }
         Integer expectedShareAccessLevelSize = expectedShareAccessLevels.size() + 1; // 'All' value is ignored, and '--NONE--' is automatically included
         List<LoggerSettingsController.PicklistOption> picklistOptions = LoggerSettingsController.getPicklistOptions().shareAccessLevelOptions;
-        System.assertEquals(expectedShareAccessLevelSize, picklistOptions.size(), picklistOptions);
+        System.Assert.areEqual(expectedShareAccessLevelSize, picklistOptions.size(), picklistOptions.toString());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
             if (String.isBlank(picklistOption.value) == true) {
-                System.assertEquals('--None--', picklistOption.label);
+                System.Assert.areEqual('--None--', picklistOption.label);
             } else {
-                System.assertEquals(picklistOption.value, picklistOption.label);
-                System.assertEquals(true, expectedShareAccessLevels.contains(picklistOption.value));
+                System.Assert.areEqual(picklistOption.value, picklistOption.label);
+                System.Assert.areEqual(true, expectedShareAccessLevels.contains(picklistOption.value));
             }
         }
     }
 
     @IsTest
     static void it_should_return_empty_settings_records_list_when_not_configured() {
-        System.assertEquals(0, [SELECT COUNT() FROM LoggerSettings__c]);
+        System.Assert.areEqual(0, [SELECT COUNT() FROM LoggerSettings__c]);
         List<LoggerSettingsController.SettingsRecordResult> records = LoggerSettingsController.getRecords();
-        System.assertEquals(0, records.size());
+        System.Assert.areEqual(0, records.size());
     }
 
     @IsTest
     static void it_should_return_settings_records_when_configured() {
-        System.assertEquals(0, [SELECT COUNT() FROM LoggerSettings__c]);
+        System.Assert.areEqual(0, [SELECT COUNT() FROM LoggerSettings__c]);
         LoggerSettings__c orgDefaultSettingsRecord = LoggerSettings__c.getOrgDefaults();
         LoggerSettings__c profileSettingsRecord = LoggerSettings__c.getInstance(UserInfo.getProfileId());
         LoggerSettings__c userSettingsRecord = LoggerSettings__c.getInstance(UserInfo.getUserId());
@@ -178,14 +178,14 @@ private class LoggerSettingsController_Tests {
         Map<Id, LoggerSettings__c> testSettingsRecordsById = queryLoggerSettingsRecords(testSettingsRecords);
 
         List<LoggerSettingsController.SettingsRecordResult> recordResults = LoggerSettingsController.getRecords();
-        System.assertNotEquals(true, recordResults.isEmpty());
-        System.assertEquals(testSettingsRecordsById.size(), recordResults.size());
+        System.Assert.isFalse(recordResults.isEmpty());
+        System.Assert.areEqual(testSettingsRecordsById.size(), recordResults.size());
         for (LoggerSettingsController.SettingsRecordResult result : recordResults) {
             LoggerSettings__c matchingRecord = testSettingsRecordsById.get(result.record.Id);
-            System.assertNotEquals(null, matchingRecord);
-            System.assertEquals(matchingRecord.SetupOwnerId, result.record.SetupOwnerId);
-            System.assertEquals(matchingRecord.CreatedBy.Username, result.createdByUsername);
-            System.assertEquals(matchingRecord.LastModifiedBy.Username, result.lastModifiedByUsername);
+            System.Assert.isNotNull(matchingRecord);
+            System.Assert.areEqual(matchingRecord.SetupOwnerId, result.record.SetupOwnerId);
+            System.Assert.areEqual(matchingRecord.CreatedBy.Username, result.createdByUsername);
+            System.Assert.areEqual(matchingRecord.LastModifiedBy.Username, result.lastModifiedByUsername);
         }
     }
 
@@ -193,27 +193,27 @@ private class LoggerSettingsController_Tests {
     static void it_should_create_new_record() {
         LoggerSettings__c expectedNewRecord = (LoggerSettings__c) Schema.LoggerSettings__c.SObjectType.newSObject(null, true);
         LoggerSettings__c newRecord = LoggerSettingsController.createRecord();
-        System.assertEquals(expectedNewRecord, newRecord);
-        System.assertEquals(null, newRecord.Id);
-        System.assertEquals(null, newRecord.SetupOwnerId);
+        System.Assert.areEqual(expectedNewRecord, newRecord);
+        System.Assert.isNull(newRecord.Id);
+        System.Assert.isNull(newRecord.SetupOwnerId);
     }
 
     @IsTest
     static void it_should_save_new_record() {
         LoggerSettings__c newRecord = LoggerSettingsController.createRecord();
         newRecord.SetupOwnerId = UserInfo.getUserId();
-        System.assertEquals(null, newRecord.Id);
+        System.Assert.isNull(newRecord.Id);
 
         LoggerSettingsController.saveRecord(newRecord);
-        System.assertNotEquals(null, newRecord.Id);
+        System.Assert.isNotNull(newRecord.Id);
     }
 
     @IsTest
     static void it_should_save_existing_record() {
         insert LoggerSettings__c.getOrgDefaults();
         LoggerSettings__c existingRecord = LoggerSettings__c.getOrgDefaults();
-        System.assertEquals([SELECT Id FROM Organization].Id, existingRecord.SetupOwnerId);
-        System.assertNotEquals(null, existingRecord.Id);
+        System.Assert.areEqual([SELECT Id FROM Organization].Id, existingRecord.SetupOwnerId);
+        System.Assert.isNotNull(existingRecord.Id);
 
         Boolean originalValue = existingRecord.IsEnabled__c;
         Boolean updatedValue = !originalValue;
@@ -221,7 +221,7 @@ private class LoggerSettingsController_Tests {
         LoggerSettingsController.saveRecord(existingRecord);
 
         existingRecord = LoggerSettings__c.getOrgDefaults();
-        System.assertEquals(updatedValue, existingRecord.IsEnabled__c);
+        System.Assert.areEqual(updatedValue, existingRecord.IsEnabled__c);
     }
 
     @IsTest
@@ -229,9 +229,9 @@ private class LoggerSettingsController_Tests {
         LoggerSettings__c invalidRecord = null;
         try {
             LoggerSettingsController.saveRecord(invalidRecord);
-            System.assert(false, 'Expected exception from previous line, this assert should not run');
+            System.Assert.fail('Expected exception from previous line, this assert should not run');
         } catch (Exception ex) {
-            System.assertEquals(AuraHandledException.class.getName(), ex.getTypeName());
+            System.Assert.areEqual(AuraHandledException.class.getName(), ex.getTypeName());
         }
     }
 
@@ -239,13 +239,13 @@ private class LoggerSettingsController_Tests {
     static void it_should_delete_existing_record() {
         insert LoggerSettings__c.getOrgDefaults();
         LoggerSettings__c existingRecord = LoggerSettings__c.getOrgDefaults();
-        System.assertEquals([SELECT Id FROM Organization].Id, existingRecord.SetupOwnerId);
-        System.assertNotEquals(null, existingRecord.Id);
+        System.Assert.areEqual([SELECT Id FROM Organization].Id, existingRecord.SetupOwnerId);
+        System.Assert.isNotNull(existingRecord.Id);
 
         LoggerSettingsController.deleteRecord(existingRecord);
 
         List<LoggerSettings__c> remainingRecords = [SELECT Id FROM LoggerSettings__c WHERE Id = :existingRecord.Id];
-        System.assertEquals(0, remainingRecords.size());
+        System.Assert.areEqual(0, remainingRecords.size());
     }
 
     @IsTest
@@ -260,9 +260,12 @@ private class LoggerSettingsController_Tests {
 
         try {
             LoggerSettingsController.deleteRecord(invalidRecord);
-            System.assert(false, 'Expected exception from previous line, this assert should not run');
+            System.Assert.fail('Expected exception from previous line, this assert should not run');
         } catch (Exception ex) {
-            System.assert(ex.getMessage().contains(expectedExceptionMessage), 'Exception did not contain expected message, received: ' + ex.getMessage());
+            System.Assert.isTrue(
+                ex.getMessage().contains(expectedExceptionMessage),
+                'Exception did not contain expected message, received: ' + ex.getMessage()
+            );
         }
     }
 
@@ -272,14 +275,14 @@ private class LoggerSettingsController_Tests {
 
         Organization returnedRecord = LoggerSettingsController.getOrganization();
 
-        System.assertEquals(expectedRecord, returnedRecord);
+        System.Assert.areEqual(expectedRecord, returnedRecord);
     }
 
     @IsTest
     static void it_should_return_empty_profile_search_results_list_when_no_matches_found() {
         String nonsenseSearchTerm = 'asdfqwert;lkhpoiy';
         List<LoggerSettingsController.SetupOwnerSearchResult> results = LoggerSettingsController.searchForSetupOwner('Profile', nonsenseSearchTerm);
-        System.assertEquals(0, results.size());
+        System.Assert.areEqual(0, results.size());
     }
 
     @IsTest
@@ -289,15 +292,15 @@ private class LoggerSettingsController_Tests {
         Map<Id, Profile> expectedResultsById = new Map<Id, Profile>([SELECT Id, Name, UserLicense.Name FROM Profile WHERE Name LIKE :searchTerm]);
         List<LoggerSettingsController.SetupOwnerSearchResult> results = LoggerSettingsController.searchForSetupOwner('Profile', searchTerm);
 
-        System.assertNotEquals(true, results.isEmpty());
-        System.assertEquals(expectedResultsById.size(), results.size());
+        System.Assert.isFalse(results.isEmpty());
+        System.Assert.areEqual(expectedResultsById.size(), results.size());
         for (LoggerSettingsController.SetupOwnerSearchResult result : results) {
             Profile matchingProfile = expectedResultsById.get(result.recordId);
-            System.assertNotEquals(null, matchingProfile);
-            System.assertEquals(matchingProfile.Name, result.label);
-            System.assertEquals('License: ' + matchingProfile.UserLicense.Name, result.secondaryLabel);
-            System.assertEquals('utility:profile', result.icon);
-            System.assertEquals(null, result.image);
+            System.Assert.isNotNull(matchingProfile);
+            System.Assert.areEqual(matchingProfile.Name, result.label);
+            System.Assert.areEqual('License: ' + matchingProfile.UserLicense.Name, result.secondaryLabel);
+            System.Assert.areEqual('utility:profile', result.icon);
+            System.Assert.isNull(result.image);
         }
     }
 
@@ -305,7 +308,7 @@ private class LoggerSettingsController_Tests {
     static void it_should_return_empty_user_search_results_list_when_no_matches_found() {
         String nonsenseSearchTerm = 'asdfqwert;lkhpoiy';
         List<LoggerSettingsController.SetupOwnerSearchResult> results = LoggerSettingsController.searchForSetupOwner('User', nonsenseSearchTerm);
-        System.assertEquals(0, results.size());
+        System.Assert.areEqual(0, results.size());
     }
 
     @IsTest
@@ -316,15 +319,15 @@ private class LoggerSettingsController_Tests {
         );
         List<LoggerSettingsController.SetupOwnerSearchResult> results = LoggerSettingsController.searchForSetupOwner('User', searchTerm);
 
-        System.assertNotEquals(true, results.isEmpty());
-        System.assertEquals(expectedResultsById.size(), results.size());
+        System.Assert.isFalse(results.isEmpty());
+        System.Assert.areEqual(expectedResultsById.size(), results.size());
         for (LoggerSettingsController.SetupOwnerSearchResult result : results) {
             User matchingUser = expectedResultsById.get(result.recordId);
-            System.assertNotEquals(null, matchingUser);
-            System.assertEquals(matchingUser.Username, result.label);
-            System.assertEquals('Name: ' + matchingUser.Name, result.secondaryLabel);
-            System.assertEquals('standard:people', result.icon);
-            System.assertEquals(matchingUser.SmallPhotoUrl, result.image);
+            System.Assert.isNotNull(matchingUser);
+            System.Assert.areEqual(matchingUser.Username, result.label);
+            System.Assert.areEqual('Name: ' + matchingUser.Name, result.secondaryLabel);
+            System.Assert.areEqual('standard:people', result.icon);
+            System.Assert.areEqual(matchingUser.SmallPhotoUrl, result.image);
         }
     }
 
@@ -336,9 +339,12 @@ private class LoggerSettingsController_Tests {
 
         try {
             LoggerSettingsController.searchForSetupOwner(invalidSetupOwnerType, searchTerm);
-            System.assert(false, 'Expected exception from previous line, this assert should not run');
+            System.Assert.fail('Expected exception from previous line, this assert should not run');
         } catch (Exception ex) {
-            System.assert(ex.getMessage().contains(expectedExceptionMessage), 'Exception did not contain expected message, received: ' + ex.getMessage());
+            System.Assert.isTrue(
+                ex.getMessage().contains(expectedExceptionMessage),
+                'Exception did not contain expected message, received: ' + ex.getMessage()
+            );
         }
     }
 

--- a/nebula-logger/core/tests/log-management/classes/LoggerTagHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerTagHandler_Tests.cls
@@ -8,7 +8,7 @@
 private class LoggerTagHandler_Tests {
     @IsTest
     static void it_should_return_the_loggerTag_sobjectType() {
-        System.assertEquals(Schema.LoggerTag__c.SObjectType, new LoggerTagHandler().getSObjectType());
+        System.Assert.areEqual(Schema.LoggerTag__c.SObjectType, new LoggerTagHandler().getSObjectType());
     }
 
     @IsTest
@@ -19,7 +19,7 @@ private class LoggerTagHandler_Tests {
 
         LoggerDataStore.getDatabase().insertRecord(tag);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LoggerTag__c.SObjectType).size(),
             'Handler class should not have executed'
@@ -32,13 +32,13 @@ private class LoggerTagHandler_Tests {
         tag.Name = 'Some tag name';
         LoggerDataStore.getDatabase().insertRecord(tag);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LoggerTag__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         tag = [SELECT Id, Name, UniqueId__c FROM LoggerTag__c WHERE Id = :tag.Id];
-        System.assertEquals(tag.Name, tag.UniqueId__c);
+        System.Assert.areEqual(tag.Name, tag.UniqueId__c);
     }
 
     @IsTest
@@ -47,13 +47,13 @@ private class LoggerTagHandler_Tests {
         tag.Name = 'Some tag name';
         LoggerDataStore.getDatabase().insertRecord(tag);
 
-        System.assertEquals(
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LoggerTag__c.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
         );
         tag = [SELECT Id, Name, UniqueId__c FROM LoggerTag__c WHERE Id = :tag.Id];
-        System.assertEquals(tag.Name, tag.UniqueId__c);
+        System.Assert.areEqual(tag.Name, tag.UniqueId__c);
     }
 
     @IsTest
@@ -68,19 +68,19 @@ private class LoggerTagHandler_Tests {
 
         try {
             insert duplicateTag;
-            System.assert(false, 'Exception expected on previous line');
+            System.Assert.fail('Exception expected on previous line');
         } catch (Exception ex) {
             thrownException = ex;
         }
 
-        System.assertEquals(
+        System.Assert.areEqual(
             3,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LoggerTag__c.SObjectType).size(),
             'Handler class should have executed three times - once for BEFORE_INSERT and once for AFTER_INSERT for the first record,' +
             ' and once for BEFORE_INSERT on the errored duplicate'
         );
-        System.assertNotEquals(null, thrownException, 'An exception should have been thrown');
+        System.Assert.isNotNull(thrownException, 'An exception should have been thrown');
         String expectedDuplicateError = 'DUPLICATE_VALUE';
-        System.assert(thrownException.getMessage().contains(expectedDuplicateError), thrownException.getMessage());
+        System.Assert.isTrue(thrownException.getMessage().contains(expectedDuplicateError), thrownException.getMessage());
     }
 }

--- a/nebula-logger/core/tests/log-management/classes/LoggerTagHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerTagHandler_Tests.cls
@@ -64,12 +64,12 @@ private class LoggerTagHandler_Tests {
         LoggerTag__c duplicateTag = (LoggerTag__c) LoggerMockDataCreator.createDataBuilder(new LoggerTag__c(Name = tag.Name))
             .populateRequiredFields()
             .getRecord();
-        Exception thrownException;
+        System.Exception thrownException;
 
         try {
             insert duplicateTag;
-            System.Assert.fail('Exception expected on previous line');
-        } catch (Exception ex) {
+            System.Assert.fail('System.Exception expected on previous line');
+        } catch (System.Exception ex) {
             thrownException = ex;
         }
 

--- a/nebula-logger/core/tests/log-management/classes/RelatedLogEntriesController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/RelatedLogEntriesController_Tests.cls
@@ -28,7 +28,7 @@ private class RelatedLogEntriesController_Tests {
         for (Integer i = 0; i < TOTAL_LOG_ENTRIES; i++) {
             LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, Message__c = 'test ' + i);
             if (i <= TOTAL_RELATED_LOG_ENTRIES) {
-                logEntry.RecordId__c = UserInfo.getUserId();
+                logEntry.RecordId__c = System.UserInfo.getUserId();
             }
             LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
 
@@ -39,7 +39,7 @@ private class RelatedLogEntriesController_Tests {
 
     @IsTest
     static void it_should_return_matching_logEntryQueryResult() {
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         String fieldSetName = getFieldSetName();
         Integer rowLimit = 10;
         Integer rowOffset = 0;
@@ -71,7 +71,7 @@ private class RelatedLogEntriesController_Tests {
 
     @IsTest
     static void it_should_return_matching_logEntryQueryResult_when_search_provided() {
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         String fieldSetName = getFieldSetName();
         Integer rowLimit = 10;
         Integer rowOffset = 0;

--- a/nebula-logger/core/tests/log-management/classes/RelatedLogEntriesController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/RelatedLogEntriesController_Tests.cls
@@ -60,12 +60,12 @@ private class RelatedLogEntriesController_Tests {
         );
         System.Test.stopTest();
 
-        System.assertEquals(fieldSetName, result.fieldSet.name);
+        System.Assert.areEqual(fieldSetName, result.fieldSet.name);
 
         // Requery the log entries so we can check additional fields that may not be in the field set
         List<LogEntry__c> logEntries = [SELECT Id, RecordId__c FROM LogEntry__c WHERE Id IN :result.records];
         for (LogEntry__c logEntry : logEntries) {
-            System.assertEquals(recordId, logEntry.RecordId__c);
+            System.Assert.areEqual(recordId, logEntry.RecordId__c);
         }
     }
 
@@ -82,18 +82,18 @@ private class RelatedLogEntriesController_Tests {
         Log__c log = [SELECT Id FROM Log__c];
         LogEntry__c logEntryWithSearchTerm = new LogEntry__c(Log__c = log.Id, Message__c = search);
         insert logEntryWithSearchTerm;
-        System.assert(logEntryWithSearchTerm.Message__c.contains(search));
+        System.Assert.isTrue(logEntryWithSearchTerm.Message__c.contains(search));
 
         // Quick sanity check on test data setup to make sure that only 1 log entry matches the search term
         List<LogEntry__c> logEntries = [SELECT Id, Message__c, RecordId__c FROM LogEntry__c];
-        System.assertEquals(TOTAL_LOG_ENTRIES + 1, logEntries.size());
+        System.Assert.areEqual(TOTAL_LOG_ENTRIES + 1, logEntries.size());
         Integer countOfMatches = 0;
         for (LogEntry__c logEntry : logEntries) {
             if (logEntry.Message__c.contains(search)) {
                 countOfMatches = countOfMatches + 1;
             }
         }
-        System.assertEquals(1, countOfMatches, logEntries);
+        System.Assert.areEqual(1, countOfMatches, JSON.serializePretty(logEntries));
 
         System.Test.startTest();
 
@@ -108,11 +108,11 @@ private class RelatedLogEntriesController_Tests {
         );
         System.Test.stopTest();
 
-        System.assertEquals(fieldSetName, result.fieldSet.name);
+        System.Assert.areEqual(fieldSetName, result.fieldSet.name);
         // FIXME
-        // System.assertEquals(1, result.records.size());
+        // System.Assert.areEqual(1, result.records.size());
         // for(LogEntry__c logEntry : result.records) {
-        //     System.assertEquals(recordId, logEntry.RecordId__c);
+        //     System.Assert.areEqual(recordId, logEntry.RecordId__c);
         // }
     }
 }

--- a/nebula-logger/core/tests/logger-engine/classes/ComponentLogger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/ComponentLogger_Tests.cls
@@ -19,12 +19,12 @@ private class ComponentLogger_Tests {
 
         System.Assert.areEqual(loggerSettings.IsEnabled__c, componentLoggerSettings.isEnabled);
         System.Assert.areEqual(loggerSettings.LoggingLevel__c, componentLoggerSettings.userLoggingLevel.name);
-        LoggingLevel userLoggingLevel = Logger.getLoggingLevel(loggerSettings.LoggingLevel__c);
+        System.LoggingLevel userLoggingLevel = Logger.getLoggingLevel(loggerSettings.LoggingLevel__c);
         System.Assert.areEqual(userLoggingLevel.name(), componentLoggerSettings.userLoggingLevel.name);
         System.Assert.areEqual(userLoggingLevel.ordinal(), componentLoggerSettings.userLoggingLevel.ordinal);
-        for (LoggingLevel currentLoggingLevel : LoggingLevel.values()) {
+        for (System.LoggingLevel currentLoggingLevel : System.LoggingLevel.values()) {
             // We don't care about logging level NONE, or the secret/undocumented INTERNAL logging level
-            if (currentLoggingLevel == LoggingLevel.NONE || currentLoggingLevel == LoggingLevel.INTERNAL) {
+            if (currentLoggingLevel == System.LoggingLevel.NONE || currentLoggingLevel == System.LoggingLevel.INTERNAL) {
                 continue;
             }
             System.Assert.isTrue(
@@ -51,7 +51,7 @@ private class ComponentLogger_Tests {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         User currentUser = new User(FirstName = System.UserInfo.getFirstName(), Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         ComponentLogger.ComponentLogEntry componentLogEntry = new ComponentLogger.ComponentLogEntry();
-        componentLogEntry.loggingLevel = LoggingLevel.INFO.name();
+        componentLogEntry.loggingLevel = System.LoggingLevel.INFO.name();
         componentLogEntry.message = 'hello, world';
         componentLogEntry.recordId = currentUser.Id;
         componentLogEntry.record = currentUser;
@@ -83,7 +83,7 @@ private class ComponentLogger_Tests {
         User currentUser = new User(FirstName = System.UserInfo.getFirstName(), Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         System.Assert.areEqual(0, System.Limits.getQueueableJobs(), 'Test should start with 0 queueable jobs used');
         ComponentLogger.ComponentLogEntry componentLogEntry = new ComponentLogger.ComponentLogEntry();
-        componentLogEntry.loggingLevel = LoggingLevel.INFO.name();
+        componentLogEntry.loggingLevel = System.LoggingLevel.INFO.name();
         componentLogEntry.message = 'hello, world';
         componentLogEntry.recordId = currentUser.Id;
         componentLogEntry.record = currentUser;
@@ -124,7 +124,7 @@ private class ComponentLogger_Tests {
         mockComponentError.type = 'JavaScript.ReferenceError';
         ComponentLogger.ComponentLogEntry componentLogEntry = new ComponentLogger.ComponentLogEntry();
         componentLogEntry.error = mockComponentError;
-        componentLogEntry.loggingLevel = LoggingLevel.INFO.name();
+        componentLogEntry.loggingLevel = System.LoggingLevel.INFO.name();
         componentLogEntry.message = 'hello, world';
         componentLogEntry.recordId = currentUser.Id;
         componentLogEntry.record = currentUser;
@@ -160,7 +160,7 @@ private class ComponentLogger_Tests {
         mockComponentError.type = mockApexException.getTypeName();
         ComponentLogger.ComponentLogEntry componentLogEntry = new ComponentLogger.ComponentLogEntry();
         componentLogEntry.error = mockComponentError;
-        componentLogEntry.loggingLevel = LoggingLevel.INFO.name();
+        componentLogEntry.loggingLevel = System.LoggingLevel.INFO.name();
         componentLogEntry.message = 'hello, world';
         componentLogEntry.recordId = currentUser.Id;
         componentLogEntry.record = currentUser;
@@ -188,9 +188,9 @@ private class ComponentLogger_Tests {
     @IsTest
     static void it_should_set_logger_scenario() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.FINEST.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.FINEST.name();
         ComponentLogger.ComponentLogEntry componentLogEntry = new ComponentLogger.ComponentLogEntry();
-        componentLogEntry.loggingLevel = LoggingLevel.INFO.name();
+        componentLogEntry.loggingLevel = System.LoggingLevel.INFO.name();
         componentLogEntry.message = 'hello, world';
         componentLogEntry.scenario = 'Some scenario';
         componentLogEntry.timestamp = System.now();
@@ -216,7 +216,7 @@ private class ComponentLogger_Tests {
         String expectedComponentApiName = 'c/loggerAuraDemo';
         String expectedComponentFunctionName = 'saveLogAuraExample';
         ComponentLogger.ComponentLogEntry componentLogEntry = new ComponentLogger.ComponentLogEntry();
-        componentLogEntry.loggingLevel = LoggingLevel.INFO.name();
+        componentLogEntry.loggingLevel = System.LoggingLevel.INFO.name();
         componentLogEntry.message = 'hello, world';
         componentLogEntry.stack = getMockAuraComponentStackTrace();
         componentLogEntry.timestamp = System.now().addDays(-1 / 24);
@@ -249,7 +249,7 @@ private class ComponentLogger_Tests {
         String expectedComponentApiName = 'c/loggerLWCDemo';
         String expectedComponentFunctionName = 'saveLogWebExample';
         ComponentLogger.ComponentLogEntry componentLogEntry = new ComponentLogger.ComponentLogEntry();
-        componentLogEntry.loggingLevel = LoggingLevel.INFO.name();
+        componentLogEntry.loggingLevel = System.LoggingLevel.INFO.name();
         componentLogEntry.message = 'hello, world';
         componentLogEntry.stack = getMockWebComponentStackTrace();
         componentLogEntry.timestamp = System.now().addDays(-1 / 24);

--- a/nebula-logger/core/tests/logger-engine/classes/ComponentLogger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/ComponentLogger_Tests.cls
@@ -41,8 +41,8 @@ private class ComponentLogger_Tests {
         try {
             ComponentLogger.saveComponentLogEntries(null, null);
             System.Assert.fail('This assert shouldn\'t run since this is a negative test');
-        } catch (Exception apexException) {
-            System.Assert.areEqual(AuraHandledException.class.getName(), apexException.getTypeName());
+        } catch (System.Exception apexException) {
+            System.Assert.isInstanceOfType(apexException, System.AuraHandledException.class);
         }
     }
 
@@ -153,7 +153,9 @@ private class ComponentLogger_Tests {
     static void it_should_save_component_log_entry_with_apex_controller_error() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         User currentUser = new User(FirstName = System.UserInfo.getFirstName(), Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
-        Exception mockApexException = new DmlException('It is with much sadness that I must inform you that this DML statement was most unsuccessful');
+        System.Exception mockApexException = new System.DmlException(
+            'It is with much sadness that I must inform you that this DML statement was most unsuccessful'
+        );
         ComponentLogger.ComponentError mockComponentError = new ComponentLogger.ComponentError();
         mockComponentError.message = mockApexException.getMessage();
         mockComponentError.stack = mockApexException.getStackTraceString();

--- a/nebula-logger/core/tests/logger-engine/classes/ComponentLogger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/ComponentLogger_Tests.cls
@@ -17,22 +17,22 @@ private class ComponentLogger_Tests {
 
         ComponentLogger.ComponentLoggerSettings componentLoggerSettings = ComponentLogger.getSettings();
 
-        System.assertEquals(loggerSettings.IsEnabled__c, componentLoggerSettings.isEnabled);
-        System.assertEquals(loggerSettings.LoggingLevel__c, componentLoggerSettings.userLoggingLevel.name);
+        System.Assert.areEqual(loggerSettings.IsEnabled__c, componentLoggerSettings.isEnabled);
+        System.Assert.areEqual(loggerSettings.LoggingLevel__c, componentLoggerSettings.userLoggingLevel.name);
         LoggingLevel userLoggingLevel = Logger.getLoggingLevel(loggerSettings.LoggingLevel__c);
-        System.assertEquals(userLoggingLevel.name(), componentLoggerSettings.userLoggingLevel.name);
-        System.assertEquals(userLoggingLevel.ordinal(), componentLoggerSettings.userLoggingLevel.ordinal);
+        System.Assert.areEqual(userLoggingLevel.name(), componentLoggerSettings.userLoggingLevel.name);
+        System.Assert.areEqual(userLoggingLevel.ordinal(), componentLoggerSettings.userLoggingLevel.ordinal);
         for (LoggingLevel currentLoggingLevel : LoggingLevel.values()) {
             // We don't care about logging level NONE, or the secret/undocumented INTERNAL logging level
             if (currentLoggingLevel == LoggingLevel.NONE || currentLoggingLevel == LoggingLevel.INTERNAL) {
                 continue;
             }
-            System.assert(
+            System.Assert.isTrue(
                 componentLoggerSettings.supportedLoggingLevels.containsKey(currentLoggingLevel.name()),
                 'Cmp settings did not contain level: ' + currentLoggingLevel
             );
             Integer returnedOrdinal = componentLoggerSettings.supportedLoggingLevels.get(currentLoggingLevel.name());
-            System.assertEquals(currentLoggingLevel.ordinal(), returnedOrdinal);
+            System.Assert.areEqual(currentLoggingLevel.ordinal(), returnedOrdinal);
         }
     }
 
@@ -40,9 +40,9 @@ private class ComponentLogger_Tests {
     static void it_should_return_aura_exception_when_it_breaks() {
         try {
             ComponentLogger.saveComponentLogEntries(null, null);
-            System.assert(false, 'This assert shouldn\'t run since this is a negative test');
+            System.Assert.fail('This assert shouldn\'t run since this is a negative test');
         } catch (Exception apexException) {
-            System.assertEquals(AuraHandledException.class.getName(), apexException.getTypeName());
+            System.Assert.areEqual(AuraHandledException.class.getName(), apexException.getTypeName());
         }
     }
 
@@ -57,23 +57,23 @@ private class ComponentLogger_Tests {
         componentLogEntry.record = currentUser;
         componentLogEntry.timestamp = System.now().addDays(-1 / 24);
         componentLogEntry.tags = new List<String>{ 'some tag', 'one more tag' };
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         ComponentLogger.saveComponentLogEntries(new List<ComponentLogger.ComponentLogEntry>{ componentLogEntry }, null);
 
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals('Component', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(componentLogEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals(componentLogEntry.recordId, publishedLogEntryEvent.RecordId__c);
-        System.assertEquals(JSON.serializePretty(currentUser), publishedLogEntryEvent.RecordJson__c);
-        System.assertEquals(Schema.SObjectType.User.getName(), publishedLogEntryEvent.RecordSObjectType__c);
-        System.assertEquals(componentLogEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
+        System.Assert.areEqual('Component', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(componentLogEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual(componentLogEntry.recordId, publishedLogEntryEvent.RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(currentUser), publishedLogEntryEvent.RecordJson__c);
+        System.Assert.areEqual(Schema.SObjectType.User.getName(), publishedLogEntryEvent.RecordSObjectType__c);
+        System.Assert.areEqual(componentLogEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
     }
 
     @IsTest
@@ -81,7 +81,7 @@ private class ComponentLogger_Tests {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggerDataStore.setMock(LoggerMockDataStore.getJobQueue());
         User currentUser = new User(FirstName = UserInfo.getFirstName(), Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
-        System.assertEquals(0, System.Limits.getQueueableJobs(), 'Test should start with 0 queueable jobs used');
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs(), 'Test should start with 0 queueable jobs used');
         ComponentLogger.ComponentLogEntry componentLogEntry = new ComponentLogger.ComponentLogEntry();
         componentLogEntry.loggingLevel = LoggingLevel.INFO.name();
         componentLogEntry.message = 'hello, world';
@@ -90,28 +90,28 @@ private class ComponentLogger_Tests {
         componentLogEntry.timestamp = System.now().addDays(-1 / 24);
         componentLogEntry.tags = new List<String>{ 'some tag', 'one more tag' };
         System.Test.startTest();
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
-        System.assertEquals(0, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
 
         ComponentLogger.saveComponentLogEntries(new List<ComponentLogger.ComponentLogEntry>{ componentLogEntry }, Logger.SaveMethod.QUEUEABLE.name());
-        System.assertEquals(1, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
+        System.Assert.areEqual(1, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
         LoggerMockDataStore.getJobQueue().executeJobs();
 
-        System.assertEquals(Logger.SaveMethod.QUEUEABLE.name(), Logger.lastSaveMethodNameUsed);
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(Logger.SaveMethod.QUEUEABLE.name(), Logger.lastSaveMethodNameUsed);
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals('Component', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(componentLogEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals(componentLogEntry.recordId, publishedLogEntryEvent.RecordId__c);
-        System.assertEquals(JSON.serializePretty(currentUser), publishedLogEntryEvent.RecordJson__c);
-        System.assertEquals(Schema.SObjectType.User.getName(), publishedLogEntryEvent.RecordSObjectType__c);
-        System.assertEquals(componentLogEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
+        System.Assert.areEqual('Component', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(componentLogEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual(componentLogEntry.recordId, publishedLogEntryEvent.RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(currentUser), publishedLogEntryEvent.RecordJson__c);
+        System.Assert.areEqual(Schema.SObjectType.User.getName(), publishedLogEntryEvent.RecordSObjectType__c);
+        System.Assert.areEqual(componentLogEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
     }
 
     @IsTest
@@ -130,23 +130,23 @@ private class ComponentLogger_Tests {
         componentLogEntry.record = currentUser;
         componentLogEntry.timestamp = System.now().addDays(-1 / 24);
         componentLogEntry.tags = new List<String>{ 'some tag', 'one more tag' };
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         ComponentLogger.saveComponentLogEntries(new List<ComponentLogger.ComponentLogEntry>{ componentLogEntry }, null);
 
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals('Component', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(componentLogEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals(componentLogEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
-        System.assertEquals(componentLogEntry.error.message, publishedLogEntryEvent.ExceptionMessage__c);
-        System.assertEquals(componentLogEntry.error.stack, publishedLogEntryEvent.ExceptionStackTrace__c);
-        System.assertEquals(componentLogEntry.error.type, publishedLogEntryEvent.ExceptionType__c);
+        System.Assert.areEqual('Component', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(componentLogEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual(componentLogEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
+        System.Assert.areEqual(componentLogEntry.error.message, publishedLogEntryEvent.ExceptionMessage__c);
+        System.Assert.areEqual(componentLogEntry.error.stack, publishedLogEntryEvent.ExceptionStackTrace__c);
+        System.Assert.areEqual(componentLogEntry.error.type, publishedLogEntryEvent.ExceptionType__c);
     }
 
     @IsTest
@@ -166,23 +166,23 @@ private class ComponentLogger_Tests {
         componentLogEntry.record = currentUser;
         componentLogEntry.timestamp = System.now().addDays(-1 / 24);
         componentLogEntry.tags = new List<String>{ 'some tag', 'one more tag' };
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         ComponentLogger.saveComponentLogEntries(new List<ComponentLogger.ComponentLogEntry>{ componentLogEntry }, null);
 
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals('Component', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(componentLogEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals(componentLogEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
-        System.assertEquals(componentLogEntry.error.message, publishedLogEntryEvent.ExceptionMessage__c);
-        System.assertEquals(componentLogEntry.error.stack, publishedLogEntryEvent.ExceptionStackTrace__c);
-        System.assertEquals(componentLogEntry.error.type, publishedLogEntryEvent.ExceptionType__c);
+        System.Assert.areEqual('Component', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(componentLogEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual(componentLogEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
+        System.Assert.areEqual(componentLogEntry.error.message, publishedLogEntryEvent.ExceptionMessage__c);
+        System.Assert.areEqual(componentLogEntry.error.stack, publishedLogEntryEvent.ExceptionStackTrace__c);
+        System.Assert.areEqual(componentLogEntry.error.type, publishedLogEntryEvent.ExceptionType__c);
     }
 
     @IsTest
@@ -194,19 +194,19 @@ private class ComponentLogger_Tests {
         componentLogEntry.message = 'hello, world';
         componentLogEntry.scenario = 'Some scenario';
         componentLogEntry.timestamp = System.now();
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         ComponentLogger.saveComponentLogEntries(new List<ComponentLogger.ComponentLogEntry>{ componentLogEntry }, null);
 
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals('Component', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(componentLogEntry.scenario, publishedLogEntryEvent.TransactionScenario__c);
-        System.assertEquals(componentLogEntry.scenario, publishedLogEntryEvent.EntryScenario__c);
+        System.Assert.areEqual('Component', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(componentLogEntry.scenario, publishedLogEntryEvent.TransactionScenario__c);
+        System.Assert.areEqual(componentLogEntry.scenario, publishedLogEntryEvent.EntryScenario__c);
     }
 
     @IsTest
@@ -220,26 +220,26 @@ private class ComponentLogger_Tests {
         componentLogEntry.message = 'hello, world';
         componentLogEntry.stack = getMockAuraComponentStackTrace();
         componentLogEntry.timestamp = System.now().addDays(-1 / 24);
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         ComponentLogger.saveComponentLogEntries(new List<ComponentLogger.ComponentLogEntry>{ componentLogEntry }, null);
 
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals('Component', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(componentLogEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Component', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(expectedComponentApiName + '.' + expectedComponentFunctionName, publishedLogEntryEvent.OriginLocation__c);
+        System.Assert.areEqual('Component', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(componentLogEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Component', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(expectedComponentApiName + '.' + expectedComponentFunctionName, publishedLogEntryEvent.OriginLocation__c);
         // TODO Move these asserts to LogEntryHandler_Tests
-        // System.assertEquals(expectedComponentApiName, publishedLogEntryEvent.ComponentApiName__c);
-        // System.assertEquals(expectedComponentFunctionName, publishedLogEntryEvent.ComponentFunctionName__c);
-        System.assertEquals(expectedComponentType, publishedLogEntryEvent.ComponentType__c);
-        System.assertEquals(componentLogEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
+        // System.Assert.areEqual(expectedComponentApiName, publishedLogEntryEvent.ComponentApiName__c);
+        // System.Assert.areEqual(expectedComponentFunctionName, publishedLogEntryEvent.ComponentFunctionName__c);
+        System.Assert.areEqual(expectedComponentType, publishedLogEntryEvent.ComponentType__c);
+        System.Assert.areEqual(componentLogEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
     }
 
     @IsTest
@@ -253,26 +253,26 @@ private class ComponentLogger_Tests {
         componentLogEntry.message = 'hello, world';
         componentLogEntry.stack = getMockWebComponentStackTrace();
         componentLogEntry.timestamp = System.now().addDays(-1 / 24);
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         ComponentLogger.saveComponentLogEntries(new List<ComponentLogger.ComponentLogEntry>{ componentLogEntry }, null);
 
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals('Component', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(componentLogEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Component', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(expectedComponentApiName + '.' + expectedComponentFunctionName, publishedLogEntryEvent.OriginLocation__c);
+        System.Assert.areEqual('Component', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(componentLogEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Component', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(expectedComponentApiName + '.' + expectedComponentFunctionName, publishedLogEntryEvent.OriginLocation__c);
         // TODO Move these asserts to LogEntryHandler_Tests
-        // System.assertEquals(expectedComponentApiName, publishedLogEntryEvent.ComponentApiName__c);
-        // System.assertEquals(expectedComponentFunctionName, publishedLogEntryEvent.ComponentFunctionName__c);
-        System.assertEquals(expectedComponentType, publishedLogEntryEvent.ComponentType__c);
-        System.assertEquals(componentLogEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
+        // System.Assert.areEqual(expectedComponentApiName, publishedLogEntryEvent.ComponentApiName__c);
+        // System.Assert.areEqual(expectedComponentFunctionName, publishedLogEntryEvent.ComponentFunctionName__c);
+        System.Assert.areEqual(expectedComponentType, publishedLogEntryEvent.ComponentType__c);
+        System.Assert.areEqual(componentLogEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
     }
 
     private static String getMockAuraComponentStackTrace() {

--- a/nebula-logger/core/tests/logger-engine/classes/ComponentLogger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/ComponentLogger_Tests.cls
@@ -49,7 +49,7 @@ private class ComponentLogger_Tests {
     @IsTest
     static void it_should_save_component_log_entry() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        User currentUser = new User(FirstName = UserInfo.getFirstName(), Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User currentUser = new User(FirstName = System.UserInfo.getFirstName(), Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         ComponentLogger.ComponentLogEntry componentLogEntry = new ComponentLogger.ComponentLogEntry();
         componentLogEntry.loggingLevel = LoggingLevel.INFO.name();
         componentLogEntry.message = 'hello, world';
@@ -80,7 +80,7 @@ private class ComponentLogger_Tests {
     static void it_should_save_component_log_entry_with_queueable_job() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggerDataStore.setMock(LoggerMockDataStore.getJobQueue());
-        User currentUser = new User(FirstName = UserInfo.getFirstName(), Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User currentUser = new User(FirstName = System.UserInfo.getFirstName(), Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         System.Assert.areEqual(0, System.Limits.getQueueableJobs(), 'Test should start with 0 queueable jobs used');
         ComponentLogger.ComponentLogEntry componentLogEntry = new ComponentLogger.ComponentLogEntry();
         componentLogEntry.loggingLevel = LoggingLevel.INFO.name();
@@ -117,7 +117,7 @@ private class ComponentLogger_Tests {
     @IsTest
     static void it_should_save_component_log_entry_with_javascript_error() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        User currentUser = new User(FirstName = UserInfo.getFirstName(), Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User currentUser = new User(FirstName = System.UserInfo.getFirstName(), Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         ComponentLogger.ComponentError mockComponentError = new ComponentLogger.ComponentError();
         mockComponentError.message = 'some JavaScript error message';
         mockComponentError.stack = 'some \nstack \ntrace \nstring';
@@ -152,7 +152,7 @@ private class ComponentLogger_Tests {
     @IsTest
     static void it_should_save_component_log_entry_with_apex_controller_error() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        User currentUser = new User(FirstName = UserInfo.getFirstName(), Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User currentUser = new User(FirstName = System.UserInfo.getFirstName(), Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         Exception mockApexException = new DmlException('It is with much sadness that I must inform you that this DML statement was most unsuccessful');
         ComponentLogger.ComponentError mockComponentError = new ComponentLogger.ComponentError();
         mockComponentError.message = mockApexException.getMessage();

--- a/nebula-logger/core/tests/logger-engine/classes/FlowCollectionLogEntry_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowCollectionLogEntry_Tests.cls
@@ -24,8 +24,8 @@ private class FlowCollectionLogEntry_Tests {
             LastName = System.UserInfo.getLastName(),
             Username = System.UserInfo.getUsername()
         );
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
-        LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
+        System.LoggingLevel flowCollectionEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() < flowCollectionEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -65,8 +65,8 @@ private class FlowCollectionLogEntry_Tests {
             LastName = System.UserInfo.getLastName(),
             Username = System.UserInfo.getUsername()
         );
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
-        LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
+        System.LoggingLevel flowCollectionEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() < flowCollectionEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -104,8 +104,8 @@ private class FlowCollectionLogEntry_Tests {
             LastName = System.UserInfo.getLastName(),
             Username = System.UserInfo.getUsername()
         );
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
-        LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
+        System.LoggingLevel flowCollectionEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() < flowCollectionEntryLoggingLevel.ordinal());
         System.Test.startTest();
         System.Assert.areEqual(0, System.Limits.getQueueableJobs(), 'Test should start with 0 queueable jobs used');
@@ -150,8 +150,8 @@ private class FlowCollectionLogEntry_Tests {
             LastName = System.UserInfo.getLastName(),
             Username = System.UserInfo.getUsername()
         );
-        LoggingLevel userLoggingLevel = LoggingLevel.ERROR;
-        LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.ERROR;
+        System.LoggingLevel flowCollectionEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() > flowCollectionEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -175,7 +175,7 @@ private class FlowCollectionLogEntry_Tests {
     @IsTest
     static void it_should_use_debug_as_default_level_when_faultMessage_is_null() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel expectedEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel expectedEntryLoggingLevel = System.LoggingLevel.DEBUG;
         Logger.getUserSettings().LoggingLevel__c = expectedEntryLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowCollectionLogEntry flowCollectionEntry = createFlowCollectionLogEntry();
@@ -204,8 +204,8 @@ private class FlowCollectionLogEntry_Tests {
     @IsTest
     static void it_should_use_error_as_default_level_when_faultMessage_is_not_null() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel expectedEntryLoggingLevel = LoggingLevel.ERROR;
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.FINEST.name();
+        System.LoggingLevel expectedEntryLoggingLevel = System.LoggingLevel.ERROR;
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.FINEST.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowCollectionLogEntry flowCollectionEntry = createFlowCollectionLogEntry();
         flowCollectionEntry.faultMessage = 'Whoops, a Flow error has occurred.';
@@ -233,7 +233,7 @@ private class FlowCollectionLogEntry_Tests {
     @IsTest
     static void it_should_set_logger_scenario() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowCollectionLogEntry flowCollectionEntry = createFlowCollectionLogEntry();
@@ -259,8 +259,8 @@ private class FlowCollectionLogEntry_Tests {
     @IsTest
     static void it_should_add_tags_to_log_entry() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
-        LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
+        System.LoggingLevel flowCollectionEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() < flowCollectionEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();

--- a/nebula-logger/core/tests/logger-engine/classes/FlowCollectionLogEntry_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowCollectionLogEntry_Tests.cls
@@ -26,34 +26,34 @@ private class FlowCollectionLogEntry_Tests {
         );
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() < flowCollectionEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() < flowCollectionEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowCollectionLogEntry flowCollectionEntry = createFlowCollectionLogEntry();
         flowCollectionEntry.loggingLevelName = flowCollectionEntryLoggingLevel.name();
         flowCollectionEntry.records = new List<SObject>{ currentUser };
         flowCollectionEntry.timestamp = System.now().addSeconds(-20);
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowCollectionLogEntry.addFlowCollectionEntries(new List<FlowCollectionLogEntry>{ flowCollectionEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
         String expectedUserJson = JSON.serializePretty(new List<SObject>{ currentUser });
-        System.assertEquals(flowCollectionEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowCollectionEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(null, publishedLogEntryEvent.RecordId__c);
-        System.assertEquals('List', publishedLogEntryEvent.RecordCollectionType__c);
-        System.assertEquals('User', publishedLogEntryEvent.RecordSObjectType__c);
-        System.assertEquals(expectedUserJson, publishedLogEntryEvent.RecordJson__c);
-        System.assertEquals(flowCollectionEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
+        System.Assert.areEqual(flowCollectionEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowCollectionEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.isNull(publishedLogEntryEvent.RecordId__c);
+        System.Assert.areEqual('List', publishedLogEntryEvent.RecordCollectionType__c);
+        System.Assert.areEqual('User', publishedLogEntryEvent.RecordSObjectType__c);
+        System.Assert.areEqual(expectedUserJson, publishedLogEntryEvent.RecordJson__c);
+        System.Assert.areEqual(flowCollectionEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
     }
 
     @IsTest
@@ -67,31 +67,31 @@ private class FlowCollectionLogEntry_Tests {
         );
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() < flowCollectionEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() < flowCollectionEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowCollectionLogEntry flowCollectionEntry = createFlowCollectionLogEntry();
         flowCollectionEntry.loggingLevelName = flowCollectionEntryLoggingLevel.name();
         flowCollectionEntry.records = new List<SObject>{ currentUser };
         flowCollectionEntry.saveLog = true;
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowCollectionLogEntry.addFlowCollectionEntries(new List<FlowCollectionLogEntry>{ flowCollectionEntry });
 
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
         String expectedUserJson = JSON.serializePretty(new List<SObject>{ currentUser });
-        System.assertEquals(flowCollectionEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowCollectionEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(null, publishedLogEntryEvent.RecordId__c);
-        System.assertEquals('List', publishedLogEntryEvent.RecordCollectionType__c);
-        System.assertEquals('User', publishedLogEntryEvent.RecordSObjectType__c);
-        System.assertEquals(expectedUserJson, publishedLogEntryEvent.RecordJson__c);
+        System.Assert.areEqual(flowCollectionEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowCollectionEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.isNull(publishedLogEntryEvent.RecordId__c);
+        System.Assert.areEqual('List', publishedLogEntryEvent.RecordCollectionType__c);
+        System.Assert.areEqual('User', publishedLogEntryEvent.RecordSObjectType__c);
+        System.Assert.areEqual(expectedUserJson, publishedLogEntryEvent.RecordJson__c);
     }
 
     @IsTest
@@ -106,9 +106,9 @@ private class FlowCollectionLogEntry_Tests {
         );
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() < flowCollectionEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() < flowCollectionEntryLoggingLevel.ordinal());
         System.Test.startTest();
-        System.assertEquals(0, System.Limits.getQueueableJobs(), 'Test should start with 0 queueable jobs used');
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs(), 'Test should start with 0 queueable jobs used');
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowCollectionLogEntry flowCollectionEntry = createFlowCollectionLogEntry();
@@ -116,29 +116,29 @@ private class FlowCollectionLogEntry_Tests {
         flowCollectionEntry.records = new List<SObject>{ currentUser };
         flowCollectionEntry.saveLog = true;
         flowCollectionEntry.saveMethodName = Logger.SaveMethod.QUEUEABLE.name();
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
-        System.assertEquals(0, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
 
         FlowCollectionLogEntry.addFlowCollectionEntries(new List<FlowCollectionLogEntry>{ flowCollectionEntry });
-        System.assertEquals(1, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
+        System.Assert.areEqual(1, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
         LoggerMockDataStore.getJobQueue().executeJobs();
 
-        System.assertEquals(Logger.SaveMethod.QUEUEABLE.name(), Logger.lastSaveMethodNameUsed);
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(Logger.SaveMethod.QUEUEABLE.name(), Logger.lastSaveMethodNameUsed);
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
         String expectedUserJson = JSON.serializePretty(new List<SObject>{ currentUser });
-        System.assertEquals(flowCollectionEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowCollectionEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(null, publishedLogEntryEvent.RecordId__c);
-        System.assertEquals('List', publishedLogEntryEvent.RecordCollectionType__c);
-        System.assertEquals('User', publishedLogEntryEvent.RecordSObjectType__c);
-        System.assertEquals(expectedUserJson, publishedLogEntryEvent.RecordJson__c);
+        System.Assert.areEqual(flowCollectionEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowCollectionEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.isNull(publishedLogEntryEvent.RecordId__c);
+        System.Assert.areEqual('List', publishedLogEntryEvent.RecordCollectionType__c);
+        System.Assert.areEqual('User', publishedLogEntryEvent.RecordSObjectType__c);
+        System.Assert.areEqual(expectedUserJson, publishedLogEntryEvent.RecordJson__c);
     }
 
     @IsTest
@@ -152,24 +152,24 @@ private class FlowCollectionLogEntry_Tests {
         );
         LoggingLevel userLoggingLevel = LoggingLevel.ERROR;
         LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() > flowCollectionEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() > flowCollectionEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowCollectionLogEntry flowCollectionEntry = createFlowCollectionLogEntry();
         flowCollectionEntry.loggingLevelName = flowCollectionEntryLoggingLevel.name();
         flowCollectionEntry.records = new List<SObject>{ currentUser };
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowCollectionLogEntry.addFlowCollectionEntries(new List<FlowCollectionLogEntry>{ flowCollectionEntry });
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
     }
 
     @IsTest
@@ -179,26 +179,26 @@ private class FlowCollectionLogEntry_Tests {
         Logger.getUserSettings().LoggingLevel__c = expectedEntryLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowCollectionLogEntry flowCollectionEntry = createFlowCollectionLogEntry();
-        System.assertEquals(null, flowCollectionEntry.faultMessage);
-        System.assertEquals(null, flowCollectionEntry.loggingLevelName);
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.isNull(flowCollectionEntry.faultMessage);
+        System.Assert.isNull(flowCollectionEntry.loggingLevelName);
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowCollectionLogEntry.addFlowCollectionEntries(new List<FlowCollectionLogEntry>{ flowCollectionEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(null, publishedLogEntryEvent.ExceptionMessage__c);
-        System.assertEquals(null, publishedLogEntryEvent.ExceptionType__c);
-        System.assertEquals(expectedEntryLoggingLevel.name(), publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowCollectionEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.isNull(publishedLogEntryEvent.ExceptionMessage__c);
+        System.Assert.isNull(publishedLogEntryEvent.ExceptionType__c);
+        System.Assert.areEqual(expectedEntryLoggingLevel.name(), publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowCollectionEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
     }
 
     @IsTest
@@ -209,25 +209,25 @@ private class FlowCollectionLogEntry_Tests {
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowCollectionLogEntry flowCollectionEntry = createFlowCollectionLogEntry();
         flowCollectionEntry.faultMessage = 'Whoops, a Flow error has occurred.';
-        System.assertEquals(null, flowCollectionEntry.loggingLevelName);
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.isNull(flowCollectionEntry.loggingLevelName);
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowCollectionLogEntry.addFlowCollectionEntries(new List<FlowCollectionLogEntry>{ flowCollectionEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowCollectionEntry.faultMessage, publishedLogEntryEvent.ExceptionMessage__c);
-        System.assertEquals('Flow.FaultError', publishedLogEntryEvent.ExceptionType__c);
-        System.assertEquals(expectedEntryLoggingLevel.name(), publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowCollectionEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(flowCollectionEntry.faultMessage, publishedLogEntryEvent.ExceptionMessage__c);
+        System.Assert.areEqual('Flow.FaultError', publishedLogEntryEvent.ExceptionType__c);
+        System.Assert.areEqual(expectedEntryLoggingLevel.name(), publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowCollectionEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
     }
 
     @IsTest
@@ -239,21 +239,21 @@ private class FlowCollectionLogEntry_Tests {
         FlowCollectionLogEntry flowCollectionEntry = createFlowCollectionLogEntry();
         flowCollectionEntry.loggingLevelName = userLoggingLevel.name();
         flowCollectionEntry.scenario = 'Some scenario';
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowCollectionLogEntry.addFlowCollectionEntries(new List<FlowCollectionLogEntry>{ flowCollectionEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowCollectionEntry.scenario, publishedLogEntryEvent.TransactionScenario__c);
-        System.assertEquals(flowCollectionEntry.scenario, publishedLogEntryEvent.EntryScenario__c);
+        System.Assert.areEqual(flowCollectionEntry.scenario, publishedLogEntryEvent.TransactionScenario__c);
+        System.Assert.areEqual(flowCollectionEntry.scenario, publishedLogEntryEvent.EntryScenario__c);
     }
 
     @IsTest
@@ -261,35 +261,35 @@ private class FlowCollectionLogEntry_Tests {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() < flowCollectionEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() < flowCollectionEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         List<String> tags = new List<String>{ 'first tag', 'SECOND TAG' };
         FlowCollectionLogEntry flowCollectionEntry = createFlowCollectionLogEntry();
         flowCollectionEntry.loggingLevelName = flowCollectionEntryLoggingLevel.name();
         flowCollectionEntry.tagsString = String.join(tags, ', ');
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowCollectionLogEntry.addFlowCollectionEntries(new List<FlowCollectionLogEntry>{ flowCollectionEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowCollectionEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowCollectionEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(flowCollectionEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowCollectionEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
         List<String> publishedLogEntryEventTags = publishedLogEntryEvent.Tags__c.split('\n');
-        System.assertEquals(tags.size(), publishedLogEntryEventTags.size(), publishedLogEntryEventTags);
+        System.Assert.areEqual(tags.size(), publishedLogEntryEventTags.size(), JSON.serializePretty(publishedLogEntryEventTags));
         Set<String> tagsSet = new Set<String>(tags);
         for (String publishedTag : publishedLogEntryEventTags) {
             publishedTag = publishedTag.trim();
-            System.assert(tagsSet.contains(publishedTag), publishedTag + ' not found in expected tags set: ' + tagsSet);
+            System.Assert.isTrue(tagsSet.contains(publishedTag), publishedTag + ' not found in expected tags set: ' + tagsSet);
         }
     }
 }

--- a/nebula-logger/core/tests/logger-engine/classes/FlowCollectionLogEntry_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowCollectionLogEntry_Tests.cls
@@ -19,10 +19,10 @@ private class FlowCollectionLogEntry_Tests {
     static void it_should_save_entry_when_logging_level_met() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         User currentUser = new User(
-            Id = UserInfo.getUserId(),
-            FirstName = UserInfo.getFirstName(),
-            LastName = UserInfo.getLastName(),
-            Username = UserInfo.getUserName()
+            Id = System.UserInfo.getUserId(),
+            FirstName = System.UserInfo.getFirstName(),
+            LastName = System.UserInfo.getLastName(),
+            Username = System.UserInfo.getUsername()
         );
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;
@@ -60,10 +60,10 @@ private class FlowCollectionLogEntry_Tests {
     static void it_should_auto_save_entry_when_saveLog_is_true() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         User currentUser = new User(
-            Id = UserInfo.getUserId(),
-            FirstName = UserInfo.getFirstName(),
-            LastName = UserInfo.getLastName(),
-            Username = UserInfo.getUserName()
+            Id = System.UserInfo.getUserId(),
+            FirstName = System.UserInfo.getFirstName(),
+            LastName = System.UserInfo.getLastName(),
+            Username = System.UserInfo.getUsername()
         );
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;
@@ -99,10 +99,10 @@ private class FlowCollectionLogEntry_Tests {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggerDataStore.setMock(LoggerMockDataStore.getJobQueue());
         User currentUser = new User(
-            Id = UserInfo.getUserId(),
-            FirstName = UserInfo.getFirstName(),
-            LastName = UserInfo.getLastName(),
-            Username = UserInfo.getUserName()
+            Id = System.UserInfo.getUserId(),
+            FirstName = System.UserInfo.getFirstName(),
+            LastName = System.UserInfo.getLastName(),
+            Username = System.UserInfo.getUsername()
         );
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;
@@ -145,10 +145,10 @@ private class FlowCollectionLogEntry_Tests {
     static void it_should_not_save_entry_when_logging_level_not_met() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         User currentUser = new User(
-            Id = UserInfo.getUserId(),
-            FirstName = UserInfo.getFirstName(),
-            LastName = UserInfo.getLastName(),
-            Username = UserInfo.getUserName()
+            Id = System.UserInfo.getUserId(),
+            FirstName = System.UserInfo.getFirstName(),
+            LastName = System.UserInfo.getLastName(),
+            Username = System.UserInfo.getUsername()
         );
         LoggingLevel userLoggingLevel = LoggingLevel.ERROR;
         LoggingLevel flowCollectionEntryLoggingLevel = LoggingLevel.DEBUG;

--- a/nebula-logger/core/tests/logger-engine/classes/FlowLogEntry_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowLogEntry_Tests.cls
@@ -20,29 +20,29 @@ private class FlowLogEntry_Tests {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() < flowEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() < flowEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowLogEntry flowEntry = createFlowLogEntry();
         flowEntry.loggingLevelName = flowEntryLoggingLevel.name();
         flowEntry.timestamp = System.now().addSeconds(-20);
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowLogEntry.addFlowEntries(new List<FlowLogEntry>{ flowEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals(flowEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual(flowEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
     }
 
     @IsTest
@@ -50,26 +50,26 @@ private class FlowLogEntry_Tests {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() < flowEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() < flowEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowLogEntry flowEntry = createFlowLogEntry();
         flowEntry.loggingLevelName = flowEntryLoggingLevel.name();
         flowEntry.saveLog = true;
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowLogEntry.addFlowEntries(new List<FlowLogEntry>{ flowEntry });
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
     }
 
     @IsTest
@@ -78,31 +78,31 @@ private class FlowLogEntry_Tests {
         LoggerDataStore.setMock(LoggerMockDataStore.getJobQueue());
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() < flowEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() < flowEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowLogEntry flowEntry = createFlowLogEntry();
         flowEntry.loggingLevelName = flowEntryLoggingLevel.name();
         flowEntry.saveLog = true;
         flowEntry.saveMethodName = Logger.SaveMethod.QUEUEABLE.name();
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
-        System.assertEquals(0, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
 
         FlowLogEntry.addFlowEntries(new List<FlowLogEntry>{ flowEntry });
-        System.assertEquals(1, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
+        System.Assert.areEqual(1, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
         LoggerMockDataStore.getJobQueue().executeJobs();
 
-        System.assertEquals(Logger.SaveMethod.QUEUEABLE.name(), Logger.lastSaveMethodNameUsed);
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(Logger.SaveMethod.QUEUEABLE.name(), Logger.lastSaveMethodNameUsed);
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
     }
 
     @IsTest
@@ -110,22 +110,22 @@ private class FlowLogEntry_Tests {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggingLevel userLoggingLevel = LoggingLevel.ERROR;
         LoggingLevel flowEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() > flowEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() > flowEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowLogEntry flowEntry = createFlowLogEntry();
         flowEntry.loggingLevelName = flowEntryLoggingLevel.name();
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowLogEntry.addFlowEntries(new List<FlowLogEntry>{ flowEntry });
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
     }
 
     @IsTest
@@ -135,26 +135,26 @@ private class FlowLogEntry_Tests {
         Logger.getUserSettings().LoggingLevel__c = expectedEntryLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowLogEntry flowEntry = createFlowLogEntry();
-        System.assertEquals(null, flowEntry.faultMessage);
-        System.assertEquals(null, flowEntry.loggingLevelName);
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.isNull(flowEntry.faultMessage);
+        System.Assert.isNull(flowEntry.loggingLevelName);
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowLogEntry.addFlowEntries(new List<FlowLogEntry>{ flowEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(null, publishedLogEntryEvent.ExceptionMessage__c);
-        System.assertEquals(null, publishedLogEntryEvent.ExceptionType__c);
-        System.assertEquals(expectedEntryLoggingLevel.name(), publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.isNull(publishedLogEntryEvent.ExceptionMessage__c);
+        System.Assert.isNull(publishedLogEntryEvent.ExceptionType__c);
+        System.Assert.areEqual(expectedEntryLoggingLevel.name(), publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
     }
 
     @IsTest
@@ -165,25 +165,25 @@ private class FlowLogEntry_Tests {
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowLogEntry flowEntry = createFlowLogEntry();
         flowEntry.faultMessage = 'Whoops, a Flow error has occurred.';
-        System.assertEquals(null, flowEntry.loggingLevelName);
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.isNull(flowEntry.loggingLevelName);
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowLogEntry.addFlowEntries(new List<FlowLogEntry>{ flowEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowEntry.faultMessage, publishedLogEntryEvent.ExceptionMessage__c);
-        System.assertEquals('Flow.FaultError', publishedLogEntryEvent.ExceptionType__c);
-        System.assertEquals(expectedEntryLoggingLevel.name(), publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(flowEntry.faultMessage, publishedLogEntryEvent.ExceptionMessage__c);
+        System.Assert.areEqual('Flow.FaultError', publishedLogEntryEvent.ExceptionType__c);
+        System.Assert.areEqual(expectedEntryLoggingLevel.name(), publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
     }
 
     @IsTest
@@ -196,21 +196,21 @@ private class FlowLogEntry_Tests {
         FlowLogEntry flowEntry = createFlowLogEntry();
         flowEntry.loggingLevelName = userLoggingLevel.name();
         flowEntry.scenario = 'Some scenario';
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowLogEntry.addFlowEntries(new List<FlowLogEntry>{ flowEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowEntry.scenario, publishedLogEntryEvent.TransactionScenario__c);
-        System.assertEquals(flowEntry.scenario, publishedLogEntryEvent.EntryScenario__c);
+        System.Assert.areEqual(flowEntry.scenario, publishedLogEntryEvent.TransactionScenario__c);
+        System.Assert.areEqual(flowEntry.scenario, publishedLogEntryEvent.EntryScenario__c);
     }
 
     @IsTest
@@ -218,7 +218,7 @@ private class FlowLogEntry_Tests {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() < flowEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() < flowEntryLoggingLevel.ordinal());
         System.Test.startTest();
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -226,28 +226,28 @@ private class FlowLogEntry_Tests {
         FlowLogEntry flowEntry = createFlowLogEntry();
         flowEntry.loggingLevelName = flowEntryLoggingLevel.name();
         flowEntry.tagsString = String.join(tags, ', ');
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowLogEntry.addFlowEntries(new List<FlowLogEntry>{ flowEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
         List<String> publishedLogEntryEventTags = publishedLogEntryEvent.Tags__c.split('\n');
-        System.assertEquals(tags.size(), publishedLogEntryEventTags.size(), publishedLogEntryEventTags);
+        System.Assert.areEqual(tags.size(), publishedLogEntryEventTags.size(), JSON.serializePretty(publishedLogEntryEventTags));
         Set<String> tagsSet = new Set<String>(tags);
         for (String publishedTag : publishedLogEntryEventTags) {
             publishedTag = publishedTag.trim();
-            System.assert(tagsSet.contains(publishedTag), publishedTag + ' not found in expected tags set: ' + tagsSet);
+            System.Assert.isTrue(tagsSet.contains(publishedTag), publishedTag + ' not found in expected tags set: ' + tagsSet);
         }
     }
 }

--- a/nebula-logger/core/tests/logger-engine/classes/FlowLogEntry_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowLogEntry_Tests.cls
@@ -18,8 +18,8 @@ private class FlowLogEntry_Tests {
     @IsTest
     static void it_should_save_entry_when_logging_level_met() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
-        LoggingLevel flowEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
+        System.LoggingLevel flowEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() < flowEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -48,8 +48,8 @@ private class FlowLogEntry_Tests {
     @IsTest
     static void it_should_auto_save_entry_when_saveLog_is_true() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
-        LoggingLevel flowEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
+        System.LoggingLevel flowEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() < flowEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -76,8 +76,8 @@ private class FlowLogEntry_Tests {
     static void it_should_auto_save_entry_with_save_method_when_saveMethodName_specified() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggerDataStore.setMock(LoggerMockDataStore.getJobQueue());
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
-        LoggingLevel flowEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
+        System.LoggingLevel flowEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() < flowEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -108,8 +108,8 @@ private class FlowLogEntry_Tests {
     @IsTest
     static void it_should_not_save_entry_when_logging_level_not_met() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel userLoggingLevel = LoggingLevel.ERROR;
-        LoggingLevel flowEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.ERROR;
+        System.LoggingLevel flowEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() > flowEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -131,7 +131,7 @@ private class FlowLogEntry_Tests {
     @IsTest
     static void it_should_use_debug_as_default_level_when_faultMessage_is_null() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel expectedEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel expectedEntryLoggingLevel = System.LoggingLevel.DEBUG;
         Logger.getUserSettings().LoggingLevel__c = expectedEntryLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowLogEntry flowEntry = createFlowLogEntry();
@@ -160,8 +160,8 @@ private class FlowLogEntry_Tests {
     @IsTest
     static void it_should_use_error_as_default_level_when_faultMessage_is_not_null() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel expectedEntryLoggingLevel = LoggingLevel.ERROR;
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.FINEST.name();
+        System.LoggingLevel expectedEntryLoggingLevel = System.LoggingLevel.ERROR;
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.FINEST.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowLogEntry flowEntry = createFlowLogEntry();
         flowEntry.faultMessage = 'Whoops, a Flow error has occurred.';
@@ -189,7 +189,7 @@ private class FlowLogEntry_Tests {
     @IsTest
     static void it_should_set_logger_scenario() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
         System.Test.startTest();
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -216,8 +216,8 @@ private class FlowLogEntry_Tests {
     @IsTest
     static void it_should_add_tags_to_log_entry() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
-        LoggingLevel flowEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
+        System.LoggingLevel flowEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() < flowEntryLoggingLevel.ordinal());
         System.Test.startTest();
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();

--- a/nebula-logger/core/tests/logger-engine/classes/FlowLogger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowLogger_Tests.cls
@@ -9,7 +9,7 @@ private class FlowLogger_Tests {
     @IsTest
     static void it_should_add_entry_to_logger_buffer() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel entryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel entryLoggingLevel = System.LoggingLevel.DEBUG;
         Logger.getUserSettings().LoggingLevel__c = entryLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -42,7 +42,7 @@ private class FlowLogger_Tests {
     @IsTest
     static void it_should_auto_save_entry_when_saveLog_is_true() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel entryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel entryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Test.startTest();
         Logger.getUserSettings().LoggingLevel__c = entryLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -75,7 +75,7 @@ private class FlowLogger_Tests {
     static void it_should_auto_save_entry_with_save_method_when_saveMethodName_specified() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggerDataStore.setMock(LoggerMockDataStore.getJobQueue());
-        LoggingLevel entryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel entryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.areEqual(0, System.Limits.getQueueableJobs(), 'Test should start with 0 queueable jobs used');
         Logger.getUserSettings().LoggingLevel__c = entryLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();

--- a/nebula-logger/core/tests/logger-engine/classes/FlowLogger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowLogger_Tests.cls
@@ -12,31 +12,31 @@ private class FlowLogger_Tests {
         LoggingLevel entryLoggingLevel = LoggingLevel.DEBUG;
         Logger.getUserSettings().LoggingLevel__c = entryLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(0, [SELECT COUNT() FROM LogEntry__c]);
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, [SELECT COUNT() FROM LogEntry__c]);
         FlowLogger.LogEntry flowEntry = new FlowLogger.LogEntry();
         flowEntry.flowName = 'MyFlow';
         flowEntry.message = 'hello from Flow';
         flowEntry.loggingLevelName = entryLoggingLevel.name();
         flowEntry.saveLog = false;
         flowEntry.timestamp = System.now();
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowLogger.addEntries(new List<FlowLogger.LogEntry>{ flowEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(flowEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
+        System.Assert.areEqual(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(flowEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
     }
 
     @IsTest
@@ -46,29 +46,29 @@ private class FlowLogger_Tests {
         System.Test.startTest();
         Logger.getUserSettings().LoggingLevel__c = entryLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(0, [SELECT COUNT() FROM LogEntry__c]);
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, [SELECT COUNT() FROM LogEntry__c]);
         FlowLogger.LogEntry flowEntry = new FlowLogger.LogEntry();
         flowEntry.flowName = 'MyFlow';
         flowEntry.message = 'hello from Flow';
         flowEntry.loggingLevelName = entryLoggingLevel.name();
         flowEntry.saveLog = true;
         flowEntry.timestamp = System.now();
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowLogger.addEntries(new List<FlowLogger.LogEntry>{ flowEntry });
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(flowEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
+        System.Assert.areEqual(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(flowEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
     }
 
     @IsTest
@@ -76,11 +76,11 @@ private class FlowLogger_Tests {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggerDataStore.setMock(LoggerMockDataStore.getJobQueue());
         LoggingLevel entryLoggingLevel = LoggingLevel.DEBUG;
-        System.assertEquals(0, System.Limits.getQueueableJobs(), 'Test should start with 0 queueable jobs used');
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs(), 'Test should start with 0 queueable jobs used');
         Logger.getUserSettings().LoggingLevel__c = entryLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(0, [SELECT COUNT() FROM LogEntry__c]);
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, [SELECT COUNT() FROM LogEntry__c]);
         FlowLogger.LogEntry flowEntry = new FlowLogger.LogEntry();
         flowEntry.flowName = 'MyFlow';
         flowEntry.message = 'hello from Flow';
@@ -88,23 +88,23 @@ private class FlowLogger_Tests {
         flowEntry.saveLog = true;
         flowEntry.saveMethodName = Logger.SaveMethod.QUEUEABLE.name();
         flowEntry.timestamp = System.now();
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowLogger.addEntries(new List<FlowLogger.LogEntry>{ flowEntry });
-        System.assertEquals(1, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
+        System.Assert.areEqual(1, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
         LoggerMockDataStore.getJobQueue().executeJobs();
 
-        System.assertEquals(Logger.SaveMethod.QUEUEABLE.name(), Logger.lastSaveMethodNameUsed);
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(Logger.SaveMethod.QUEUEABLE.name(), Logger.lastSaveMethodNameUsed);
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(flowEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
+        System.Assert.areEqual(flowEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(flowEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
     }
 }

--- a/nebula-logger/core/tests/logger-engine/classes/FlowRecordLogEntry_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowRecordLogEntry_Tests.cls
@@ -24,8 +24,8 @@ private class FlowRecordLogEntry_Tests {
             LastName = System.UserInfo.getLastName(),
             Username = System.UserInfo.getUsername()
         );
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
-        LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
+        System.LoggingLevel flowRecordEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() < flowRecordEntryLoggingLevel.ordinal());
         System.Test.startTest();
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
@@ -66,8 +66,8 @@ private class FlowRecordLogEntry_Tests {
             LastName = System.UserInfo.getLastName(),
             Username = System.UserInfo.getUsername()
         );
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
-        LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
+        System.LoggingLevel flowRecordEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() < flowRecordEntryLoggingLevel.ordinal());
         System.Assert.areEqual(0, System.Limits.getQueueableJobs(), 'Test should start with 0 queueable jobs used');
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
@@ -110,8 +110,8 @@ private class FlowRecordLogEntry_Tests {
             LastName = System.UserInfo.getLastName(),
             Username = System.UserInfo.getUsername()
         );
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
-        LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
+        System.LoggingLevel flowRecordEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() < flowRecordEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -147,8 +147,8 @@ private class FlowRecordLogEntry_Tests {
             LastName = System.UserInfo.getLastName(),
             Username = System.UserInfo.getUsername()
         );
-        LoggingLevel userLoggingLevel = LoggingLevel.ERROR;
-        LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.ERROR;
+        System.LoggingLevel flowRecordEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() > flowRecordEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -172,7 +172,7 @@ private class FlowRecordLogEntry_Tests {
     @IsTest
     static void it_should_use_debug_as_default_level_when_faultMessage_is_null() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel expectedEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel expectedEntryLoggingLevel = System.LoggingLevel.DEBUG;
         Logger.getUserSettings().LoggingLevel__c = expectedEntryLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowRecordLogEntry flowRecordEntry = createFlowRecordLogEntry();
@@ -201,8 +201,8 @@ private class FlowRecordLogEntry_Tests {
     @IsTest
     static void it_should_use_error_as_default_level_when_faultMessage_is_not_null() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel expectedEntryLoggingLevel = LoggingLevel.ERROR;
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.FINEST.name();
+        System.LoggingLevel expectedEntryLoggingLevel = System.LoggingLevel.ERROR;
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.FINEST.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowRecordLogEntry flowRecordEntry = createFlowRecordLogEntry();
         flowRecordEntry.faultMessage = 'Whoops, a Flow error has occurred.';
@@ -230,7 +230,7 @@ private class FlowRecordLogEntry_Tests {
     @IsTest
     static void it_should_set_logger_scenario() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowRecordLogEntry flowRecordEntry = createFlowRecordLogEntry();
@@ -256,8 +256,8 @@ private class FlowRecordLogEntry_Tests {
     @IsTest
     static void it_should_add_tags_to_log_entry() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
-        LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.FINEST;
+        System.LoggingLevel flowRecordEntryLoggingLevel = System.LoggingLevel.DEBUG;
         System.Assert.isTrue(userLoggingLevel.ordinal() < flowRecordEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();

--- a/nebula-logger/core/tests/logger-engine/classes/FlowRecordLogEntry_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowRecordLogEntry_Tests.cls
@@ -19,10 +19,10 @@ private class FlowRecordLogEntry_Tests {
     static void it_should_save_entry_when_logging_level_met() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         User currentUser = new User(
-            Id = UserInfo.getUserId(),
-            FirstName = UserInfo.getFirstName(),
-            LastName = UserInfo.getLastName(),
-            Username = UserInfo.getUserName()
+            Id = System.UserInfo.getUserId(),
+            FirstName = System.UserInfo.getFirstName(),
+            LastName = System.UserInfo.getLastName(),
+            Username = System.UserInfo.getUsername()
         );
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;
@@ -61,10 +61,10 @@ private class FlowRecordLogEntry_Tests {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggerDataStore.setMock(LoggerMockDataStore.getJobQueue());
         User currentUser = new User(
-            Id = UserInfo.getUserId(),
-            FirstName = UserInfo.getFirstName(),
-            LastName = UserInfo.getLastName(),
-            Username = UserInfo.getUserName()
+            Id = System.UserInfo.getUserId(),
+            FirstName = System.UserInfo.getFirstName(),
+            LastName = System.UserInfo.getLastName(),
+            Username = System.UserInfo.getUsername()
         );
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;
@@ -105,10 +105,10 @@ private class FlowRecordLogEntry_Tests {
     static void it_should_auto_save_entry_when_saveLog_is_true() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         User currentUser = new User(
-            Id = UserInfo.getUserId(),
-            FirstName = UserInfo.getFirstName(),
-            LastName = UserInfo.getLastName(),
-            Username = UserInfo.getUserName()
+            Id = System.UserInfo.getUserId(),
+            FirstName = System.UserInfo.getFirstName(),
+            LastName = System.UserInfo.getLastName(),
+            Username = System.UserInfo.getUsername()
         );
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;
@@ -142,10 +142,10 @@ private class FlowRecordLogEntry_Tests {
     static void it_should_not_save_entry_when_logging_level_not_met() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         User currentUser = new User(
-            Id = UserInfo.getUserId(),
-            FirstName = UserInfo.getFirstName(),
-            LastName = UserInfo.getLastName(),
-            Username = UserInfo.getUserName()
+            Id = System.UserInfo.getUserId(),
+            FirstName = System.UserInfo.getFirstName(),
+            LastName = System.UserInfo.getLastName(),
+            Username = System.UserInfo.getUsername()
         );
         LoggingLevel userLoggingLevel = LoggingLevel.ERROR;
         LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;

--- a/nebula-logger/core/tests/logger-engine/classes/FlowRecordLogEntry_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowRecordLogEntry_Tests.cls
@@ -26,7 +26,7 @@ private class FlowRecordLogEntry_Tests {
         );
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() < flowRecordEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() < flowRecordEntryLoggingLevel.ordinal());
         System.Test.startTest();
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -34,26 +34,26 @@ private class FlowRecordLogEntry_Tests {
         flowRecordEntry.loggingLevelName = flowRecordEntryLoggingLevel.name();
         flowRecordEntry.record = currentUser;
         flowRecordEntry.timestamp = System.now().addSeconds(-20);
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowRecordLogEntry.addFlowRecordEntries(new List<FlowRecordLogEntry>{ flowRecordEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
         String expectedUserJson = JSON.serializePretty(currentUser);
-        System.assertEquals(flowRecordEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowRecordEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(currentUser.Id, publishedLogEntryEvent.RecordId__c);
-        System.assertEquals(expectedUserJson, publishedLogEntryEvent.RecordJson__c);
-        System.assertEquals(flowRecordEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
+        System.Assert.areEqual(flowRecordEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowRecordEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(currentUser.Id, publishedLogEntryEvent.RecordId__c);
+        System.Assert.areEqual(expectedUserJson, publishedLogEntryEvent.RecordJson__c);
+        System.Assert.areEqual(flowRecordEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
     }
 
     @IsTest
@@ -68,8 +68,8 @@ private class FlowRecordLogEntry_Tests {
         );
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() < flowRecordEntryLoggingLevel.ordinal());
-        System.assertEquals(0, System.Limits.getQueueableJobs(), 'Test should start with 0 queueable jobs used');
+        System.Assert.isTrue(userLoggingLevel.ordinal() < flowRecordEntryLoggingLevel.ordinal());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs(), 'Test should start with 0 queueable jobs used');
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowRecordLogEntry flowRecordEntry = createFlowRecordLogEntry();
@@ -77,28 +77,28 @@ private class FlowRecordLogEntry_Tests {
         flowRecordEntry.record = currentUser;
         flowRecordEntry.saveLog = true;
         flowRecordEntry.saveMethodName = Logger.SaveMethod.QUEUEABLE.name();
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
-        System.assertEquals(0, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
 
         FlowRecordLogEntry.addFlowRecordEntries(new List<FlowRecordLogEntry>{ flowRecordEntry });
-        System.assertEquals(1, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
+        System.Assert.areEqual(1, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
         LoggerMockDataStore.getJobQueue().executeJobs();
 
-        System.assertEquals(Logger.SaveMethod.QUEUEABLE.name(), Logger.lastSaveMethodNameUsed);
-        System.assertEquals(1, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(Logger.SaveMethod.QUEUEABLE.name(), Logger.lastSaveMethodNameUsed);
+        System.Assert.areEqual(1, LoggerMockDataStore.getJobQueue().getEnqueuedJobs().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
         String expectedUserJson = JSON.serializePretty(currentUser);
-        System.assertEquals(flowRecordEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowRecordEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(currentUser.Id, publishedLogEntryEvent.RecordId__c);
-        System.assertEquals(expectedUserJson, publishedLogEntryEvent.RecordJson__c);
+        System.Assert.areEqual(flowRecordEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowRecordEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(currentUser.Id, publishedLogEntryEvent.RecordId__c);
+        System.Assert.areEqual(expectedUserJson, publishedLogEntryEvent.RecordJson__c);
     }
 
     @IsTest
@@ -112,30 +112,30 @@ private class FlowRecordLogEntry_Tests {
         );
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() < flowRecordEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() < flowRecordEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowRecordLogEntry flowRecordEntry = createFlowRecordLogEntry();
         flowRecordEntry.loggingLevelName = flowRecordEntryLoggingLevel.name();
         flowRecordEntry.record = currentUser;
         flowRecordEntry.saveLog = true;
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowRecordLogEntry.addFlowRecordEntries(new List<FlowRecordLogEntry>{ flowRecordEntry });
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
         String expectedUserJson = JSON.serializePretty(currentUser);
-        System.assertEquals(flowRecordEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowRecordEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
-        System.assertEquals(currentUser.Id, publishedLogEntryEvent.RecordId__c);
-        System.assertEquals(expectedUserJson, publishedLogEntryEvent.RecordJson__c);
+        System.Assert.areEqual(flowRecordEntry.loggingLevelName, publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowRecordEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(currentUser.Id, publishedLogEntryEvent.RecordId__c);
+        System.Assert.areEqual(expectedUserJson, publishedLogEntryEvent.RecordJson__c);
     }
 
     @IsTest
@@ -149,24 +149,24 @@ private class FlowRecordLogEntry_Tests {
         );
         LoggingLevel userLoggingLevel = LoggingLevel.ERROR;
         LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() > flowRecordEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() > flowRecordEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowRecordLogEntry flowRecordEntry = createFlowRecordLogEntry();
         flowRecordEntry.loggingLevelName = flowRecordEntryLoggingLevel.name();
         flowRecordEntry.record = currentUser;
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowRecordLogEntry.addFlowRecordEntries(new List<FlowRecordLogEntry>{ flowRecordEntry });
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
     }
 
     @IsTest
@@ -176,26 +176,26 @@ private class FlowRecordLogEntry_Tests {
         Logger.getUserSettings().LoggingLevel__c = expectedEntryLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowRecordLogEntry flowRecordEntry = createFlowRecordLogEntry();
-        System.assertEquals(null, flowRecordEntry.faultMessage);
-        System.assertEquals(null, flowRecordEntry.loggingLevelName);
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.isNull(flowRecordEntry.faultMessage);
+        System.Assert.isNull(flowRecordEntry.loggingLevelName);
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowRecordLogEntry.addFlowRecordEntries(new List<FlowRecordLogEntry>{ flowRecordEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(null, publishedLogEntryEvent.ExceptionMessage__c);
-        System.assertEquals(null, publishedLogEntryEvent.ExceptionType__c);
-        System.assertEquals(expectedEntryLoggingLevel.name(), publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowRecordEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.isNull(publishedLogEntryEvent.ExceptionMessage__c);
+        System.Assert.isNull(publishedLogEntryEvent.ExceptionType__c);
+        System.Assert.areEqual(expectedEntryLoggingLevel.name(), publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowRecordEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
     }
 
     @IsTest
@@ -206,25 +206,25 @@ private class FlowRecordLogEntry_Tests {
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         FlowRecordLogEntry flowRecordEntry = createFlowRecordLogEntry();
         flowRecordEntry.faultMessage = 'Whoops, a Flow error has occurred.';
-        System.assertEquals(null, flowRecordEntry.loggingLevelName);
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.isNull(flowRecordEntry.loggingLevelName);
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowRecordLogEntry.addFlowRecordEntries(new List<FlowRecordLogEntry>{ flowRecordEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowRecordEntry.faultMessage, publishedLogEntryEvent.ExceptionMessage__c);
-        System.assertEquals('Flow.FaultError', publishedLogEntryEvent.ExceptionType__c);
-        System.assertEquals(expectedEntryLoggingLevel.name(), publishedLogEntryEvent.LoggingLevel__c);
-        System.assertEquals(flowRecordEntry.message, publishedLogEntryEvent.Message__c);
-        System.assertEquals('Flow', publishedLogEntryEvent.OriginType__c);
+        System.Assert.areEqual(flowRecordEntry.faultMessage, publishedLogEntryEvent.ExceptionMessage__c);
+        System.Assert.areEqual('Flow.FaultError', publishedLogEntryEvent.ExceptionType__c);
+        System.Assert.areEqual(expectedEntryLoggingLevel.name(), publishedLogEntryEvent.LoggingLevel__c);
+        System.Assert.areEqual(flowRecordEntry.message, publishedLogEntryEvent.Message__c);
+        System.Assert.areEqual('Flow', publishedLogEntryEvent.OriginType__c);
     }
 
     @IsTest
@@ -236,21 +236,21 @@ private class FlowRecordLogEntry_Tests {
         FlowRecordLogEntry flowRecordEntry = createFlowRecordLogEntry();
         flowRecordEntry.loggingLevelName = userLoggingLevel.name();
         flowRecordEntry.scenario = 'Some scenario';
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowRecordLogEntry.addFlowRecordEntries(new List<FlowRecordLogEntry>{ flowRecordEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
-        System.assertEquals(flowRecordEntry.scenario, publishedLogEntryEvent.TransactionScenario__c);
-        System.assertEquals(flowRecordEntry.scenario, publishedLogEntryEvent.EntryScenario__c);
+        System.Assert.areEqual(flowRecordEntry.scenario, publishedLogEntryEvent.TransactionScenario__c);
+        System.Assert.areEqual(flowRecordEntry.scenario, publishedLogEntryEvent.EntryScenario__c);
     }
 
     @IsTest
@@ -258,32 +258,32 @@ private class FlowRecordLogEntry_Tests {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggingLevel userLoggingLevel = LoggingLevel.FINEST;
         LoggingLevel flowRecordEntryLoggingLevel = LoggingLevel.DEBUG;
-        System.assert(userLoggingLevel.ordinal() < flowRecordEntryLoggingLevel.ordinal());
+        System.Assert.isTrue(userLoggingLevel.ordinal() < flowRecordEntryLoggingLevel.ordinal());
         Logger.getUserSettings().LoggingLevel__c = userLoggingLevel.name();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         List<String> tags = new List<String>{ 'first tag', 'SECOND TAG' };
         FlowRecordLogEntry flowRecordEntry = createFlowRecordLogEntry();
         flowRecordEntry.loggingLevelName = flowRecordEntryLoggingLevel.name();
         flowRecordEntry.tagsString = String.join(tags, ', ');
-        System.assertEquals(0, Logger.saveLogCallCount);
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         FlowRecordLogEntry.addFlowRecordEntries(new List<FlowRecordLogEntry>{ flowRecordEntry });
-        System.assertEquals(1, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(1, Logger.saveLogCallCount);
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
-        System.assertEquals(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
         List<String> publishedLogEntryEventTags = publishedLogEntryEvent.Tags__c.split('\n');
-        System.assertEquals(tags.size(), publishedLogEntryEventTags.size(), publishedLogEntryEventTags);
+        System.Assert.areEqual(tags.size(), publishedLogEntryEventTags.size(), JSON.serializePretty(publishedLogEntryEventTags));
         Set<String> tagsSet = new Set<String>(tags);
         for (String publishedTag : publishedLogEntryEventTags) {
             publishedTag = publishedTag.trim();
-            System.assert(tagsSet.contains(publishedTag), publishedTag + ' not found in expected tags set: ' + tagsSet);
+            System.Assert.isTrue(tagsSet.contains(publishedTag), publishedTag + ' not found in expected tags set: ' + tagsSet);
         }
     }
 }

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -10,7 +10,7 @@
 private class LogEntryEventBuilder_Tests {
     @IsTest
     static void it_should_short_circuit_when_disabled() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.DEBUG, false, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.DEBUG, false, new Set<String>());
 
         // Run all public and global methods to make sure no errors occur when not enabled (it's happened before)
         System.Assert.isNull(builder.setMessage(getLogMessage()).getLogEntryEvent());
@@ -37,13 +37,13 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_short_circuit_when_enabled_logging_level_above_called_level() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.FINE, false, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.FINE, false, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent());
     }
 
     @IsTest
     static void it_should_not_short_circuit_when_enabled() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.FINE, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.FINE, true, new Set<String>());
         System.Assert.isNotNull(builder.getLogEntryEvent());
     }
 
@@ -57,7 +57,7 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isFalse(Logger.isEnabled());
         System.Assert.areEqual(0, System.Limits.getQueries());
 
-        new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, Logger.getUserSettings().IsEnabled__c, new Set<String>())
+        new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, Logger.getUserSettings().IsEnabled__c, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
         System.Assert.areEqual(0, System.Limits.getQueries());
@@ -71,7 +71,7 @@ private class LogEntryEventBuilder_Tests {
         LoggerEngineDataSelector.setMock(mockSelector);
         System.Assert.areEqual(0, mockSelector.getCachedAuthSessionQueryCount());
 
-        LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>())
+        LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
 
@@ -96,7 +96,7 @@ private class LogEntryEventBuilder_Tests {
         LoggerEngineDataSelector.setMock(mockSelector);
         System.Assert.areEqual(0, mockSelector.getCachedAuthSessionQueryCount());
 
-        LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>())
+        LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
 
@@ -122,7 +122,7 @@ private class LogEntryEventBuilder_Tests {
         LoggerEngineDataSelector.setMock(mockSelector);
         System.Assert.areEqual(0, mockSelector.getCachedOrganizationQueryCount());
 
-        LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>())
+        LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
 
@@ -142,7 +142,7 @@ private class LogEntryEventBuilder_Tests {
         LoggerEngineDataSelector.setMock(mockSelector);
         System.Assert.areEqual(0, mockSelector.getCachedOrganizationQueryCount());
 
-        LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>())
+        LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
 
@@ -163,7 +163,7 @@ private class LogEntryEventBuilder_Tests {
         LoggerEngineDataSelector.setMock(mockSelector);
         System.Assert.areEqual(0, mockSelector.getCachedUserQueryCount());
 
-        LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>())
+        LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
 
@@ -184,7 +184,7 @@ private class LogEntryEventBuilder_Tests {
         LoggerEngineDataSelector.setMock(mockSelector);
         System.Assert.areEqual(0, mockSelector.getCachedUserQueryCount());
 
-        LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>())
+        LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
 
@@ -200,7 +200,8 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_keep_timestamp_string_in_sync_with_timestamp() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>()).setMessage('some message');
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>())
+            .setMessage('some message');
 
         for (Integer i = 0; i < 5; i++) {
             builder.getLogEntryEvent().Timestamp__c = builder.getLogEntryEvent().Timestamp__c.addSeconds(i);
@@ -215,7 +216,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_message_fields_for_logMessage() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
         System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
         System.Assert.isNull(builder.getLogEntryEvent().Message__c);
@@ -230,7 +231,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_message_fields_for_null_logMessage() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
         System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
         System.Assert.isNull(builder.getLogEntryEvent().Message__c);
@@ -245,7 +246,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_message_fields_for_string() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
         System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
         System.Assert.isNull(builder.getLogEntryEvent().Message__c);
@@ -260,7 +261,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_message_fields_for_null_string() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
         System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
         System.Assert.isNull(builder.getLogEntryEvent().Message__c);
@@ -283,7 +284,7 @@ private class LogEntryEventBuilder_Tests {
         Account account = new Account(Name = message);
         String accountJson = JSON.serializePretty(account);
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setMessage(message).setRecord(account);
 
         System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c, builder.getLogEntryEvent().Message__c);
@@ -302,7 +303,7 @@ private class LogEntryEventBuilder_Tests {
         Account account = new Account(Name = message);
         String accountJson = JSON.serializePretty(account);
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setMessage(message).setRecord(account);
 
         System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
@@ -320,7 +321,7 @@ private class LogEntryEventBuilder_Tests {
         String sensitiveString = 'Something, something, and my social is 400 11 9999 in case you want to steal my identity';
         String expectedSanitizedString = 'Something, something, and my social is XXX-XX-9999 in case you want to steal my identity';
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setMessage(sensitiveString);
 
         System.Assert.isTrue(builder.getLogEntryEvent().MessageMasked__c);
@@ -340,7 +341,7 @@ private class LogEntryEventBuilder_Tests {
         String accountJson = JSON.serializePretty(account);
         String expectedSanitizedAccountJson = JSON.serializePretty(new Account(Name = expectedSanitizedString));
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setRecord(account);
 
         System.Assert.isTrue(builder.getLogEntryEvent().RecordJsonMasked__c);
@@ -360,7 +361,7 @@ private class LogEntryEventBuilder_Tests {
         List<Account> accounts = new List<Account>{ new Account(Name = sensitiveString) };
         String accountListJson = JSON.serializePretty(accounts);
         String expectedSanitizedAccountListJson = JSON.serializePretty(new List<Account>{ new Account(Name = expectedSanitizedString) });
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setRecord(accounts);
 
         System.Assert.isTrue(builder.getLogEntryEvent().RecordJsonMasked__c);
@@ -379,7 +380,7 @@ private class LogEntryEventBuilder_Tests {
         HttpRequest httpRequest = LoggerMockDataCreator.createHttpRequest();
         httpRequest.setBody(sensitiveString);
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setHttpRequestDetails(httpRequest);
 
         System.Assert.isTrue(builder.getLogEntryEvent().HttpRequestBodyMasked__c);
@@ -398,7 +399,7 @@ private class LogEntryEventBuilder_Tests {
         HttpResponse httpResponse = LoggerMockDataCreator.createHttpResponse();
         httpResponse.setBody(sensitiveString);
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setHttpResponseDetails(httpResponse);
 
         System.Assert.isTrue(builder.getLogEntryEvent().HttpResponseBodyMasked__c);
@@ -408,7 +409,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_truncate_message_for_long_logMessage() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
         System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
         System.Assert.isNull(builder.getLogEntryEvent().Message__c);
@@ -426,7 +427,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_truncate_message_for_long_string() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
         System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
         System.Assert.isNull(builder.getLogEntryEvent().Message__c);
@@ -442,7 +443,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_exception_fields_for_dmlException() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().ExceptionMessage__c);
         System.Assert.isNull(builder.getLogEntryEvent().ExceptionType__c);
 
@@ -458,7 +459,7 @@ private class LogEntryEventBuilder_Tests {
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
         System.Assert.isNotNull(deleteResult);
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(deleteResult);
 
         System.Assert.areEqual(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
@@ -472,7 +473,7 @@ private class LogEntryEventBuilder_Tests {
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
         System.Assert.isNotNull(mergeResult);
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(mergeResult);
 
         System.Assert.areEqual(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
@@ -486,7 +487,7 @@ private class LogEntryEventBuilder_Tests {
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
         System.Assert.isNotNull(saveResult);
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(saveResult);
 
         System.Assert.areEqual(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
@@ -500,7 +501,7 @@ private class LogEntryEventBuilder_Tests {
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
         System.Assert.isNotNull(undeleteResult);
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(undeleteResult);
 
         System.Assert.areEqual(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
@@ -515,7 +516,7 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isNotNull(upsertResult);
         System.Assert.isTrue(upsertResult.isCreated());
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(upsertResult);
 
         System.Assert.areEqual(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
@@ -530,7 +531,7 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isNotNull(upsertResult);
         System.Assert.isFalse(upsertResult.isCreated());
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(upsertResult);
 
         System.Assert.areEqual(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
@@ -546,7 +547,7 @@ private class LogEntryEventBuilder_Tests {
             deleteResults.add(LoggerMockDataCreator.createDatabaseDeleteResult(false));
         }
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(deleteResults);
 
         System.Assert.areEqual(deleteResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
@@ -562,7 +563,7 @@ private class LogEntryEventBuilder_Tests {
             mergeResults.add(LoggerMockDataCreator.createDatabaseMergeResult(false));
         }
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(mergeResults);
 
         System.Assert.areEqual(mergeResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
@@ -578,7 +579,7 @@ private class LogEntryEventBuilder_Tests {
             saveResults.add(LoggerMockDataCreator.createDatabaseSaveResult(false));
         }
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(saveResults);
 
         System.Assert.areEqual(saveResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
@@ -594,7 +595,7 @@ private class LogEntryEventBuilder_Tests {
             undeleteResults.add(LoggerMockDataCreator.createDatabaseUndeleteResult(false));
         }
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(undeleteResults);
 
         System.Assert.areEqual(undeleteResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
@@ -610,7 +611,7 @@ private class LogEntryEventBuilder_Tests {
             upsertResults.add(LoggerMockDataCreator.createDatabaseUpsertResult(false, false));
         }
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(upsertResults);
 
         System.Assert.areEqual(upsertResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
@@ -621,7 +622,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_record_fields_for_recordId_when_standard_object() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
@@ -642,7 +643,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_record_fields_for_recordId_when_template_standard_object() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
         System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
         System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
@@ -663,7 +664,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_record_fields_for_recordId_when_custom_object() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
@@ -683,7 +684,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_record_fields_for_recordId_when_custom_metadata_type() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
@@ -703,7 +704,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_record_fields_for_record_when_null() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
@@ -725,7 +726,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_record_fields_for_record_when_standard_object() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
@@ -746,7 +747,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_record_fields_for_record_when_custom_object() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
@@ -766,7 +767,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_record_fields_for_record_when_custom_metadata_type() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
@@ -786,7 +787,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_record_fields_for_record_when_platform_event() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
@@ -813,7 +814,7 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder;
         System.runAs(standardUser) {
             Logger.getUserSettings().IsRecordFieldStrippingEnabled__c = true;
-            builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAggregateResult);
+            builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAggregateResult);
         }
 
         System.Assert.areEqual(JSON.serializePretty(mockAggregateResult), builder.getLogEntryEvent().RecordJson__c);
@@ -827,7 +828,7 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder;
         System.runAs(standardUser) {
             Logger.getUserSettings().IsRecordFieldStrippingEnabled__c = true;
-            builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAggregateResults);
+            builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAggregateResults);
         }
 
         System.Assert.areEqual(JSON.serializePretty(mockAggregateResults), builder.getLogEntryEvent().RecordJson__c);
@@ -835,7 +836,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_record_fields_for_list_of_records_when_list_is_null() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
@@ -855,7 +856,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_record_fields_for_list_of_records_when_list_is_empty() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
@@ -875,7 +876,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_record_fields_for_list_of_records_when_first_record_is_null() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
@@ -897,7 +898,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_record_fields_for_list_of_records_when_populated() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
@@ -916,7 +917,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_skip_setting_http_request_fields_when_request_is_null() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
         System.Assert.isFalse(builder.getLogEntryEvent().HttpRequestCompressed__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
@@ -933,7 +934,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_http_request_fields_when_request_is_populated() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
@@ -953,7 +954,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_skip_setting_http_response_fields_when_response_is_null() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
@@ -969,7 +970,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_http_response_fields_when_populated() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
@@ -990,7 +991,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_set_tags_string_for_list_of_tags() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().Tags__c);
 
         List<String> tags = new List<String>{ 'some-tag', 'another One', 'here\'s one more!' };
@@ -1003,7 +1004,7 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_deduplicate_and_sort_tags() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().Tags__c);
 
         List<String> tags = new List<String>{ 'duplicate-tag', 'duplicate-tag', 'another One' };
@@ -1025,7 +1026,7 @@ private class LogEntryEventBuilder_Tests {
         LoggerParameter.setMock(mockParameter);
         System.Assert.isFalse(LoggerParameter.ENABLE_STACK_TRACE_PARSING);
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
 
         System.Assert.isNull(builder.getLogEntryEvent().OriginLocation__c);
         System.Assert.isNull(builder.getLogEntryEvent().StackTrace__c);
@@ -1042,7 +1043,7 @@ private class LogEntryEventBuilder_Tests {
         LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'EnableStackTraceParsing', Value__c = String.valueOf(false));
         LoggerParameter.setMock(mockParameter);
         System.Assert.isFalse(LoggerParameter.ENABLE_STACK_TRACE_PARSING);
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
 
         builder.parseStackTrace('AnonymousBlock: line 1, column 1');
 
@@ -1062,7 +1063,7 @@ private class LogEntryEventBuilder_Tests {
         String expectedOriginLocation = qualifiedClassName + '.<init>';
         DebugStringExample constructedClass = new DebugStringExample();
         String expectedStackTrace = constructedClass.getStackTraceString();
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.FINE, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.FINE, true, new Set<String>());
         builder.getLogEntryEvent().OriginLocation__c = null;
         builder.getLogEntryEvent().StackTrace__c = null;
 
@@ -1086,7 +1087,7 @@ private class LogEntryEventBuilder_Tests {
         String qualifiedClassName = LogEntryEventBuilder_Tests.class.getName();
         String expectedOriginLocation = qualifiedClassName + '.it_should_set_stack_trace_and_origin_location_for_method_stack_trace_string';
         String expectedStackTrace = stackTraceHandler.getStackTraceString();
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.FINE, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.FINE, true, new Set<String>());
         builder.getLogEntryEvent().OriginLocation__c = null;
         builder.getLogEntryEvent().StackTrace__c = null;
 
@@ -1112,7 +1113,7 @@ private class LogEntryEventBuilder_Tests {
 
         LogEntryEventBuilder builder = new LogEntryEventBuilder(
             getUserSettings(),
-            LoggingLevel.FINE,
+            System.LoggingLevel.FINE,
             true,
             new Set<String>{ LogEntryEventBuilder_Tests.class.getName() }
         );
@@ -1131,7 +1132,7 @@ private class LogEntryEventBuilder_Tests {
 
         LogEntryEventBuilder builder = new LogEntryEventBuilder(
             getUserSettings(),
-            LoggingLevel.FINE,
+            System.LoggingLevel.FINE,
             true,
             new Set<String>{ LogEntryEventBuilder_Tests.class.getName() }
         );
@@ -1149,7 +1150,7 @@ private class LogEntryEventBuilder_Tests {
         String deduplicatedStackTraceString = 'AnonymousBlock: line 9, column 1';
         String duplicatedStackTraceString = deduplicatedStackTraceString + '\n' + deduplicatedStackTraceString + '\n' + deduplicatedStackTraceString;
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.FINE, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.FINE, true, new Set<String>());
         builder.getLogEntryEvent().OriginLocation__c = null;
         builder.getLogEntryEvent().StackTrace__c = null;
         builder.parseStackTrace(duplicatedStackTraceString);
@@ -1164,7 +1165,7 @@ private class LogEntryEventBuilder_Tests {
     static void it_should_not_set_stack_trace_and_origin_location_for_invalid_stack_trace_string() {
         final String invalidStackTrace = '()';
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         // Clear out any auto-set values
         builder.getLogEntryEvent().OriginLocation__c = null;
         builder.getLogEntryEvent().StackTrace__c = null;
@@ -1176,13 +1177,13 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_return_value_of_shouldSave_when_true() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isTrue(builder.shouldSave());
     }
 
     @IsTest
     static void it_should_return_value_of_shouldSave_when_false() {
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, false, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, false, new Set<String>());
         System.Assert.isFalse(builder.shouldSave());
     }
 
@@ -1194,7 +1195,7 @@ private class LogEntryEventBuilder_Tests {
         String organizationEnvironmentType = LoggerMockDataCreator.getOrganizationEnvironmentType();
         User user = LoggerMockDataCreator.getUser();
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
 
         // Verify organization fields
         System.Assert.areEqual(Url.getOrgDomainUrl().toExternalForm(), builder.getLogEntryEvent().OrganizationDomainUrl__c);
@@ -1269,7 +1270,7 @@ private class LogEntryEventBuilder_Tests {
             '\n' +
             example.loggingString +
             ': ' +
-            LoggingLevel.DEBUG.name(),
+            System.LoggingLevel.DEBUG.name(),
             builder.debugMessage
         );
     }

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -15,7 +15,7 @@ private class LogEntryEventBuilder_Tests {
         // Run all public and global methods to make sure no errors occur when not enabled (it's happened before)
         System.Assert.isNull(builder.setMessage(getLogMessage()).getLogEntryEvent());
         System.Assert.isNull(builder.setMessage(getMessage()).getLogEntryEvent());
-        System.Assert.isNull(builder.setExceptionDetails(new DmlException()).getLogEntryEvent());
+        System.Assert.isNull(builder.setExceptionDetails(new System.DmlException()).getLogEntryEvent());
         System.Assert.isNull(builder.setDatabaseResult((Database.DeleteResult) null).getLogEntryEvent());
         System.Assert.isNull(builder.setDatabaseResult((Database.MergeResult) null).getLogEntryEvent());
         System.Assert.isNull(builder.setDatabaseResult((Database.SaveResult) null).getLogEntryEvent());
@@ -32,7 +32,7 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isNull(builder.setRecord(new User(Id = System.UserInfo.getUserId())).getLogEntryEvent());
         System.Assert.isNull(builder.setRecord(new List<User>{ new User(Id = System.UserInfo.getUserId()) }).getLogEntryEvent());
         System.Assert.isNull(builder.addTags(new List<String>{ 'tag-1', 'tag-2' }).getLogEntryEvent());
-        System.Assert.isNull(builder.parseStackTrace(new DmlException().getStackTraceString()).getLogEntryEvent());
+        System.Assert.isNull(builder.parseStackTrace(new System.DmlException().getStackTraceString()).getLogEntryEvent());
     }
 
     @IsTest
@@ -377,7 +377,7 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder.setMockDataMaskRule(rule);
         String sensitiveString = 'Something, something, and my social is 400 11 9999 in case you want to steal my identity';
         String expectedSanitizedString = 'Something, something, and my social is XXX-XX-9999 in case you want to steal my identity';
-        HttpRequest httpRequest = LoggerMockDataCreator.createHttpRequest();
+        System.HttpRequest httpRequest = LoggerMockDataCreator.createHttpRequest();
         httpRequest.setBody(sensitiveString);
 
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
@@ -396,7 +396,7 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder.setMockDataMaskRule(rule);
         String sensitiveString = 'Something, something, and my social is 400 11 9999 in case you want to steal my identity';
         String expectedSanitizedString = 'Something, something, and my social is XXX-XX-9999 in case you want to steal my identity';
-        HttpResponse httpResponse = LoggerMockDataCreator.createHttpResponse();
+        System.HttpResponse httpResponse = LoggerMockDataCreator.createHttpResponse();
         httpResponse.setBody(sensitiveString);
 
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
@@ -447,7 +447,7 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isNull(builder.getLogEntryEvent().ExceptionMessage__c);
         System.Assert.isNull(builder.getLogEntryEvent().ExceptionType__c);
 
-        DmlException dmlException = new DmlException('Test DML exception');
+        System.DmlException dmlException = new System.DmlException('Test DML exception');
         builder.setExceptionDetails(dmlException);
 
         System.Assert.areEqual(dmlException.getMessage(), builder.getLogEntryEvent().ExceptionMessage__c);
@@ -644,22 +644,22 @@ private class LogEntryEventBuilder_Tests {
     @IsTest
     static void it_should_set_record_fields_for_recordId_when_template_standard_object() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         Id templateSObjectRecordId = LoggerMockDataCreator.createId(Schema.CaseComment.SObjectType);
         builder.setRecordId(templateSObjectRecordId);
 
-        System.assertEquals(1, builder.getLogEntryEvent().RecordCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().RecordCollectionType__c);
-        System.assertEquals(templateSObjectRecordId, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().RecordCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().RecordCollectionType__c);
+        System.Assert.areEqual(templateSObjectRecordId, builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
     }
 
     @IsTest
@@ -922,7 +922,7 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isFalse(builder.getLogEntryEvent().HttpRequestCompressed__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
-        HttpRequest request = null;
+        System.HttpRequest request = null;
 
         builder.setHttpRequestDetails(request);
 
@@ -938,7 +938,7 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
-        HttpRequest request = new HttpRequest();
+        System.HttpRequest request = new System.HttpRequest();
         request.setBody('Hello, world!');
         request.setCompressed(true);
         request.setEndpoint('https://fake.salesforce.com');
@@ -958,7 +958,7 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
-        HttpResponse response = null;
+        System.HttpResponse response = null;
 
         builder.setHttpResponseDetails(response);
 
@@ -974,7 +974,7 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
-        HttpResponse response = new HttpResponse();
+        System.HttpResponse response = new System.HttpResponse();
         response.setBody('Hello, world!');
         response.setHeader('someKey', 'some string value');
         response.setHeader('anotherKey', 'an amazing example value, wow');
@@ -1083,7 +1083,7 @@ private class LogEntryEventBuilder_Tests {
             return;
         }
 
-        DmlException stackTraceHandler = new DmlException();
+        System.DmlException stackTraceHandler = new System.DmlException();
         String qualifiedClassName = LogEntryEventBuilder_Tests.class.getName();
         String expectedOriginLocation = qualifiedClassName + '.it_should_set_stack_trace_and_origin_location_for_method_stack_trace_string';
         String expectedStackTrace = stackTraceHandler.getStackTraceString();
@@ -1307,10 +1307,10 @@ private class LogEntryEventBuilder_Tests {
 
     private class DebugStringExample {
         public final String loggingString = 'Inside DebugStringExample.myMethod!';
-        private Exception stackTraceHandler;
+        private System.Exception stackTraceHandler;
 
         public DebugStringExample() {
-            this.stackTraceHandler = new DmlException();
+            this.stackTraceHandler = new System.DmlException();
             Logger.debug('Logging in a constructor');
         }
 

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -26,11 +26,11 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isNull(builder.setDatabaseResult(new List<Database.SaveResult>()).getLogEntryEvent());
         System.Assert.isNull(builder.setDatabaseResult(new List<Database.UpsertResult>()).getLogEntryEvent());
         System.Assert.isNull(builder.setDatabaseResult(new List<Database.UndeleteResult>()).getLogEntryEvent());
-        System.Assert.isNull(builder.setRecordId(UserInfo.getUserId()).getLogEntryEvent());
-        System.Assert.isNull(builder.setRecordId(new User(Id = UserInfo.getUserId())).getLogEntryEvent());
-        System.Assert.isNull(builder.setRecord(UserInfo.getUserId()).getLogEntryEvent());
-        System.Assert.isNull(builder.setRecord(new User(Id = UserInfo.getUserId())).getLogEntryEvent());
-        System.Assert.isNull(builder.setRecord(new List<User>{ new User(Id = UserInfo.getUserId()) }).getLogEntryEvent());
+        System.Assert.isNull(builder.setRecordId(System.UserInfo.getUserId()).getLogEntryEvent());
+        System.Assert.isNull(builder.setRecordId(new User(Id = System.UserInfo.getUserId())).getLogEntryEvent());
+        System.Assert.isNull(builder.setRecord(System.UserInfo.getUserId()).getLogEntryEvent());
+        System.Assert.isNull(builder.setRecord(new User(Id = System.UserInfo.getUserId())).getLogEntryEvent());
+        System.Assert.isNull(builder.setRecord(new List<User>{ new User(Id = System.UserInfo.getUserId()) }).getLogEntryEvent());
         System.Assert.isNull(builder.addTags(new List<String>{ 'tag-1', 'tag-2' }).getLogEntryEvent());
         System.Assert.isNull(builder.parseStackTrace(new DmlException().getStackTraceString()).getLogEntryEvent());
     }
@@ -628,7 +628,7 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
-        Id currentUserId = UserInfo.getUserId();
+        Id currentUserId = System.UserInfo.getUserId();
         builder.setRecordId(currentUserId);
 
         System.Assert.areEqual(1, builder.getLogEntryEvent().RecordCollectionSize__c);
@@ -732,7 +732,7 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
         System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
-        User currentUser = [SELECT Id, Name, ProfileId, Profile.Name, IsActive FROM User WHERE Id = :UserInfo.getUserId()];
+        User currentUser = [SELECT Id, Name, ProfileId, Profile.Name, IsActive FROM User WHERE Id = :System.UserInfo.getUserId()];
         builder.setRecordId(currentUser);
 
         System.Assert.areEqual(1, builder.getLogEntryEvent().RecordCollectionSize__c);
@@ -885,7 +885,7 @@ private class LogEntryEventBuilder_Tests {
         List<SObject> users = new List<SObject>();
         User nullUser;
         users.add(nullUser);
-        users.add(new User(Id = UserInfo.getUserId()));
+        users.add(new User(Id = System.UserInfo.getUserId()));
         builder.setRecord(users);
 
         System.Assert.areEqual('List', builder.getLogEntryEvent().RecordCollectionType__c);
@@ -1300,7 +1300,7 @@ private class LogEntryEventBuilder_Tests {
 
     static LoggerSettings__c getUserSettings() {
         LoggerSettings__c userSettings = (LoggerSettings__c) Schema.LoggerSettings__c.SObjectType.newSObject(null, true);
-        userSettings.SetupOwnerId = UserInfo.getUserId();
+        userSettings.SetupOwnerId = System.UserInfo.getUserId();
         return userSettings;
     }
 

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -13,38 +13,38 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.DEBUG, false, new Set<String>());
 
         // Run all public and global methods to make sure no errors occur when not enabled (it's happened before)
-        System.assertEquals(null, builder.setMessage(getLogMessage()).getLogEntryEvent());
-        System.assertEquals(null, builder.setMessage(getMessage()).getLogEntryEvent());
-        System.assertEquals(null, builder.setExceptionDetails(new DmlException()).getLogEntryEvent());
-        System.assertEquals(null, builder.setDatabaseResult((Database.DeleteResult) null).getLogEntryEvent());
-        System.assertEquals(null, builder.setDatabaseResult((Database.MergeResult) null).getLogEntryEvent());
-        System.assertEquals(null, builder.setDatabaseResult((Database.SaveResult) null).getLogEntryEvent());
-        System.assertEquals(null, builder.setDatabaseResult((Database.UpsertResult) null).getLogEntryEvent());
-        System.assertEquals(null, builder.setDatabaseResult((Database.UndeleteResult) null).getLogEntryEvent());
-        System.assertEquals(null, builder.setDatabaseResult(new List<Database.DeleteResult>()).getLogEntryEvent());
-        System.assertEquals(null, builder.setDatabaseResult(new List<Database.MergeResult>()).getLogEntryEvent());
-        System.assertEquals(null, builder.setDatabaseResult(new List<Database.SaveResult>()).getLogEntryEvent());
-        System.assertEquals(null, builder.setDatabaseResult(new List<Database.UpsertResult>()).getLogEntryEvent());
-        System.assertEquals(null, builder.setDatabaseResult(new List<Database.UndeleteResult>()).getLogEntryEvent());
-        System.assertEquals(null, builder.setRecordId(UserInfo.getUserId()).getLogEntryEvent());
-        System.assertEquals(null, builder.setRecordId(new User(Id = UserInfo.getUserId())).getLogEntryEvent());
-        System.assertEquals(null, builder.setRecord(UserInfo.getUserId()).getLogEntryEvent());
-        System.assertEquals(null, builder.setRecord(new User(Id = UserInfo.getUserId())).getLogEntryEvent());
-        System.assertEquals(null, builder.setRecord(new List<User>{ new User(Id = UserInfo.getUserId()) }).getLogEntryEvent());
-        System.assertEquals(null, builder.addTags(new List<String>{ 'tag-1', 'tag-2' }).getLogEntryEvent());
-        System.assertEquals(null, builder.parseStackTrace(new DmlException().getStackTraceString()).getLogEntryEvent());
+        System.Assert.isNull(builder.setMessage(getLogMessage()).getLogEntryEvent());
+        System.Assert.isNull(builder.setMessage(getMessage()).getLogEntryEvent());
+        System.Assert.isNull(builder.setExceptionDetails(new DmlException()).getLogEntryEvent());
+        System.Assert.isNull(builder.setDatabaseResult((Database.DeleteResult) null).getLogEntryEvent());
+        System.Assert.isNull(builder.setDatabaseResult((Database.MergeResult) null).getLogEntryEvent());
+        System.Assert.isNull(builder.setDatabaseResult((Database.SaveResult) null).getLogEntryEvent());
+        System.Assert.isNull(builder.setDatabaseResult((Database.UpsertResult) null).getLogEntryEvent());
+        System.Assert.isNull(builder.setDatabaseResult((Database.UndeleteResult) null).getLogEntryEvent());
+        System.Assert.isNull(builder.setDatabaseResult(new List<Database.DeleteResult>()).getLogEntryEvent());
+        System.Assert.isNull(builder.setDatabaseResult(new List<Database.MergeResult>()).getLogEntryEvent());
+        System.Assert.isNull(builder.setDatabaseResult(new List<Database.SaveResult>()).getLogEntryEvent());
+        System.Assert.isNull(builder.setDatabaseResult(new List<Database.UpsertResult>()).getLogEntryEvent());
+        System.Assert.isNull(builder.setDatabaseResult(new List<Database.UndeleteResult>()).getLogEntryEvent());
+        System.Assert.isNull(builder.setRecordId(UserInfo.getUserId()).getLogEntryEvent());
+        System.Assert.isNull(builder.setRecordId(new User(Id = UserInfo.getUserId())).getLogEntryEvent());
+        System.Assert.isNull(builder.setRecord(UserInfo.getUserId()).getLogEntryEvent());
+        System.Assert.isNull(builder.setRecord(new User(Id = UserInfo.getUserId())).getLogEntryEvent());
+        System.Assert.isNull(builder.setRecord(new List<User>{ new User(Id = UserInfo.getUserId()) }).getLogEntryEvent());
+        System.Assert.isNull(builder.addTags(new List<String>{ 'tag-1', 'tag-2' }).getLogEntryEvent());
+        System.Assert.isNull(builder.parseStackTrace(new DmlException().getStackTraceString()).getLogEntryEvent());
     }
 
     @IsTest
     static void it_should_short_circuit_when_enabled_logging_level_above_called_level() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.FINE, false, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent());
+        System.Assert.isNull(builder.getLogEntryEvent());
     }
 
     @IsTest
     static void it_should_not_short_circuit_when_enabled() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.FINE, true, new Set<String>());
-        System.assertNotEquals(null, builder.getLogEntryEvent());
+        System.Assert.isNotNull(builder.getLogEntryEvent());
     }
 
     @IsTest
@@ -54,171 +54,148 @@ private class LogEntryEventBuilder_Tests {
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryOrganizationDataSynchronously', Value__c = String.valueOf(true)));
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryUserDataSynchronously', Value__c = String.valueOf(true)));
         Logger.getUserSettings().IsEnabled__c = false;
-        System.assertEquals(false, Logger.isEnabled());
-        System.assertEquals(0, System.Limits.getQueries());
+        System.Assert.isFalse(Logger.isEnabled());
+        System.Assert.areEqual(0, System.Limits.getQueries());
 
         new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, Logger.getUserSettings().IsEnabled__c, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
-        System.assertEquals(0, System.Limits.getQueries());
+        System.Assert.areEqual(0, System.Limits.getQueries());
     }
 
     @IsTest
     static void it_should_not_run_authSession_query_when_disabled_via_logger_parameter() {
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryAuthSessionDataSynchronously', Value__c = String.valueOf(false)));
-        System.assertEquals(false, LoggerParameter.QUERY_AUTH_SESSION_DATA_SYNCHRONOUSLY);
+        System.Assert.isFalse(LoggerParameter.QUERY_AUTH_SESSION_DATA_SYNCHRONOUSLY);
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
         LoggerEngineDataSelector.setMock(mockSelector);
-        System.assertEquals(0, mockSelector.getCachedAuthSessionQueryCount());
+        System.Assert.areEqual(0, mockSelector.getCachedAuthSessionQueryCount());
 
         LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
 
-        System.assertEquals(0, mockSelector.getCachedAuthSessionQueryCount());
-        System.assertEquals(null, logEntryEvent.LoginApplication__c);
-        System.assertEquals(null, logEntryEvent.LoginBrowser__c);
-        System.assertEquals(null, logEntryEvent.LoginHistoryId__c);
-        System.assertEquals(null, logEntryEvent.LoginPlatform__c);
-        System.assertEquals(null, logEntryEvent.LoginType__c);
-        System.assertEquals(null, logEntryEvent.LogoutUrl__c);
-        System.assertEquals(null, logEntryEvent.SessionId__c);
-        System.assertEquals(null, logEntryEvent.SessionSecurityLevel__c);
-        System.assertEquals(null, logEntryEvent.SessionType__c);
-        System.assertEquals(null, logEntryEvent.SourceIp__c);
+        System.Assert.areEqual(0, mockSelector.getCachedAuthSessionQueryCount());
+        System.Assert.isNull(logEntryEvent.LoginApplication__c);
+        System.Assert.isNull(logEntryEvent.LoginBrowser__c);
+        System.Assert.isNull(logEntryEvent.LoginHistoryId__c);
+        System.Assert.isNull(logEntryEvent.LoginPlatform__c);
+        System.Assert.isNull(logEntryEvent.LoginType__c);
+        System.Assert.isNull(logEntryEvent.LogoutUrl__c);
+        System.Assert.isNull(logEntryEvent.SessionId__c);
+        System.Assert.isNull(logEntryEvent.SessionSecurityLevel__c);
+        System.Assert.isNull(logEntryEvent.SessionType__c);
+        System.Assert.isNull(logEntryEvent.SourceIp__c);
     }
 
     @IsTest
     static void it_should_run_authSession_query_when_enabled_via_logger_parameter() {
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryAuthSessionDataSynchronously', Value__c = String.valueOf(true)));
-        System.assertEquals(true, LoggerParameter.QUERY_AUTH_SESSION_DATA_SYNCHRONOUSLY);
+        System.Assert.isTrue(LoggerParameter.QUERY_AUTH_SESSION_DATA_SYNCHRONOUSLY);
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
         LoggerEngineDataSelector.setMock(mockSelector);
-        System.assertEquals(0, mockSelector.getCachedAuthSessionQueryCount());
+        System.Assert.areEqual(0, mockSelector.getCachedAuthSessionQueryCount());
 
         LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
 
-        System.assertEquals(1, mockSelector.getCachedAuthSessionQueryCount());
-        LoggerSObjectProxy.AuthSession cachedAuthSessionProxy = LoggerEngineDataSelector.getInstance().getCachedAuthSessionProxy();
-        System.assertEquals(cachedAuthSessionProxy?.LoginHistory.Application, logEntryEvent.LoginApplication__c);
-        System.assertEquals(cachedAuthSessionProxy?.LoginHistory.Browser, logEntryEvent.LoginBrowser__c);
-        System.assertEquals(cachedAuthSessionProxy?.LoginHistoryId, logEntryEvent.LoginHistoryId__c);
-        System.assertEquals(cachedAuthSessionProxy?.LoginHistory.Platform, logEntryEvent.LoginPlatform__c);
-        System.assertEquals(cachedAuthSessionProxy?.LoginType, logEntryEvent.LoginType__c);
-        System.assertEquals(cachedAuthSessionProxy?.LogoutUrl, logEntryEvent.LogoutUrl__c);
-        System.assertEquals(cachedAuthSessionProxy?.Id, logEntryEvent.SessionId__c);
-        System.assertEquals(cachedAuthSessionProxy?.SessionSecurityLevel, logEntryEvent.SessionSecurityLevel__c);
-        System.assertEquals(cachedAuthSessionProxy?.SessionType, logEntryEvent.SessionType__c);
-        System.assertEquals(cachedAuthSessionProxy?.SourceIp, logEntryEvent.SourceIp__c);
-    }
-
-    @IsTest
-    static void it_should_set_impersonatedById_when_authSession_userId_is_not_current_user() {
-        Id currentUserId = System.UserInfo.getUserId();
-        Id anotherUserId = [SELECT Id FROM User WHERE Id != :System.UserInfo.getUserId() LIMIT 1].Id;
-        System.assertEquals(true, LoggerParameter.QUERY_AUTH_SESSION_DATA_SYNCHRONOUSLY);
-        MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
-        LoggerSObjectProxy.LoginHistory mockLoginHistoryProxy = new LoggerSObjectProxy.LoginHistory(null);
-        mockLoginHistoryProxy.UserId = anotherUserId;
-        LoggerSObjectProxy.AuthSession mockAuthSessionProxy = new LoggerSObjectProxy.AuthSession(null);
-        mockAuthSessionProxy.LoginHistory = mockLoginHistoryProxy;
-        mockAuthSessionProxy.UsersId = currentUserId;
-        mockSelector.setCachedAuthSessionProxy(mockAuthSessionProxy);
-        LoggerEngineDataSelector.setMock(mockSelector);
-
-        LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>())
-            .setMessage('some message')
-            .getLogEntryEvent();
-
-        System.assertNotEquals(logEntryEvent.LoggedById__c, logEntryEvent.ImpersonatedById__c);
-        System.assertEquals(currentUserId, logEntryEvent.LoggedById__c);
-        System.assertEquals(anotherUserId, logEntryEvent.ImpersonatedById__c);
+        System.Assert.areEqual(1, mockSelector.getCachedAuthSessionQueryCount());
+        LoggerSObjectProxy.AuthSession cachedAuthSession = LoggerEngineDataSelector.getInstance().getCachedAuthSessionProxy();
+        System.Assert.areEqual(cachedAuthSession?.LoginHistory.Application, logEntryEvent.LoginApplication__c);
+        System.Assert.areEqual(cachedAuthSession?.LoginHistory.Browser, logEntryEvent.LoginBrowser__c);
+        System.Assert.areEqual(cachedAuthSession?.LoginHistoryId, logEntryEvent.LoginHistoryId__c);
+        System.Assert.areEqual(cachedAuthSession?.LoginHistory.Platform, logEntryEvent.LoginPlatform__c);
+        System.Assert.areEqual(cachedAuthSession?.LoginType, logEntryEvent.LoginType__c);
+        System.Assert.areEqual(cachedAuthSession?.LogoutUrl, logEntryEvent.LogoutUrl__c);
+        System.Assert.areEqual(cachedAuthSession?.Id, logEntryEvent.SessionId__c);
+        System.Assert.areEqual(cachedAuthSession?.SessionSecurityLevel, logEntryEvent.SessionSecurityLevel__c);
+        System.Assert.areEqual(cachedAuthSession?.SessionType, logEntryEvent.SessionType__c);
+        System.Assert.areEqual(cachedAuthSession?.SourceIp, logEntryEvent.SourceIp__c);
     }
 
     @IsTest
     static void it_should_not_run_organization_query_when_disabled_via_logger_parameter() {
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryOrganizationDataSynchronously', Value__c = String.valueOf(false)));
-        System.assertEquals(false, LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY);
+        System.Assert.isFalse(LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY);
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
         LoggerEngineDataSelector.setMock(mockSelector);
-        System.assertEquals(0, mockSelector.getCachedOrganizationQueryCount());
+        System.Assert.areEqual(0, mockSelector.getCachedOrganizationQueryCount());
 
         LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
 
-        System.assertEquals(0, mockSelector.getCachedOrganizationQueryCount());
-        System.assertEquals(null, logEntryEvent.OrganizationId__c);
-        System.assertEquals(null, logEntryEvent.OrganizationInstanceName__c);
-        System.assertEquals(null, logEntryEvent.OrganizationName__c);
-        System.assertEquals(null, logEntryEvent.OrganizationNamespacePrefix__c);
-        System.assertEquals(null, logEntryEvent.OrganizationType__c);
+        System.Assert.areEqual(0, mockSelector.getCachedOrganizationQueryCount());
+        System.Assert.isNull(logEntryEvent.OrganizationId__c);
+        System.Assert.isNull(logEntryEvent.OrganizationInstanceName__c);
+        System.Assert.isNull(logEntryEvent.OrganizationName__c);
+        System.Assert.isNull(logEntryEvent.OrganizationNamespacePrefix__c);
+        System.Assert.isNull(logEntryEvent.OrganizationType__c);
     }
 
     @IsTest
     static void it_should_run_organization_query_when_enabled_via_logger_parameter() {
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryOrganizationDataSynchronously', Value__c = String.valueOf(true)));
-        System.assertEquals(true, LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY);
+        System.Assert.isTrue(LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY);
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
         LoggerEngineDataSelector.setMock(mockSelector);
-        System.assertEquals(0, mockSelector.getCachedOrganizationQueryCount());
+        System.Assert.areEqual(0, mockSelector.getCachedOrganizationQueryCount());
 
         LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
 
-        System.assertNotEquals(0, mockSelector.getCachedOrganizationQueryCount());
+        System.Assert.areNotEqual(0, mockSelector.getCachedOrganizationQueryCount());
         Organization cachedOrganization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
-        System.assertEquals(cachedOrganization.Id, logEntryEvent.OrganizationId__c);
-        System.assertEquals(cachedOrganization.InstanceName, logEntryEvent.OrganizationInstanceName__c);
-        System.assertEquals(cachedOrganization.Name, logEntryEvent.OrganizationName__c);
-        System.assertEquals(cachedOrganization.NamespacePrefix, logEntryEvent.OrganizationNamespacePrefix__c);
-        System.assertEquals(cachedOrganization.OrganizationType, logEntryEvent.OrganizationType__c);
+        System.Assert.areEqual(cachedOrganization.Id, logEntryEvent.OrganizationId__c);
+        System.Assert.areEqual(cachedOrganization.InstanceName, logEntryEvent.OrganizationInstanceName__c);
+        System.Assert.areEqual(cachedOrganization.Name, logEntryEvent.OrganizationName__c);
+        System.Assert.areEqual(cachedOrganization.NamespacePrefix, logEntryEvent.OrganizationNamespacePrefix__c);
+        System.Assert.areEqual(cachedOrganization.OrganizationType, logEntryEvent.OrganizationType__c);
     }
 
     @IsTest
     static void it_should_not_run_user_query_when_disabled_via_logger_parameter() {
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryUserDataSynchronously', Value__c = String.valueOf(false)));
-        System.assertEquals(false, LoggerParameter.QUERY_USER_DATA_SYNCHRONOUSLY);
+        System.Assert.isFalse(LoggerParameter.QUERY_USER_DATA_SYNCHRONOUSLY);
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
         LoggerEngineDataSelector.setMock(mockSelector);
-        System.assertEquals(0, mockSelector.getCachedUserQueryCount());
+        System.Assert.areEqual(0, mockSelector.getCachedUserQueryCount());
 
         LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
 
-        System.assertEquals(0, mockSelector.getCachedUserQueryCount());
-        System.assertEquals(null, logEntryEvent.LoggedByUsername__c);
-        System.assertEquals(null, logEntryEvent.ProfileName__c);
-        System.assertEquals(null, logEntryEvent.UserLicenseDefinitionKey__c);
-        System.assertEquals(null, logEntryEvent.UserLicenseId__c);
-        System.assertEquals(null, logEntryEvent.UserLicenseName__c);
-        System.assertEquals(null, logEntryEvent.UserRoleName__c);
+        System.Assert.areEqual(0, mockSelector.getCachedUserQueryCount());
+        System.Assert.isNull(logEntryEvent.LoggedByUsername__c);
+        System.Assert.isNull(logEntryEvent.ProfileName__c);
+        System.Assert.isNull(logEntryEvent.UserLicenseDefinitionKey__c);
+        System.Assert.isNull(logEntryEvent.UserLicenseId__c);
+        System.Assert.isNull(logEntryEvent.UserLicenseName__c);
+        System.Assert.isNull(logEntryEvent.UserRoleName__c);
     }
 
     @IsTest
     static void it_should_run_user_query_when_enabled_via_logger_parameter() {
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryUserDataSynchronously', Value__c = String.valueOf(true)));
-        System.assertEquals(true, LoggerParameter.QUERY_USER_DATA_SYNCHRONOUSLY);
+        System.Assert.isTrue(LoggerParameter.QUERY_USER_DATA_SYNCHRONOUSLY);
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
         LoggerEngineDataSelector.setMock(mockSelector);
-        System.assertEquals(0, mockSelector.getCachedUserQueryCount());
+        System.Assert.areEqual(0, mockSelector.getCachedUserQueryCount());
 
         LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
 
-        System.assertNotEquals(0, mockSelector.getCachedUserQueryCount());
+        System.Assert.areNotEqual(0, mockSelector.getCachedUserQueryCount());
         User cachedUser = LoggerEngineDataSelector.getInstance().getCachedUser();
-        System.assertEquals(cachedUser.Username, logEntryEvent.LoggedByUsername__c);
-        System.assertEquals(cachedUser.Profile.Name, logEntryEvent.ProfileName__c);
-        System.assertEquals(cachedUser.Profile.UserLicense.LicenseDefinitionKey, logEntryEvent.UserLicenseDefinitionKey__c);
-        System.assertEquals(cachedUser.Profile.UserLicenseId, logEntryEvent.UserLicenseId__c);
-        System.assertEquals(cachedUser.Profile.UserLicense.Name, logEntryEvent.UserLicenseName__c);
-        System.assertEquals(cachedUser.UserRole?.Name, logEntryEvent.UserRoleName__c);
+        System.Assert.areEqual(cachedUser.Username, logEntryEvent.LoggedByUsername__c);
+        System.Assert.areEqual(cachedUser.Profile.Name, logEntryEvent.ProfileName__c);
+        System.Assert.areEqual(cachedUser.Profile.UserLicense.LicenseDefinitionKey, logEntryEvent.UserLicenseDefinitionKey__c);
+        System.Assert.areEqual(cachedUser.Profile.UserLicenseId, logEntryEvent.UserLicenseId__c);
+        System.Assert.areEqual(cachedUser.Profile.UserLicense.Name, logEntryEvent.UserLicenseName__c);
+        System.Assert.areEqual(cachedUser.UserRole?.Name, logEntryEvent.UserRoleName__c);
     }
 
     @IsTest
@@ -228,7 +205,7 @@ private class LogEntryEventBuilder_Tests {
         for (Integer i = 0; i < 5; i++) {
             builder.getLogEntryEvent().Timestamp__c = builder.getLogEntryEvent().Timestamp__c.addSeconds(i);
 
-            System.assertEquals(
+            System.Assert.areEqual(
                 String.valueOf(builder.getLogEntryEvent().Timestamp__c.getTime()),
                 builder.getLogEntryEvent().TimestampString__c,
                 'Timestamp string was inaccurate when i ==' + i
@@ -239,61 +216,61 @@ private class LogEntryEventBuilder_Tests {
     @IsTest
     static void it_should_set_message_fields_for_logMessage() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(false, builder.getLogEntryEvent().MessageTruncated__c);
-        System.assertEquals(false, builder.getLogEntryEvent().MessageMasked__c);
-        System.assertEquals(null, builder.getLogEntryEvent().Message__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
+        System.Assert.isNull(builder.getLogEntryEvent().Message__c);
 
         LogMessage logMessage = new LogMessage('The time is {0}', System.now());
         builder.setMessage(logMessage);
 
-        System.assertEquals(false, builder.getLogEntryEvent().MessageTruncated__c);
-        System.assertEquals(false, builder.getLogEntryEvent().MessageMasked__c);
-        System.assertEquals(logMessage.getMessage(), builder.getLogEntryEvent().Message__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
+        System.Assert.areEqual(logMessage.getMessage(), builder.getLogEntryEvent().Message__c);
     }
 
     @IsTest
     static void it_should_set_message_fields_for_null_logMessage() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(false, builder.getLogEntryEvent().MessageTruncated__c);
-        System.assertEquals(false, builder.getLogEntryEvent().MessageMasked__c);
-        System.assertEquals(null, builder.getLogEntryEvent().Message__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
+        System.Assert.isNull(builder.getLogEntryEvent().Message__c);
 
         LogMessage logMessage = null;
         builder.setMessage(logMessage);
 
-        System.assertEquals(false, builder.getLogEntryEvent().MessageTruncated__c);
-        System.assertEquals(false, builder.getLogEntryEvent().MessageMasked__c);
-        System.assertEquals(null, builder.getLogEntryEvent().Message__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
+        System.Assert.isNull(builder.getLogEntryEvent().Message__c);
     }
 
     @IsTest
     static void it_should_set_message_fields_for_string() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(false, builder.getLogEntryEvent().MessageTruncated__c);
-        System.assertEquals(false, builder.getLogEntryEvent().MessageMasked__c);
-        System.assertEquals(null, builder.getLogEntryEvent().Message__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
+        System.Assert.isNull(builder.getLogEntryEvent().Message__c);
 
         String message = 'The time is ' + String.valueOf(System.now());
         builder.setMessage(message);
 
-        System.assertEquals(false, builder.getLogEntryEvent().MessageTruncated__c);
-        System.assertEquals(false, builder.getLogEntryEvent().MessageMasked__c);
-        System.assertEquals(message, builder.getLogEntryEvent().Message__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
+        System.Assert.areEqual(message, builder.getLogEntryEvent().Message__c);
     }
 
     @IsTest
     static void it_should_set_message_fields_for_null_string() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(false, builder.getLogEntryEvent().MessageTruncated__c);
-        System.assertEquals(false, builder.getLogEntryEvent().MessageMasked__c);
-        System.assertEquals(null, builder.getLogEntryEvent().Message__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
+        System.Assert.isNull(builder.getLogEntryEvent().Message__c);
 
         String message = null;
         builder.setMessage(message);
 
-        System.assertEquals(false, builder.getLogEntryEvent().MessageTruncated__c);
-        System.assertEquals(false, builder.getLogEntryEvent().MessageMasked__c);
-        System.assertEquals(message, builder.getLogEntryEvent().Message__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
+        System.Assert.areEqual(message, builder.getLogEntryEvent().Message__c);
     }
 
     @IsTest
@@ -309,10 +286,10 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setMessage(message).setRecord(account);
 
-        System.assertEquals(false, builder.getLogEntryEvent().MessageMasked__c, builder.getLogEntryEvent().Message__c);
-        System.assertEquals(message, builder.getLogEntryEvent().Message__c);
-        System.assertEquals(false, builder.getLogEntryEvent().RecordJsonMasked__c);
-        System.assertEquals(accountJson, builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c, builder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(message, builder.getLogEntryEvent().Message__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().RecordJsonMasked__c);
+        System.Assert.areEqual(accountJson, builder.getLogEntryEvent().RecordJson__c);
     }
 
     @IsTest
@@ -328,10 +305,10 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setMessage(message).setRecord(account);
 
-        System.assertEquals(false, builder.getLogEntryEvent().MessageMasked__c);
-        System.assertEquals(message, builder.getLogEntryEvent().Message__c);
-        System.assertEquals(false, builder.getLogEntryEvent().RecordJsonMasked__c);
-        System.assertEquals(accountJson, builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
+        System.Assert.areEqual(message, builder.getLogEntryEvent().Message__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().RecordJsonMasked__c);
+        System.Assert.areEqual(accountJson, builder.getLogEntryEvent().RecordJson__c);
     }
 
     @IsTest
@@ -346,9 +323,9 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setMessage(sensitiveString);
 
-        System.assertEquals(true, builder.getLogEntryEvent().MessageMasked__c);
-        System.assertNotEquals(sensitiveString, builder.getLogEntryEvent().Message__c);
-        System.assertEquals(expectedSanitizedString, builder.getLogEntryEvent().Message__c);
+        System.Assert.isTrue(builder.getLogEntryEvent().MessageMasked__c);
+        System.Assert.areNotEqual(sensitiveString, builder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(expectedSanitizedString, builder.getLogEntryEvent().Message__c);
     }
 
     @IsTest
@@ -366,9 +343,9 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setRecord(account);
 
-        System.assertEquals(true, builder.getLogEntryEvent().RecordJsonMasked__c);
-        System.assertNotEquals(accountJson, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(expectedSanitizedAccountJson, builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isTrue(builder.getLogEntryEvent().RecordJsonMasked__c);
+        System.Assert.areNotEqual(accountJson, builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(expectedSanitizedAccountJson, builder.getLogEntryEvent().RecordJson__c);
     }
 
     @IsTest
@@ -386,9 +363,9 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setRecord(accounts);
 
-        System.assertEquals(true, builder.getLogEntryEvent().RecordJsonMasked__c);
-        System.assertNotEquals(accountListJson, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(expectedSanitizedAccountListJson, builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isTrue(builder.getLogEntryEvent().RecordJsonMasked__c);
+        System.Assert.areNotEqual(accountListJson, builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(expectedSanitizedAccountListJson, builder.getLogEntryEvent().RecordJson__c);
     }
 
     @IsTest
@@ -405,9 +382,9 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setHttpRequestDetails(httpRequest);
 
-        System.assertEquals(true, builder.getLogEntryEvent().HttpRequestBodyMasked__c);
-        System.assertNotEquals(sensitiveString, builder.getLogEntryEvent().HttpRequestBody__c);
-        System.assertEquals(expectedSanitizedString, builder.getLogEntryEvent().HttpRequestBody__c);
+        System.Assert.isTrue(builder.getLogEntryEvent().HttpRequestBodyMasked__c);
+        System.Assert.areNotEqual(sensitiveString, builder.getLogEntryEvent().HttpRequestBody__c);
+        System.Assert.areEqual(expectedSanitizedString, builder.getLogEntryEvent().HttpRequestBody__c);
     }
 
     @IsTest
@@ -424,142 +401,142 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setHttpResponseDetails(httpResponse);
 
-        System.assertEquals(true, builder.getLogEntryEvent().HttpResponseBodyMasked__c);
-        System.assertNotEquals(sensitiveString, builder.getLogEntryEvent().HttpResponseBody__c);
-        System.assertEquals(expectedSanitizedString, builder.getLogEntryEvent().HttpResponseBody__c);
+        System.Assert.isTrue(builder.getLogEntryEvent().HttpResponseBodyMasked__c);
+        System.Assert.areNotEqual(sensitiveString, builder.getLogEntryEvent().HttpResponseBody__c);
+        System.Assert.areEqual(expectedSanitizedString, builder.getLogEntryEvent().HttpResponseBody__c);
     }
 
     @IsTest
     static void it_should_truncate_message_for_long_logMessage() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(false, builder.getLogEntryEvent().MessageTruncated__c);
-        System.assertEquals(false, builder.getLogEntryEvent().MessageMasked__c);
-        System.assertEquals(null, builder.getLogEntryEvent().Message__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
+        System.Assert.isNull(builder.getLogEntryEvent().Message__c);
 
         Integer maxMessageLength = Schema.LogEntry__c.Message__c.getDescribe().getLength();
         String baseMessage = 'z'.repeat(LogEntryEvent__e.Message__c.getDescribe().getLength() + 1);
         LogMessage logMessage = new LogMessage(baseMessage, 'something else');
         builder.setMessage(logMessage);
-        System.assert(logMessage.getMessage().length() > maxMessageLength, 'Test message length should exceed the field length');
+        System.Assert.isTrue(logMessage.getMessage().length() > maxMessageLength, 'Test message length should exceed the field length');
         builder.setMessage(logMessage);
 
-        System.assertEquals(true, builder.getLogEntryEvent().MessageTruncated__c, 'Message should have been truncated');
-        System.assertEquals(logMessage.getMessage().left(maxMessageLength), builder.getLogEntryEvent().Message__c);
+        System.Assert.isTrue(builder.getLogEntryEvent().MessageTruncated__c, 'Message should have been truncated');
+        System.Assert.areEqual(logMessage.getMessage().left(maxMessageLength), builder.getLogEntryEvent().Message__c);
     }
 
     @IsTest
     static void it_should_truncate_message_for_long_string() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(false, builder.getLogEntryEvent().MessageTruncated__c);
-        System.assertEquals(false, builder.getLogEntryEvent().MessageMasked__c);
-        System.assertEquals(null, builder.getLogEntryEvent().Message__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageTruncated__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
+        System.Assert.isNull(builder.getLogEntryEvent().Message__c);
 
         Integer maxMessageLength = Schema.LogEntry__c.Message__c.getDescribe().getLength();
         String message = 'z'.repeat(LogEntryEvent__e.Message__c.getDescribe().getLength() + 1);
-        System.assert(message.length() > maxMessageLength, 'Test message length should exceed the field length');
+        System.Assert.isTrue(message.length() > maxMessageLength, 'Test message length should exceed the field length');
         builder.setMessage(message);
 
-        System.assertEquals(true, builder.getLogEntryEvent().MessageTruncated__c, 'Message should have been truncated');
-        System.assertEquals(message.left(maxMessageLength), builder.getLogEntryEvent().Message__c);
+        System.Assert.isTrue(builder.getLogEntryEvent().MessageTruncated__c, 'Message should have been truncated');
+        System.Assert.areEqual(message.left(maxMessageLength), builder.getLogEntryEvent().Message__c);
     }
 
     @IsTest
     static void it_should_set_exception_fields_for_dmlException() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, builder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(builder.getLogEntryEvent().ExceptionType__c);
 
         DmlException dmlException = new DmlException('Test DML exception');
         builder.setExceptionDetails(dmlException);
 
-        System.assertEquals(dmlException.getMessage(), builder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(dmlException.getTypeName(), builder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.areEqual(dmlException.getMessage(), builder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(dmlException.getTypeName(), builder.getLogEntryEvent().ExceptionType__c);
     }
 
     @IsTest
     static void it_should_set_database_result_fields_for_deleteResult() {
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
-        System.assertNotEquals(null, deleteResult);
+        System.Assert.isNotNull(deleteResult);
 
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(deleteResult);
 
-        System.assertEquals(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), builder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), builder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
     }
 
     @IsTest
     static void it_should_set_database_result_fields_for_mergeResult() {
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
-        System.assertNotEquals(null, mergeResult);
+        System.Assert.isNotNull(mergeResult);
 
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(mergeResult);
 
-        System.assertEquals(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
-        System.assertEquals(JSON.serializePretty(mergeResult), builder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.MergeResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
+        System.Assert.areEqual(JSON.serializePretty(mergeResult), builder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.MergeResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
     }
 
     @IsTest
     static void it_should_set_database_result_fields_for_saveResult() {
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
-        System.assertNotEquals(null, saveResult);
+        System.Assert.isNotNull(saveResult);
 
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(saveResult);
 
-        System.assertEquals(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
-        System.assertEquals(JSON.serializePretty(saveResult), builder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), builder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
     }
 
     @IsTest
     static void it_should_set_database_result_fields_for_undeleteResult() {
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
-        System.assertNotEquals(null, undeleteResult);
+        System.Assert.isNotNull(undeleteResult);
 
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(undeleteResult);
 
-        System.assertEquals(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), builder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), builder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
     }
 
     @IsTest
     static void it_should_set_database_result_fields_for_upsertResult_when_insert() {
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
-        System.assertNotEquals(null, upsertResult);
-        System.assertEquals(true, upsertResult.isCreated());
+        System.Assert.isNotNull(upsertResult);
+        System.Assert.isTrue(upsertResult.isCreated());
 
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(upsertResult);
 
-        System.assertEquals(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), builder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', builder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), builder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', builder.getLogEntryEvent().DatabaseResultType__c);
     }
 
     @IsTest
     static void it_should_set_database_result_fields_for_upsertResult_when_update() {
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
-        System.assertNotEquals(null, upsertResult);
-        System.assertEquals(false, upsertResult.isCreated());
+        System.Assert.isNotNull(upsertResult);
+        System.Assert.isFalse(upsertResult.isCreated());
 
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(upsertResult);
 
-        System.assertEquals(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), builder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', builder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), builder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', builder.getLogEntryEvent().DatabaseResultType__c);
     }
 
     @IsTest
@@ -572,10 +549,10 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(deleteResults);
 
-        System.assertEquals(deleteResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
-        System.assertEquals('List', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
-        System.assertEquals(JSON.serializePretty(deleteResults), builder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.areEqual(deleteResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual('List', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResults), builder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
     }
 
     @IsTest
@@ -588,10 +565,10 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(mergeResults);
 
-        System.assertEquals(mergeResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
-        System.assertEquals('List', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
-        System.assertEquals(JSON.serializePretty(mergeResults), builder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.MergeResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.areEqual(mergeResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual('List', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
+        System.Assert.areEqual(JSON.serializePretty(mergeResults), builder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.MergeResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
     }
 
     @IsTest
@@ -604,10 +581,10 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(saveResults);
 
-        System.assertEquals(saveResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
-        System.assertEquals('List', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
-        System.assertEquals(JSON.serializePretty(saveResults), builder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.areEqual(saveResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual('List', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResults), builder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
     }
 
     @IsTest
@@ -620,10 +597,10 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(undeleteResults);
 
-        System.assertEquals(undeleteResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
-        System.assertEquals('List', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
-        System.assertEquals(JSON.serializePretty(undeleteResults), builder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.areEqual(undeleteResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual('List', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResults), builder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
     }
 
     @IsTest
@@ -636,31 +613,31 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
         builder.setDatabaseResult(upsertResults);
 
-        System.assertEquals(upsertResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
-        System.assertEquals('List', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
-        System.assertEquals(JSON.serializePretty(upsertResults), builder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.areEqual(upsertResults.size(), builder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual('List', builder.getLogEntryEvent().DatabaseResultCollectionType__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResults), builder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName(), builder.getLogEntryEvent().DatabaseResultType__c);
     }
 
     @IsTest
     static void it_should_set_record_fields_for_recordId_when_standard_object() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         Id currentUserId = UserInfo.getUserId();
         builder.setRecordId(currentUserId);
 
-        System.assertEquals(1, builder.getLogEntryEvent().RecordCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().RecordCollectionType__c);
-        System.assertEquals(currentUserId, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals('Standard Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals('User', builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().RecordCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().RecordCollectionType__c);
+        System.Assert.areEqual(currentUserId, builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual('Standard Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.areEqual('User', builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
     }
 
     @IsTest
@@ -687,145 +664,145 @@ private class LogEntryEventBuilder_Tests {
     @IsTest
     static void it_should_set_record_fields_for_recordId_when_custom_object() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         Id mockLogId = LoggerMockDataCreator.createId(Schema.Log__c.SObjectType);
         builder.setRecordId(mockLogId);
 
-        System.assertEquals(1, builder.getLogEntryEvent().RecordCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().RecordCollectionType__c);
-        System.assertEquals(mockLogId, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals('Custom Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(Log__c.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().RecordCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().RecordCollectionType__c);
+        System.Assert.areEqual(mockLogId, builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual('Custom Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.areEqual(Log__c.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
     }
 
     @IsTest
     static void it_should_set_record_fields_for_recordId_when_custom_metadata_type() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         LogStatus__mdt status = [SELECT Id, MasterLabel, DeveloperName FROM LogStatus__mdt LIMIT 1];
         builder.setRecordId(status.Id);
 
-        System.assertEquals(1, builder.getLogEntryEvent().RecordCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().RecordCollectionType__c);
-        System.assertEquals(status.Id, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals('Custom Metadata Type Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(LogStatus__mdt.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().RecordCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().RecordCollectionType__c);
+        System.Assert.areEqual(status.Id, builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual('Custom Metadata Type Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.areEqual(LogStatus__mdt.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
     }
 
     @IsTest
     static void it_should_set_record_fields_for_record_when_null() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         User nullUser;
-        System.assertEquals(null, nullUser);
+        System.Assert.isNull(nullUser);
         builder.setRecordId(nullUser);
 
-        System.assertEquals(1, builder.getLogEntryEvent().RecordCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().RecordCollectionType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals('null', builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals('Unknown', builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals('Unknown', builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().RecordCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().RecordCollectionType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual('null', builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual('Unknown', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.areEqual('Unknown', builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
     }
 
     @IsTest
     static void it_should_set_record_fields_for_record_when_standard_object() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         User currentUser = [SELECT Id, Name, ProfileId, Profile.Name, IsActive FROM User WHERE Id = :UserInfo.getUserId()];
         builder.setRecordId(currentUser);
 
-        System.assertEquals(1, builder.getLogEntryEvent().RecordCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().RecordCollectionType__c);
-        System.assertEquals(currentUser.Id, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(currentUser), builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals('Standard Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals('User', builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().RecordCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().RecordCollectionType__c);
+        System.Assert.areEqual(currentUser.Id, builder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(currentUser), builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual('Standard Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.areEqual('User', builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
     }
 
     @IsTest
     static void it_should_set_record_fields_for_record_when_custom_object() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         Log__c log = (Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord();
         builder.setRecordId(log);
 
-        System.assertEquals(1, builder.getLogEntryEvent().RecordCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().RecordCollectionType__c);
-        System.assertEquals(log.Id, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(log), builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals('Custom Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(Log__c.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().RecordCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().RecordCollectionType__c);
+        System.Assert.areEqual(log.Id, builder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(log), builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual('Custom Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.areEqual(Log__c.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
     }
 
     @IsTest
     static void it_should_set_record_fields_for_record_when_custom_metadata_type() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         LogStatus__mdt status = [SELECT Id, MasterLabel, DeveloperName FROM LogStatus__mdt LIMIT 1];
         builder.setRecordId(status);
 
-        System.assertEquals(1, builder.getLogEntryEvent().RecordCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().RecordCollectionType__c);
-        System.assertEquals(status.Id, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(status), builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals('Custom Metadata Type Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(LogStatus__mdt.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().RecordCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().RecordCollectionType__c);
+        System.Assert.areEqual(status.Id, builder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(status), builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual('Custom Metadata Type Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.areEqual(LogStatus__mdt.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
     }
 
     @IsTest
     static void it_should_set_record_fields_for_record_when_platform_event() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         // To avoid creating a new platform event just for testing purposes, Nebula Logger's LogEntryEvent__e is reused
         LogEntryEvent__e platformEvent = new LogEntryEvent__e();
         builder.setRecordId(platformEvent);
 
-        System.assertEquals(1, builder.getLogEntryEvent().RecordCollectionSize__c);
-        System.assertEquals('Single', builder.getLogEntryEvent().RecordCollectionType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(platformEvent), builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals('Platform Event Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(LogEntryEvent__e.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.areEqual(1, builder.getLogEntryEvent().RecordCollectionSize__c);
+        System.Assert.areEqual('Single', builder.getLogEntryEvent().RecordCollectionType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(platformEvent), builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual('Platform Event Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.areEqual(LogEntryEvent__e.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
     }
 
     @IsTest
@@ -839,7 +816,7 @@ private class LogEntryEventBuilder_Tests {
             builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAggregateResult);
         }
 
-        System.assertEquals(JSON.serializePretty(mockAggregateResult), builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(mockAggregateResult), builder.getLogEntryEvent().RecordJson__c);
     }
 
     @IsTest
@@ -853,57 +830,57 @@ private class LogEntryEventBuilder_Tests {
             builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAggregateResults);
         }
 
-        System.assertEquals(JSON.serializePretty(mockAggregateResults), builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(mockAggregateResults), builder.getLogEntryEvent().RecordJson__c);
     }
 
     @IsTest
     static void it_should_set_record_fields_for_list_of_records_when_list_is_null() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         List<SObject> users;
-        System.assertEquals(null, users);
+        System.Assert.isNull(users);
         builder.setRecord(users);
 
-        System.assertEquals('List', builder.getLogEntryEvent().RecordCollectionType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals('null', builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals('Unknown', builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals('Unknown', builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.areEqual('List', builder.getLogEntryEvent().RecordCollectionType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual('null', builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual('Unknown', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.areEqual('Unknown', builder.getLogEntryEvent().RecordSObjectType__c);
     }
 
     @IsTest
     static void it_should_set_record_fields_for_list_of_records_when_list_is_empty() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         List<SObject> users = new List<SObject>();
-        System.assertEquals(true, users.isEmpty());
+        System.Assert.isTrue(users.isEmpty());
         builder.setRecord(users);
 
-        System.assertEquals('List', builder.getLogEntryEvent().RecordCollectionType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals('Unknown', builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals('Unknown', builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.areEqual('List', builder.getLogEntryEvent().RecordCollectionType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual('Unknown', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.areEqual('Unknown', builder.getLogEntryEvent().RecordSObjectType__c);
     }
 
     @IsTest
     static void it_should_set_record_fields_for_list_of_records_when_first_record_is_null() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         List<SObject> users = new List<SObject>();
         User nullUser;
@@ -911,55 +888,55 @@ private class LogEntryEventBuilder_Tests {
         users.add(new User(Id = UserInfo.getUserId()));
         builder.setRecord(users);
 
-        System.assertEquals('List', builder.getLogEntryEvent().RecordCollectionType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals('Unknown', builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals('Unknown', builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.areEqual('List', builder.getLogEntryEvent().RecordCollectionType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual('Unknown', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.areEqual('Unknown', builder.getLogEntryEvent().RecordSObjectType__c);
     }
 
     @IsTest
     static void it_should_set_record_fields_for_list_of_records_when_populated() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordSObjectTypeNamespace__c);
 
         List<User> users = [SELECT Id, Name, Username, IsActive FROM User LIMIT 5];
         builder.setRecord(users);
 
-        System.assertEquals('List', builder.getLogEntryEvent().RecordCollectionType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), builder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals('Standard Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
-        System.assertEquals(User.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
+        System.Assert.areEqual('List', builder.getLogEntryEvent().RecordCollectionType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), builder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual('Standard Object', builder.getLogEntryEvent().RecordSObjectClassification__c);
+        System.Assert.areEqual(User.SObjectType.getDescribe().getName(), builder.getLogEntryEvent().RecordSObjectType__c);
     }
 
     @IsTest
     static void it_should_skip_setting_http_request_fields_when_request_is_null() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestBody__c);
-        System.assertEquals(false, builder.getLogEntryEvent().HttpRequestCompressed__c);
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestEndpoint__c);
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestMethod__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().HttpRequestCompressed__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
         HttpRequest request = null;
 
         builder.setHttpRequestDetails(request);
 
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestBody__c);
-        System.assertEquals(false, builder.getLogEntryEvent().HttpRequestCompressed__c);
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestEndpoint__c);
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestMethod__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
+        System.Assert.isFalse(builder.getLogEntryEvent().HttpRequestCompressed__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
     }
 
     @IsTest
     static void it_should_set_http_request_fields_when_request_is_populated() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestBody__c);
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestEndpoint__c);
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestMethod__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
         HttpRequest request = new HttpRequest();
         request.setBody('Hello, world!');
         request.setCompressed(true);
@@ -968,34 +945,34 @@ private class LogEntryEventBuilder_Tests {
 
         builder.setHttpRequestDetails(request);
 
-        System.assertEquals(request.getBody(), builder.getLogEntryEvent().HttpRequestBody__c);
-        System.assertEquals(request.getCompressed(), builder.getLogEntryEvent().HttpRequestCompressed__c);
-        System.assertEquals(request.getEndpoint(), builder.getLogEntryEvent().HttpRequestEndpoint__c);
-        System.assertEquals(request.getMethod(), builder.getLogEntryEvent().HttpRequestMethod__c);
+        System.Assert.areEqual(request.getBody(), builder.getLogEntryEvent().HttpRequestBody__c);
+        System.Assert.areEqual(request.getCompressed(), builder.getLogEntryEvent().HttpRequestCompressed__c);
+        System.Assert.areEqual(request.getEndpoint(), builder.getLogEntryEvent().HttpRequestEndpoint__c);
+        System.Assert.areEqual(request.getMethod(), builder.getLogEntryEvent().HttpRequestMethod__c);
     }
 
     @IsTest
     static void it_should_skip_setting_http_response_fields_when_response_is_null() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestBody__c);
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestEndpoint__c);
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestMethod__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
         HttpResponse response = null;
 
         builder.setHttpResponseDetails(response);
 
-        System.assertEquals(null, builder.getLogEntryEvent().HttpResponseBody__c);
-        System.assertEquals(null, builder.getLogEntryEvent().HttpResponseHeaderKeys__c);
-        System.assertEquals(null, builder.getLogEntryEvent().HttpResponseStatus__c);
-        System.assertEquals(null, builder.getLogEntryEvent().HttpResponseStatusCode__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpResponseBody__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpResponseHeaderKeys__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpResponseStatus__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpResponseStatusCode__c);
     }
 
     @IsTest
     static void it_should_set_http_response_fields_when_populated() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestBody__c);
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestEndpoint__c);
-        System.assertEquals(null, builder.getLogEntryEvent().HttpRequestMethod__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
         HttpResponse response = new HttpResponse();
         response.setBody('Hello, world!');
         response.setHeader('someKey', 'some string value');
@@ -1005,35 +982,35 @@ private class LogEntryEventBuilder_Tests {
 
         builder.setHttpResponseDetails(response);
 
-        System.assertEquals(response.getBody(), builder.getLogEntryEvent().HttpResponseBody__c);
-        System.assertEquals(String.join(response.getHeaderKeys(), '\n'), builder.getLogEntryEvent().HttpResponseHeaderKeys__c);
-        System.assertEquals(response.getStatus(), builder.getLogEntryEvent().HttpResponseStatus__c);
-        System.assertEquals(response.getStatusCode(), builder.getLogEntryEvent().HttpResponseStatusCode__c);
+        System.Assert.areEqual(response.getBody(), builder.getLogEntryEvent().HttpResponseBody__c);
+        System.Assert.areEqual(String.join(response.getHeaderKeys(), '\n'), builder.getLogEntryEvent().HttpResponseHeaderKeys__c);
+        System.Assert.areEqual(response.getStatus(), builder.getLogEntryEvent().HttpResponseStatus__c);
+        System.Assert.areEqual(response.getStatusCode(), builder.getLogEntryEvent().HttpResponseStatusCode__c);
     }
 
     @IsTest
     static void it_should_set_tags_string_for_list_of_tags() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().Tags__c);
+        System.Assert.isNull(builder.getLogEntryEvent().Tags__c);
 
         List<String> tags = new List<String>{ 'some-tag', 'another One', 'here\'s one more!' };
         builder.addTags(tags);
 
         tags.sort();
         String expectedTagsString = String.escapeSingleQuotes(String.join(tags, '\n'));
-        System.assertEquals(expectedTagsString, builder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(expectedTagsString, builder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_deduplicate_and_sort_tags() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(null, builder.getLogEntryEvent().Tags__c);
+        System.Assert.isNull(builder.getLogEntryEvent().Tags__c);
 
         List<String> tags = new List<String>{ 'duplicate-tag', 'duplicate-tag', 'another One' };
         builder.addTags(tags);
 
         String expectedTagsString = 'another One\nduplicate-tag';
-        System.assertEquals(expectedTagsString, builder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(expectedTagsString, builder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
@@ -1046,12 +1023,12 @@ private class LogEntryEventBuilder_Tests {
 
         LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'EnableStackTraceParsing', Value__c = String.valueOf(false));
         LoggerParameter.setMock(mockParameter);
-        System.assertEquals(false, LoggerParameter.ENABLE_STACK_TRACE_PARSING);
+        System.Assert.isFalse(LoggerParameter.ENABLE_STACK_TRACE_PARSING);
 
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
 
-        System.assertEquals(null, builder.getLogEntryEvent().OriginLocation__c);
-        System.assertEquals(null, builder.getLogEntryEvent().StackTrace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.isNull(builder.getLogEntryEvent().StackTrace__c);
     }
 
     @IsTest
@@ -1064,13 +1041,13 @@ private class LogEntryEventBuilder_Tests {
 
         LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'EnableStackTraceParsing', Value__c = String.valueOf(false));
         LoggerParameter.setMock(mockParameter);
-        System.assertEquals(false, LoggerParameter.ENABLE_STACK_TRACE_PARSING);
+        System.Assert.isFalse(LoggerParameter.ENABLE_STACK_TRACE_PARSING);
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
 
         builder.parseStackTrace('AnonymousBlock: line 1, column 1');
 
-        System.assertEquals(null, builder.getLogEntryEvent().OriginLocation__c);
-        System.assertEquals(null, builder.getLogEntryEvent().StackTrace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.isNull(builder.getLogEntryEvent().StackTrace__c);
     }
 
     @IsTest
@@ -1091,10 +1068,10 @@ private class LogEntryEventBuilder_Tests {
 
         builder.parseStackTrace(constructedClass.getStackTraceString());
 
-        System.assertNotEquals(null, builder.getLogEntryEvent().OriginLocation__c);
-        System.assertEquals(expectedOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
-        System.assertNotEquals(null, builder.getLogEntryEvent().StackTrace__c);
-        System.assertEquals(expectedStackTrace, builder.getLogEntryEvent().StackTrace__c);
+        System.Assert.isNotNull(builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.areEqual(expectedOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.isNotNull(builder.getLogEntryEvent().StackTrace__c);
+        System.Assert.areEqual(expectedStackTrace, builder.getLogEntryEvent().StackTrace__c);
     }
 
     @IsTest
@@ -1115,10 +1092,10 @@ private class LogEntryEventBuilder_Tests {
 
         builder.parseStackTrace(stackTraceHandler.getStackTraceString());
 
-        System.assertNotEquals(null, builder.getLogEntryEvent().OriginLocation__c);
-        System.assertEquals(expectedOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
-        System.assertNotEquals(null, builder.getLogEntryEvent().StackTrace__c);
-        System.assertEquals(expectedStackTrace, builder.getLogEntryEvent().StackTrace__c);
+        System.Assert.isNotNull(builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.areEqual(expectedOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.isNotNull(builder.getLogEntryEvent().StackTrace__c);
+        System.Assert.areEqual(expectedStackTrace, builder.getLogEntryEvent().StackTrace__c);
     }
 
     @IsTest
@@ -1141,10 +1118,10 @@ private class LogEntryEventBuilder_Tests {
         );
         builder.parseStackTrace(mockStackTrace);
 
-        System.assertNotEquals(null, builder.getLogEntryEvent().OriginLocation__c);
-        System.assertEquals(expectedOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
-        System.assertNotEquals(null, builder.getLogEntryEvent().StackTrace__c);
-        System.assertEquals(expectedStackTrace, builder.getLogEntryEvent().StackTrace__c);
+        System.Assert.isNotNull(builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.areEqual(expectedOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.isNotNull(builder.getLogEntryEvent().StackTrace__c);
+        System.Assert.areEqual(expectedStackTrace, builder.getLogEntryEvent().StackTrace__c);
     }
 
     @IsTest
@@ -1160,10 +1137,10 @@ private class LogEntryEventBuilder_Tests {
         );
         builder.parseStackTrace(anonymousApexStackTraceString);
 
-        System.assertNotEquals(null, builder.getLogEntryEvent().OriginLocation__c);
-        System.assertEquals(anonymousApexOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
-        System.assertNotEquals(null, builder.getLogEntryEvent().StackTrace__c);
-        System.assertEquals(anonymousApexStackTraceString, builder.getLogEntryEvent().StackTrace__c);
+        System.Assert.isNotNull(builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.areEqual(anonymousApexOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.isNotNull(builder.getLogEntryEvent().StackTrace__c);
+        System.Assert.areEqual(anonymousApexStackTraceString, builder.getLogEntryEvent().StackTrace__c);
     }
 
     @IsTest
@@ -1177,10 +1154,10 @@ private class LogEntryEventBuilder_Tests {
         builder.getLogEntryEvent().StackTrace__c = null;
         builder.parseStackTrace(duplicatedStackTraceString);
 
-        System.assertNotEquals(null, builder.getLogEntryEvent().OriginLocation__c);
-        System.assertEquals(anonymousApexOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
-        System.assertNotEquals(null, builder.getLogEntryEvent().StackTrace__c);
-        System.assertEquals(deduplicatedStackTraceString, builder.getLogEntryEvent().StackTrace__c);
+        System.Assert.isNotNull(builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.areEqual(anonymousApexOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.isNotNull(builder.getLogEntryEvent().StackTrace__c);
+        System.Assert.areEqual(deduplicatedStackTraceString, builder.getLogEntryEvent().StackTrace__c);
     }
 
     @IsTest
@@ -1193,20 +1170,20 @@ private class LogEntryEventBuilder_Tests {
         builder.getLogEntryEvent().StackTrace__c = null;
         builder.parseStackTrace(invalidStackTrace);
 
-        System.assertEquals(null, builder.getLogEntryEvent().OriginLocation__c);
-        System.assertEquals(null, builder.getLogEntryEvent().StackTrace__c);
+        System.Assert.isNull(builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.isNull(builder.getLogEntryEvent().StackTrace__c);
     }
 
     @IsTest
     static void it_should_return_value_of_shouldSave_when_true() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
-        System.assertEquals(true, builder.shouldSave());
+        System.Assert.isTrue(builder.shouldSave());
     }
 
     @IsTest
     static void it_should_return_value_of_shouldSave_when_false() {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, false, new Set<String>());
-        System.assertEquals(false, builder.shouldSave());
+        System.Assert.isFalse(builder.shouldSave());
     }
 
     @IsTest
@@ -1220,23 +1197,23 @@ private class LogEntryEventBuilder_Tests {
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>());
 
         // Verify organization fields
-        System.assertEquals(Url.getOrgDomainUrl().toExternalForm(), builder.getLogEntryEvent().OrganizationDomainUrl__c);
+        System.Assert.areEqual(Url.getOrgDomainUrl().toExternalForm(), builder.getLogEntryEvent().OrganizationDomainUrl__c);
         // TODO switch to using mock instances of Organization & re-enable these asserts
-        System.assertEquals(organizationEnvironmentType, builder.getLogEntryEvent().OrganizationEnvironmentType__c);
-        System.assertEquals(organization.Id, builder.getLogEntryEvent().OrganizationId__c);
-        System.assertEquals(organization.InstanceName, builder.getLogEntryEvent().OrganizationInstanceName__c);
-        System.assertEquals(organization.Name, builder.getLogEntryEvent().OrganizationName__c);
-        System.assertEquals(organization.NamespacePrefix, builder.getLogEntryEvent().OrganizationNamespacePrefix__c);
-        System.assertEquals(organization.OrganizationType, builder.getLogEntryEvent().OrganizationType__c);
+        System.Assert.areEqual(organizationEnvironmentType, builder.getLogEntryEvent().OrganizationEnvironmentType__c);
+        System.Assert.areEqual(organization.Id, builder.getLogEntryEvent().OrganizationId__c);
+        System.Assert.areEqual(organization.InstanceName, builder.getLogEntryEvent().OrganizationInstanceName__c);
+        System.Assert.areEqual(organization.Name, builder.getLogEntryEvent().OrganizationName__c);
+        System.Assert.areEqual(organization.NamespacePrefix, builder.getLogEntryEvent().OrganizationNamespacePrefix__c);
+        System.Assert.areEqual(organization.OrganizationType, builder.getLogEntryEvent().OrganizationType__c);
 
         // Verify user fields
-        System.assertEquals(user.Id, builder.getLogEntryEvent().LoggedById__c);
-        System.assertEquals(user.Username, builder.getLogEntryEvent().LoggedByUsername__c);
-        System.assertEquals(user.Profile.Name, builder.getLogEntryEvent().ProfileName__c);
-        System.assertEquals(user.Profile.UserLicense.LicenseDefinitionKey, builder.getLogEntryEvent().UserLicenseDefinitionKey__c);
-        System.assertEquals(user.Profile.UserLicenseId, builder.getLogEntryEvent().UserLicenseId__c);
-        System.assertEquals(user.Profile.UserLicense.Name, builder.getLogEntryEvent().UserLicenseName__c);
-        System.assertEquals(user.UserRole?.Name, builder.getLogEntryEvent().UserRoleName__c);
+        System.Assert.areEqual(user.Id, builder.getLogEntryEvent().LoggedById__c);
+        System.Assert.areEqual(user.Username, builder.getLogEntryEvent().LoggedByUsername__c);
+        System.Assert.areEqual(user.Profile.Name, builder.getLogEntryEvent().ProfileName__c);
+        System.Assert.areEqual(user.Profile.UserLicense.LicenseDefinitionKey, builder.getLogEntryEvent().UserLicenseDefinitionKey__c);
+        System.Assert.areEqual(user.Profile.UserLicenseId, builder.getLogEntryEvent().UserLicenseId__c);
+        System.Assert.areEqual(user.Profile.UserLicense.Name, builder.getLogEntryEvent().UserLicenseName__c);
+        System.Assert.areEqual(user.UserRole?.Name, builder.getLogEntryEvent().UserRoleName__c);
     }
 
     @IsTest
@@ -1245,30 +1222,30 @@ private class LogEntryEventBuilder_Tests {
 
         LogEntryEventBuilder builder = Logger.debug('test log entry');
 
-        System.assertEquals(null, builder.getLogEntryEvent().Locale__c);
-        System.assertEquals(null, builder.getLogEntryEvent().LoggedById__c);
-        System.assertEquals(null, builder.getLogEntryEvent().LoggedByUsername__c);
-        System.assertEquals(null, builder.getLogEntryEvent().LoginApplication__c);
-        System.assertEquals(null, builder.getLogEntryEvent().LoginBrowser__c);
-        System.assertEquals(null, builder.getLogEntryEvent().LoginHistoryId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().LoginPlatform__c);
-        System.assertEquals(null, builder.getLogEntryEvent().LoginType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().LogoutUrl__c);
-        System.assertEquals(null, builder.getLogEntryEvent().ProfileId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().ProfileName__c);
-        System.assertEquals(null, builder.getLogEntryEvent().SessionId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().SessionSecurityLevel__c);
-        System.assertEquals(null, builder.getLogEntryEvent().SessionType__c);
-        System.assertEquals(null, builder.getLogEntryEvent().SourceIp__c);
-        System.assertEquals(null, builder.getLogEntryEvent().ThemeDisplayed__c);
-        System.assertEquals(null, builder.getLogEntryEvent().TimeZoneId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().TimeZoneName__c);
-        System.assertEquals(null, builder.getLogEntryEvent().UserLicenseDefinitionKey__c);
-        System.assertEquals(null, builder.getLogEntryEvent().UserLicenseId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().UserLicenseName__c);
-        System.assertEquals(null, builder.getLogEntryEvent().UserRoleId__c);
-        System.assertEquals(null, builder.getLogEntryEvent().UserRoleName__c);
-        System.assertEquals(null, builder.getLogEntryEvent().UserType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().Locale__c);
+        System.Assert.isNull(builder.getLogEntryEvent().LoggedById__c);
+        System.Assert.isNull(builder.getLogEntryEvent().LoggedByUsername__c);
+        System.Assert.isNull(builder.getLogEntryEvent().LoginApplication__c);
+        System.Assert.isNull(builder.getLogEntryEvent().LoginBrowser__c);
+        System.Assert.isNull(builder.getLogEntryEvent().LoginHistoryId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().LoginPlatform__c);
+        System.Assert.isNull(builder.getLogEntryEvent().LoginType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().LogoutUrl__c);
+        System.Assert.isNull(builder.getLogEntryEvent().ProfileId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().ProfileName__c);
+        System.Assert.isNull(builder.getLogEntryEvent().SessionId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().SessionSecurityLevel__c);
+        System.Assert.isNull(builder.getLogEntryEvent().SessionType__c);
+        System.Assert.isNull(builder.getLogEntryEvent().SourceIp__c);
+        System.Assert.isNull(builder.getLogEntryEvent().ThemeDisplayed__c);
+        System.Assert.isNull(builder.getLogEntryEvent().TimeZoneId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().TimeZoneName__c);
+        System.Assert.isNull(builder.getLogEntryEvent().UserLicenseDefinitionKey__c);
+        System.Assert.isNull(builder.getLogEntryEvent().UserLicenseId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().UserLicenseName__c);
+        System.Assert.isNull(builder.getLogEntryEvent().UserRoleId__c);
+        System.Assert.isNull(builder.getLogEntryEvent().UserRoleName__c);
+        System.Assert.isNull(builder.getLogEntryEvent().UserType__c);
     }
 
     @IsTest
@@ -1286,7 +1263,7 @@ private class LogEntryEventBuilder_Tests {
         DebugStringExample example = new DebugStringExample();
         LogEntryEventBuilder builder = example.myMethod();
 
-        System.assertEquals(
+        System.Assert.areEqual(
             DebugStringExample.class.getName() +
             '.myMethod' +
             '\n' +

--- a/nebula-logger/core/tests/logger-engine/classes/LogMessage_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogMessage_Tests.cls
@@ -17,7 +17,7 @@ private class LogMessage_Tests {
 
         String returnedMessage = new CustomLogMessageWithoutImplementation().getMessage();
 
-        System.assertEquals(expectedMessage, returnedMessage);
+        System.Assert.areEqual(expectedMessage, returnedMessage);
     }
 
     @IsTest
@@ -27,7 +27,7 @@ private class LogMessage_Tests {
 
         String returnedMessage = new CustomLogMessageWithMessageOverride(originalMessage).getMessage();
 
-        System.assertEquals(expectedMessage, returnedMessage);
+        System.Assert.areEqual(expectedMessage, returnedMessage);
     }
 
     @IsTest
@@ -38,7 +38,7 @@ private class LogMessage_Tests {
 
         String returnedMessage = new LogMessage(unformattedMessage, arguments).getMessage();
 
-        System.assertEquals(expectedMessage, returnedMessage);
+        System.Assert.areEqual(expectedMessage, returnedMessage);
     }
 
     @IsTest
@@ -49,7 +49,7 @@ private class LogMessage_Tests {
 
         String returnedMessage = new LogMessage(unformattedMessage, argument1).getMessage();
 
-        System.assertEquals(expectedMessage, returnedMessage);
+        System.Assert.areEqual(expectedMessage, returnedMessage);
     }
 
     @IsTest
@@ -61,7 +61,7 @@ private class LogMessage_Tests {
 
         String returnedMessage = new LogMessage(unformattedMessage, argument1, argument2).getMessage();
 
-        System.assertEquals(expectedMessage, returnedMessage);
+        System.Assert.areEqual(expectedMessage, returnedMessage);
     }
 
     @IsTest
@@ -74,7 +74,7 @@ private class LogMessage_Tests {
 
         String returnedMessage = new LogMessage(unformattedMessage, argument1, argument2, argument3).getMessage();
 
-        System.assertEquals(expectedMessage, returnedMessage);
+        System.Assert.areEqual(expectedMessage, returnedMessage);
     }
 
     private class CustomLogMessageWithoutImplementation extends LogMessage {

--- a/nebula-logger/core/tests/logger-engine/classes/LogMessage_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogMessage_Tests.cls
@@ -69,7 +69,7 @@ private class LogMessage_Tests {
         String unformattedMessage = 'my string with 1 input: {0} and then {1} and finally {2}';
         Datetime argument1 = System.now();
         Date argument2 = System.today();
-        User argument3 = new User(Id = UserInfo.getUserId());
+        User argument3 = new User(Id = System.UserInfo.getUserId());
         String expectedMessage = String.format(unformattedMessage, new List<Object>{ argument1, argument2, argument3 });
 
         String returnedMessage = new LogMessage(unformattedMessage, argument1, argument2, argument3).getMessage();

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerDataStore_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerDataStore_Tests.cls
@@ -14,16 +14,16 @@ private class LoggerDataStore_Tests {
     static void it_should_delete_record() {
         Log__c log = (Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord();
         insert log;
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(1, System.Limits.getDmlRows());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(1, System.Limits.getDmlRows());
 
         Database.DeleteResult result = LoggerDataStore.getDatabase().deleteRecord(log);
 
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(2, System.Limits.getDmlRows());
-        System.assertEquals(true, result.isSuccess());
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(2, System.Limits.getDmlRows());
+        System.Assert.isTrue(result.isSuccess());
         Log__c persistedLog = [SELECT Id, IsDeleted FROM Log__c WHERE Id = :log.Id ALL ROWS];
-        System.assertEquals(true, persistedLog.IsDeleted);
+        System.Assert.isTrue(persistedLog.IsDeleted);
     }
 
     @IsTest
@@ -32,21 +32,21 @@ private class LoggerDataStore_Tests {
         logsToDelete.add((Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord());
         logsToDelete.add((Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord());
         insert logsToDelete;
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(2, System.Limits.getDmlRows());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(2, System.Limits.getDmlRows());
 
         List<Database.DeleteResult> results = LoggerDataStore.getDatabase().deleteRecords(logsToDelete);
 
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(4, System.Limits.getDmlRows());
-        System.assertEquals(logsToDelete.size(), results.size());
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(4, System.Limits.getDmlRows());
+        System.Assert.areEqual(logsToDelete.size(), results.size());
         for (Database.DeleteResult result : results) {
-            System.assertEquals(true, result.isSuccess());
+            System.Assert.isTrue(result.isSuccess());
         }
         List<Log__c> persistedLogs = [SELECT Id, IsDeleted FROM Log__c WHERE Id IN :logsToDelete ALL ROWS];
-        System.assertEquals(logsToDelete.size(), persistedLogs.size());
+        System.Assert.areEqual(logsToDelete.size(), persistedLogs.size());
         for (Log__c persistedLog : persistedLogs) {
-            System.assertEquals(true, persistedLog.IsDeleted);
+            System.Assert.isTrue(persistedLog.IsDeleted);
         }
     }
 
@@ -58,20 +58,20 @@ private class LoggerDataStore_Tests {
         insert logsToDelete;
         // Delete one of the logs first to cause a failure in the delete DML statement
         delete logsToDelete.get(0);
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(3, System.Limits.getDmlRows());
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(3, System.Limits.getDmlRows());
 
         List<Database.DeleteResult> results = LoggerDataStore.getDatabase().deleteRecords(logsToDelete, false);
 
-        System.assertEquals(3, System.Limits.getDmlStatements());
-        System.assertEquals(5, System.Limits.getDmlRows());
-        System.assertEquals(logsToDelete.size(), results.size());
-        System.assertEquals(false, results.get(0).isSuccess());
-        System.assertEquals(true, results.get(1).isSuccess());
+        System.Assert.areEqual(3, System.Limits.getDmlStatements());
+        System.Assert.areEqual(5, System.Limits.getDmlRows());
+        System.Assert.areEqual(logsToDelete.size(), results.size());
+        System.Assert.isFalse(results.get(0).isSuccess());
+        System.Assert.isTrue(results.get(1).isSuccess());
         List<Log__c> persistedLogs = [SELECT Id, IsDeleted FROM Log__c WHERE Id IN :logsToDelete ALL ROWS];
-        System.assertEquals(logsToDelete.size(), persistedLogs.size());
+        System.Assert.areEqual(logsToDelete.size(), persistedLogs.size());
         for (Log__c persistedLog : persistedLogs) {
-            System.assertEquals(true, persistedLog.IsDeleted);
+            System.Assert.isTrue(persistedLog.IsDeleted);
         }
     }
 
@@ -80,19 +80,19 @@ private class LoggerDataStore_Tests {
         Log__c log = (Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord();
         log.TransactionId__c = '999';
         insert log;
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(1, System.Limits.getDmlRows());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(1, System.Limits.getDmlRows());
 
         Database.DeleteResult result = LoggerDataStore.getDatabase().hardDeleteRecord(log);
 
-        System.assertEquals(3, System.Limits.getDmlStatements());
-        System.assertEquals(3, System.Limits.getDmlRows());
-        System.assertEquals(true, result.isSuccess());
+        System.Assert.areEqual(3, System.Limits.getDmlStatements());
+        System.Assert.areEqual(3, System.Limits.getDmlRows());
+        System.Assert.isTrue(result.isSuccess());
         // Frustratingly, there's not a way to ensure that Database.emptyRecycleBin() was called and
         // the supposedly-hard-deleted records are still returned in SOQL, so at least verify that the
         // record has IsDeleted = true for now. This can probably be tested better with a @TestVisible property later.
         Log__c persistedLog = [SELECT Id, IsDeleted FROM Log__c WHERE Id = :log.Id ALL ROWS];
-        System.assertEquals(true, persistedLog.IsDeleted);
+        System.Assert.isTrue(persistedLog.IsDeleted);
     }
 
     @IsTest
@@ -101,24 +101,24 @@ private class LoggerDataStore_Tests {
         logsToDelete.add((Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord());
         logsToDelete.add((Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord());
         insert logsToDelete;
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(2, System.Limits.getDmlRows());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(2, System.Limits.getDmlRows());
 
         List<Database.DeleteResult> results = LoggerDataStore.getDatabase().hardDeleteRecords(logsToDelete);
 
-        System.assertEquals(3, System.Limits.getDmlStatements());
-        System.assertEquals(6, System.Limits.getDmlRows());
-        System.assertEquals(logsToDelete.size(), results.size());
+        System.Assert.areEqual(3, System.Limits.getDmlStatements());
+        System.Assert.areEqual(6, System.Limits.getDmlRows());
+        System.Assert.areEqual(logsToDelete.size(), results.size());
         for (Database.DeleteResult result : results) {
-            System.assertEquals(true, result.isSuccess());
+            System.Assert.isTrue(result.isSuccess());
         }
         // Frustratingly, there's not a way to ensure that Database.emptyRecycleBin() was called and
         // the supposedly-hard-deleted records are still returned in SOQL, so at least verify that the
         // record has IsDeleted = true for now. This can probably be tested better with a @TestVisible property later.
         List<Log__c> persistedLogs = [SELECT Id, IsDeleted FROM Log__c WHERE Id IN :logsToDelete ALL ROWS];
-        System.assertEquals(logsToDelete.size(), persistedLogs.size());
+        System.Assert.areEqual(logsToDelete.size(), persistedLogs.size());
         for (Log__c persistedLog : persistedLogs) {
-            System.assertEquals(true, persistedLog.IsDeleted);
+            System.Assert.isTrue(persistedLog.IsDeleted);
         }
     }
 
@@ -126,17 +126,17 @@ private class LoggerDataStore_Tests {
     static void it_should_insert_record() {
         Log__c log = (Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord();
         log.TransactionId__c = '1234';
-        System.assertEquals(0, System.Limits.getDmlStatements());
-        System.assertEquals(0, System.Limits.getDmlRows());
+        System.Assert.areEqual(0, System.Limits.getDmlStatements());
+        System.Assert.areEqual(0, System.Limits.getDmlRows());
 
         Database.SaveResult result = LoggerDataStore.getDatabase().insertRecord(log);
 
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(1, System.Limits.getDmlRows());
-        System.assertNotEquals(null, log.Id);
-        System.assertEquals(true, result.isSuccess());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(1, System.Limits.getDmlRows());
+        System.Assert.isNotNull(log.Id);
+        System.Assert.isTrue(result.isSuccess());
         Log__c persistedLog = [SELECT Id, TransactionId__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(log.TransactionId__c, persistedLog.TransactionId__c);
+        System.Assert.areEqual(log.TransactionId__c, persistedLog.TransactionId__c);
     }
 
     @IsTest
@@ -144,19 +144,19 @@ private class LoggerDataStore_Tests {
         List<Log__c> logsToInsert = new List<Log__c>();
         logsToInsert.add((Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord());
         logsToInsert.add((Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord());
-        System.assertEquals(0, System.Limits.getDmlStatements());
-        System.assertEquals(0, System.Limits.getDmlRows());
+        System.Assert.areEqual(0, System.Limits.getDmlStatements());
+        System.Assert.areEqual(0, System.Limits.getDmlRows());
 
         List<Database.SaveResult> results = LoggerDataStore.getDatabase().insertRecords(logsToInsert);
 
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(2, System.Limits.getDmlRows());
-        System.assertEquals(logsToInsert.size(), results.size());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(2, System.Limits.getDmlRows());
+        System.Assert.areEqual(logsToInsert.size(), results.size());
         for (Database.SaveResult result : results) {
-            System.assertEquals(true, result.isSuccess());
+            System.Assert.isTrue(result.isSuccess());
         }
         List<Log__c> persistedLogs = [SELECT Id, TransactionId__c FROM Log__c WHERE Id IN :logsToInsert];
-        System.assertEquals(logsToInsert.size(), persistedLogs.size());
+        System.Assert.areEqual(logsToInsert.size(), persistedLogs.size());
     }
 
     @IsTest
@@ -166,18 +166,18 @@ private class LoggerDataStore_Tests {
         List<Log__c> logsToInsert = new List<Log__c>();
         logsToInsert.add((Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord());
         logsToInsert.add(existingRecord);
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(1, System.Limits.getDmlRows());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(1, System.Limits.getDmlRows());
 
         List<Database.SaveResult> results = LoggerDataStore.getDatabase().insertRecords(logsToInsert, false);
 
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(3, System.Limits.getDmlRows());
-        System.assertEquals(logsToInsert.size(), results.size());
-        System.assertEquals(true, results.get(0).isSuccess());
-        System.assertEquals(false, results.get(1).isSuccess());
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(3, System.Limits.getDmlRows());
+        System.Assert.areEqual(logsToInsert.size(), results.size());
+        System.Assert.isTrue(results.get(0).isSuccess());
+        System.Assert.isFalse(results.get(1).isSuccess());
         List<Log__c> persistedLogs = [SELECT Id, TransactionId__c FROM Log__c WHERE Id IN :logsToInsert];
-        System.assertEquals(2, persistedLogs.size());
+        System.Assert.areEqual(2, persistedLogs.size());
     }
 
     @IsTest
@@ -189,18 +189,18 @@ private class LoggerDataStore_Tests {
         logsToInsert.add(existingRecord);
         Database.DmlOptions dmlOptions = new Database.DmlOptions();
         dmlOptions.OptAllOrNone = false;
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(1, System.Limits.getDmlRows());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(1, System.Limits.getDmlRows());
 
         List<Database.SaveResult> results = LoggerDataStore.getDatabase().insertRecords(logsToInsert, dmlOptions);
 
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(3, System.Limits.getDmlRows());
-        System.assertEquals(logsToInsert.size(), results.size());
-        System.assertEquals(true, results.get(0).isSuccess());
-        System.assertEquals(false, results.get(1).isSuccess());
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(3, System.Limits.getDmlRows());
+        System.Assert.areEqual(logsToInsert.size(), results.size());
+        System.Assert.isTrue(results.get(0).isSuccess());
+        System.Assert.isFalse(results.get(1).isSuccess());
         List<Log__c> persistedLogs = [SELECT Id, TransactionId__c FROM Log__c WHERE Id IN :logsToInsert];
-        System.assertEquals(2, persistedLogs.size());
+        System.Assert.areEqual(2, persistedLogs.size());
     }
 
     @IsTest
@@ -209,17 +209,17 @@ private class LoggerDataStore_Tests {
         insert log;
         delete log;
         log = [SELECT Id, IsDeleted FROM Log__c WHERE Id = :log.Id ALL ROWS];
-        System.assertEquals(true, log.IsDeleted);
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(2, System.Limits.getDmlRows());
+        System.Assert.isTrue(log.IsDeleted);
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(2, System.Limits.getDmlRows());
 
         Database.UndeleteResult result = LoggerDataStore.getDatabase().undeleteRecord(log);
 
-        System.assertEquals(3, System.Limits.getDmlStatements());
-        System.assertEquals(3, System.Limits.getDmlRows());
-        System.assertEquals(true, result.isSuccess());
+        System.Assert.areEqual(3, System.Limits.getDmlStatements());
+        System.Assert.areEqual(3, System.Limits.getDmlRows());
+        System.Assert.isTrue(result.isSuccess());
         Log__c persistedLog = [SELECT Id, IsDeleted FROM Log__c WHERE Id = :log.Id ALL ROWS];
-        System.assertEquals(false, persistedLog.IsDeleted);
+        System.Assert.isFalse(persistedLog.IsDeleted);
     }
 
     @IsTest
@@ -231,23 +231,23 @@ private class LoggerDataStore_Tests {
         delete logsToUndelete;
         logsToUndelete = [SELECT Id, IsDeleted FROM Log__c WHERE Id IN :logsToUndelete ALL ROWS];
         for (Log__c deletedLog : logsToUndelete) {
-            System.assertEquals(true, deletedLog.IsDeleted);
+            System.Assert.isTrue(deletedLog.IsDeleted);
         }
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(4, System.Limits.getDmlRows());
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(4, System.Limits.getDmlRows());
 
         List<Database.UndeleteResult> results = LoggerDataStore.getDatabase().undeleteRecords(logsToUndelete);
 
-        System.assertEquals(3, System.Limits.getDmlStatements());
-        System.assertEquals(6, System.Limits.getDmlRows());
-        System.assertEquals(logsToUndelete.size(), results.size());
+        System.Assert.areEqual(3, System.Limits.getDmlStatements());
+        System.Assert.areEqual(6, System.Limits.getDmlRows());
+        System.Assert.areEqual(logsToUndelete.size(), results.size());
         for (Database.UndeleteResult result : results) {
-            System.assertEquals(true, result.isSuccess());
+            System.Assert.isTrue(result.isSuccess());
         }
         List<Log__c> persistedLogs = [SELECT Id, IsDeleted FROM Log__c WHERE Id IN :logsToUndelete ALL ROWS];
-        System.assertEquals(logsToUndelete.size(), persistedLogs.size());
+        System.Assert.areEqual(logsToUndelete.size(), persistedLogs.size());
         for (Log__c persistedLog : persistedLogs) {
-            System.assertEquals(false, persistedLog.IsDeleted);
+            System.Assert.isFalse(persistedLog.IsDeleted);
         }
     }
 
@@ -259,22 +259,22 @@ private class LoggerDataStore_Tests {
         insert logsToUndelete;
         delete logsToUndelete.get(0);
         logsToUndelete = [SELECT Id, IsDeleted FROM Log__c WHERE Id IN :logsToUndelete ALL ROWS];
-        System.assertEquals(true, logsToUndelete.get(0).IsDeleted);
-        System.assertEquals(false, logsToUndelete.get(1).IsDeleted);
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(3, System.Limits.getDmlRows());
+        System.Assert.isTrue(logsToUndelete.get(0).IsDeleted);
+        System.Assert.isFalse(logsToUndelete.get(1).IsDeleted);
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(3, System.Limits.getDmlRows());
 
         List<Database.UndeleteResult> results = LoggerDataStore.getDatabase().undeleteRecords(logsToUndelete, false);
 
-        System.assertEquals(3, System.Limits.getDmlStatements());
-        System.assertEquals(5, System.Limits.getDmlRows());
-        System.assertEquals(logsToUndelete.size(), results.size());
-        System.assertEquals(true, results.get(0).isSuccess());
-        System.assertEquals(false, results.get(1).isSuccess());
+        System.Assert.areEqual(3, System.Limits.getDmlStatements());
+        System.Assert.areEqual(5, System.Limits.getDmlRows());
+        System.Assert.areEqual(logsToUndelete.size(), results.size());
+        System.Assert.isTrue(results.get(0).isSuccess());
+        System.Assert.isFalse(results.get(1).isSuccess());
         List<Log__c> persistedLogs = [SELECT Id, IsDeleted FROM Log__c WHERE Id IN :logsToUndelete ALL ROWS];
-        System.assertEquals(logsToUndelete.size(), persistedLogs.size());
+        System.Assert.areEqual(logsToUndelete.size(), persistedLogs.size());
         for (Log__c persistedLog : persistedLogs) {
-            System.assertEquals(false, persistedLog.IsDeleted);
+            System.Assert.isFalse(persistedLog.IsDeleted);
         }
     }
 
@@ -288,24 +288,24 @@ private class LoggerDataStore_Tests {
         insert logsToUpdate;
         logsToUpdate = [SELECT Id, Scenario__c FROM Log__c WHERE Id IN :logsToUpdate];
         for (Log__c logToUpdate : logsToUpdate) {
-            System.assertEquals(originalScenario, logToUpdate.Scenario__c);
+            System.Assert.areEqual(originalScenario, logToUpdate.Scenario__c);
             logToUpdate.Scenario__c = updatedScenario;
         }
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(2, System.Limits.getDmlRows());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(2, System.Limits.getDmlRows());
 
         List<Database.SaveResult> results = LoggerDataStore.getDatabase().updateRecords(logsToUpdate);
 
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(4, System.Limits.getDmlRows());
-        System.assertEquals(logsToUpdate.size(), results.size());
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(4, System.Limits.getDmlRows());
+        System.Assert.areEqual(logsToUpdate.size(), results.size());
         for (Database.SaveResult result : results) {
-            System.assertEquals(true, result.isSuccess());
+            System.Assert.isTrue(result.isSuccess());
         }
         List<Log__c> persistedLogs = [SELECT Id, Scenario__c FROM Log__c WHERE Id IN :logsToUpdate ALL ROWS];
-        System.assertEquals(logsToUpdate.size(), persistedLogs.size());
+        System.Assert.areEqual(logsToUpdate.size(), persistedLogs.size());
         for (Log__c persistedLog : persistedLogs) {
-            System.assertEquals(updatedScenario, persistedLog.Scenario__c);
+            System.Assert.areEqual(updatedScenario, persistedLog.Scenario__c);
         }
     }
 
@@ -317,18 +317,18 @@ private class LoggerDataStore_Tests {
         log.Scenario__c = originalScenario;
         insert log;
         log = [SELECT Id, Scenario__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(originalScenario, log.Scenario__c);
+        System.Assert.areEqual(originalScenario, log.Scenario__c);
         log.Scenario__c = updatedScenario;
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(1, System.Limits.getDmlRows());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(1, System.Limits.getDmlRows());
 
         Database.SaveResult result = LoggerDataStore.getDatabase().updateRecord(log);
 
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(2, System.Limits.getDmlRows());
-        System.assertEquals(true, result.isSuccess());
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(2, System.Limits.getDmlRows());
+        System.Assert.isTrue(result.isSuccess());
         Log__c persistedLog = [SELECT Id, Scenario__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(updatedScenario, persistedLog.Scenario__c);
+        System.Assert.areEqual(updatedScenario, persistedLog.Scenario__c);
     }
 
     @IsTest
@@ -342,19 +342,19 @@ private class LoggerDataStore_Tests {
         for (Log__c log : logsToUpdate) {
             log.Scenario__c = updatedScenario;
         }
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(1, System.Limits.getDmlRows());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(1, System.Limits.getDmlRows());
 
         List<Database.SaveResult> results = LoggerDataStore.getDatabase().updateRecords(logsToUpdate, false);
 
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(3, System.Limits.getDmlRows());
-        System.assertEquals(logsToUpdate.size(), results.size());
-        System.assertEquals(true, results.get(0).isSuccess());
-        System.assertEquals(false, results.get(1).isSuccess());
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(3, System.Limits.getDmlRows());
+        System.Assert.areEqual(logsToUpdate.size(), results.size());
+        System.Assert.isTrue(results.get(0).isSuccess());
+        System.Assert.isFalse(results.get(1).isSuccess());
         List<Log__c> persistedLogs = [SELECT Id, Scenario__c FROM Log__c WHERE Id IN :logsToUpdate];
-        System.assertEquals(1, persistedLogs.size());
-        System.assertEquals(updatedScenario, persistedLogs.get(0).Scenario__c);
+        System.Assert.areEqual(1, persistedLogs.size());
+        System.Assert.areEqual(updatedScenario, persistedLogs.get(0).Scenario__c);
     }
 
     @IsTest
@@ -370,19 +370,19 @@ private class LoggerDataStore_Tests {
         }
         Database.DmlOptions dmlOptions = new Database.DmlOptions();
         dmlOptions.OptAllOrNone = false;
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(1, System.Limits.getDmlRows());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(1, System.Limits.getDmlRows());
 
         List<Database.SaveResult> results = LoggerDataStore.getDatabase().updateRecords(logsToUpdate, dmlOptions);
 
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(3, System.Limits.getDmlRows());
-        System.assertEquals(logsToUpdate.size(), results.size());
-        System.assertEquals(true, results.get(0).isSuccess());
-        System.assertEquals(false, results.get(1).isSuccess());
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(3, System.Limits.getDmlRows());
+        System.Assert.areEqual(logsToUpdate.size(), results.size());
+        System.Assert.isTrue(results.get(0).isSuccess());
+        System.Assert.isFalse(results.get(1).isSuccess());
         List<Log__c> persistedLogs = [SELECT Id, Scenario__c FROM Log__c WHERE Id IN :logsToUpdate];
-        System.assertEquals(1, persistedLogs.size());
-        System.assertEquals(updatedScenario, persistedLogs.get(0).Scenario__c);
+        System.Assert.areEqual(1, persistedLogs.size());
+        System.Assert.areEqual(updatedScenario, persistedLogs.get(0).Scenario__c);
     }
 
     @IsTest
@@ -394,24 +394,24 @@ private class LoggerDataStore_Tests {
         log.TransactionId__c = '1234';
         insert log;
         log = [SELECT Id, Scenario__c, TransactionId__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(originalScenario, log.Scenario__c);
+        System.Assert.areEqual(originalScenario, log.Scenario__c);
         log.Scenario__c = updatedScenario;
         Id originalLogId = log.Id;
         log.Id = null;
-        System.assertEquals(null, log.Id);
-        System.assertNotEquals(null, log.TransactionId__c);
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(1, System.Limits.getDmlRows());
+        System.Assert.isNull(log.Id);
+        System.Assert.isNotNull(log.TransactionId__c);
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(1, System.Limits.getDmlRows());
 
         Database.UpsertResult result = LoggerDataStore.getDatabase().upsertRecord(log, Schema.Log__c.TransactionId__c);
 
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(2, System.Limits.getDmlRows());
-        System.assertEquals(false, result.isCreated());
-        System.assertEquals(true, result.isSuccess());
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(2, System.Limits.getDmlRows());
+        System.Assert.isFalse(result.isCreated());
+        System.Assert.isTrue(result.isSuccess());
         Log__c persistedLog = [SELECT Id, Scenario__c, TransactionId__c FROM Log__c WHERE TransactionId__c = :log.TransactionId__c];
-        System.assertEquals(originalLogId, persistedLog.Id);
-        System.assertEquals(updatedScenario, persistedLog.Scenario__c);
+        System.Assert.areEqual(originalLogId, persistedLog.Id);
+        System.Assert.areEqual(updatedScenario, persistedLog.Scenario__c);
     }
 
     @IsTest
@@ -432,24 +432,24 @@ private class LoggerDataStore_Tests {
         insert logsToUpsert;
         logsToUpsert = [SELECT Id, Scenario__c, TransactionId__c FROM Log__c WHERE Id IN :logsToUpsert];
         for (Log__c logToUpdate : logsToUpsert) {
-            System.assertEquals(originalScenario, logToUpdate.Scenario__c);
+            System.Assert.areEqual(originalScenario, logToUpdate.Scenario__c);
             logToUpdate.Scenario__c = updatedScenario;
         }
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(2, System.Limits.getDmlRows());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(2, System.Limits.getDmlRows());
 
         List<Database.UpsertResult> results = LoggerDataStore.getDatabase().upsertRecords(logsToUpsert, Schema.Log__c.TransactionId__c);
 
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(4, System.Limits.getDmlRows());
-        System.assertEquals(logsToUpsert.size(), results.size());
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(4, System.Limits.getDmlRows());
+        System.Assert.areEqual(logsToUpsert.size(), results.size());
         for (Database.UpsertResult result : results) {
-            System.assertEquals(true, result.isSuccess());
+            System.Assert.isTrue(result.isSuccess());
         }
         List<Log__c> persistedLogs = [SELECT Id, Scenario__c FROM Log__c WHERE Id IN :logsToUpsert];
-        System.assertEquals(logsToUpsert.size(), persistedLogs.size());
+        System.Assert.areEqual(logsToUpsert.size(), persistedLogs.size());
         for (Log__c persistedLog : persistedLogs) {
-            System.assertEquals(updatedScenario, persistedLog.Scenario__c);
+            System.Assert.areEqual(updatedScenario, persistedLog.Scenario__c);
         }
     }
 
@@ -471,42 +471,42 @@ private class LoggerDataStore_Tests {
         insert logsToUpsert;
         logsToUpsert = [SELECT Id, Scenario__c, TransactionId__c FROM Log__c WHERE Id IN :logsToUpsert];
         for (Log__c logToUpdate : logsToUpsert) {
-            System.assertEquals(originalScenario, logToUpdate.Scenario__c);
+            System.Assert.areEqual(originalScenario, logToUpdate.Scenario__c);
             logToUpdate.Scenario__c = updatedScenario;
         }
         logsToUpsert.get(1).TransactionId__c = null; // This will cause an error since the upsert is on TransactionId__c
-        System.assertEquals(1, System.Limits.getDmlStatements());
-        System.assertEquals(2, System.Limits.getDmlRows());
+        System.Assert.areEqual(1, System.Limits.getDmlStatements());
+        System.Assert.areEqual(2, System.Limits.getDmlRows());
 
         List<Database.UpsertResult> results = LoggerDataStore.getDatabase().upsertRecords(logsToUpsert, Schema.Log__c.TransactionId__c, false);
 
-        System.assertEquals(2, System.Limits.getDmlStatements());
-        System.assertEquals(4, System.Limits.getDmlRows());
-        System.assertEquals(logsToUpsert.size(), results.size());
-        System.assertEquals(true, results.get(0).isSuccess());
-        System.assertEquals(false, results.get(1).isSuccess());
+        System.Assert.areEqual(2, System.Limits.getDmlStatements());
+        System.Assert.areEqual(4, System.Limits.getDmlRows());
+        System.Assert.areEqual(logsToUpsert.size(), results.size());
+        System.Assert.isTrue(results.get(0).isSuccess());
+        System.Assert.isFalse(results.get(1).isSuccess());
         List<Log__c> persistedLogs = [SELECT Id, Scenario__c FROM Log__c WHERE Id IN :logsToUpsert];
-        System.assertEquals(2, persistedLogs.size());
-        System.assertEquals(updatedScenario, persistedLogs.get(0).Scenario__c);
-        System.assertEquals(originalScenario, persistedLogs.get(1).Scenario__c);
+        System.Assert.areEqual(2, persistedLogs.size());
+        System.Assert.areEqual(updatedScenario, persistedLogs.get(0).Scenario__c);
+        System.Assert.areEqual(originalScenario, persistedLogs.get(1).Scenario__c);
     }
 
     // Event Bus tests
     @IsTest
-    static void it_should_publish_record() {
+    static void it_should_publish_platform_event_record() {
         LogEntryEvent__e logEntryEvent = (LOgEntryEvent__e) LoggerMockDataCreator.createDataBuilder(Schema.LogEntryEvent__e.SObjectType)
             .populateRequiredFields()
             .getRecord();
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
 
         Database.SaveResult result = LoggerDataStore.getEventBus().publishRecord(logEntryEvent);
 
-        System.assertEquals(1, System.Limits.getPublishImmediateDml(), result);
-        System.assertEquals(true, result.isSuccess());
+        System.Assert.areEqual(1, System.Limits.getPublishImmediateDml(), result.getErrors().toString());
+        System.Assert.isTrue(result.isSuccess());
     }
 
     @IsTest
-    static void it_should_publish_record_list() {
+    static void it_should_publish_platform_event_record_list() {
         List<LogEntryEvent__e> logEntryEventsToPublish = new List<LogEntryEvent__e>();
         logEntryEventsToPublish.add(
             (LogEntryEvent__e) LoggerMockDataCreator.createDataBuilder(Schema.LogEntryEvent__e.SObjectType).populateRequiredFields().getRecord()
@@ -514,62 +514,62 @@ private class LoggerDataStore_Tests {
         logEntryEventsToPublish.add(
             (LogEntryEvent__e) LoggerMockDataCreator.createDataBuilder(Schema.LogEntryEvent__e.SObjectType).populateRequiredFields().getRecord()
         );
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
 
         List<Database.SaveResult> results = LoggerDataStore.getEventBus().publishRecords(logEntryEventsToPublish);
 
-        System.assertEquals(1, System.Limits.getPublishImmediateDml(), results);
-        System.assertEquals(logEntryEventsToPublish.size(), results.size());
+        System.Assert.areEqual(1, System.Limits.getPublishImmediateDml(), results.toString());
+        System.Assert.areEqual(logEntryEventsToPublish.size(), results.size());
         for (Database.SaveResult result : results) {
-            System.assertEquals(true, result.isSuccess());
+            System.Assert.isTrue(result.isSuccess());
         }
     }
 
     // Queueable tests
     @IsTest
     static void it_should_enqueue_job() {
-        System.assertEquals(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
 
         LoggerDataStore.getJobQueue().enqueueJob(new MockQueueable());
 
-        System.assertEquals(1, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(1, System.Limits.getQueueableJobs());
     }
 
     // Mocking tests
     @IsTest
     static void it_should_support_overriding_database_instance() {
         MockDatabase mockDatabaseInstance = new MockDatabase();
-        System.assertEquals(0, mockDatabaseInstance.callCount);
+        System.Assert.areEqual(0, mockDatabaseInstance.callCount);
         LoggerDataStore.setMock(mockDatabaseInstance);
-        System.assertEquals(mockDatabaseInstance, LoggerDataStore.getDatabase());
+        System.Assert.areEqual(mockDatabaseInstance, LoggerDataStore.getDatabase());
 
         LoggerDataStore.getDatabase().updateRecord(new User(Id = UserInfo.getUserId()));
 
-        System.assertEquals(1, mockDatabaseInstance.callCount);
+        System.Assert.areEqual(1, mockDatabaseInstance.callCount);
     }
 
     @IsTest
     static void it_should_support_overriding_event_bus_instance() {
         MockEventBus mockEventBusInstance = new MockEventBus();
-        System.assertEquals(0, mockEventBusInstance.callCount);
+        System.Assert.areEqual(0, mockEventBusInstance.callCount);
         LoggerDataStore.setMock(mockEventBusInstance);
-        System.assertEquals(mockEventBusInstance, LoggerDataStore.getEventBus());
+        System.Assert.areEqual(mockEventBusInstance, LoggerDataStore.getEventBus());
 
         LoggerDataStore.getEventBus().publishRecord(new User()); // Not an actual platform event, but for mocking/test purposes, User is fine
 
-        System.assertEquals(1, mockEventBusInstance.callCount);
+        System.Assert.areEqual(1, mockEventBusInstance.callCount);
     }
 
     @IsTest
     static void it_should_support_overriding_job_queue_instance() {
         MockJobQueue mockJobQueueInstance = new MockJobQueue();
-        System.assertEquals(0, mockJobQueueInstance.callCount);
+        System.Assert.areEqual(0, mockJobQueueInstance.callCount);
         LoggerDataStore.setMock(mockJobQueueInstance);
-        System.assertEquals(mockJobQueueInstance, LoggerDataStore.getJobQueue());
+        System.Assert.areEqual(mockJobQueueInstance, LoggerDataStore.getJobQueue());
 
         LoggerDataStore.getJobQueue().enqueueJob(new MockQueueable());
 
-        System.assertEquals(1, mockJobQueueInstance.callCount);
+        System.Assert.areEqual(1, mockJobQueueInstance.callCount);
     }
 
     private class MockDatabase extends LoggerDataStore.Database {

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerDataStore_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerDataStore_Tests.cls
@@ -543,7 +543,7 @@ private class LoggerDataStore_Tests {
         LoggerDataStore.setMock(mockDatabaseInstance);
         System.Assert.areEqual(mockDatabaseInstance, LoggerDataStore.getDatabase());
 
-        LoggerDataStore.getDatabase().updateRecord(new User(Id = UserInfo.getUserId()));
+        LoggerDataStore.getDatabase().updateRecord(new User(Id = System.UserInfo.getUserId()));
 
         System.Assert.areEqual(1, mockDatabaseInstance.callCount);
     }

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerEngineDataSelector_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerEngineDataSelector_Tests.cls
@@ -31,7 +31,7 @@ private class LoggerEngineDataSelector_Tests {
                 SessionType,
                 SourceIp
             FROM AuthSession
-            WHERE UsersId = :UserInfo.getUserId() AND IsCurrent = TRUE AND ParentId = NULL
+            WHERE UsersId = :System.UserInfo.getUserId() AND IsCurrent = TRUE AND ParentId = NULL
         ];
         LoggerSObjectProxy.AuthSession expectedAuthSessionProxy = sessions.isEmpty() ? null : new LoggerSObjectProxy.AuthSession(sessions.get(0));
         System.assertEquals(1, System.Limits.getQueries());
@@ -131,7 +131,7 @@ private class LoggerEngineDataSelector_Tests {
         User expectedUser = [
             SELECT Id, Profile.Name, Profile.UserLicenseId, Profile.UserLicense.LicenseDefinitionKey, Profile.UserLicense.Name, Username, UserRole.Name
             FROM User
-            WHERE Id = :UserInfo.getUserId()
+            WHERE Id = :System.UserInfo.getUserId()
         ];
         System.Assert.areEqual(1, System.Limits.getQueries());
 

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerEngineDataSelector_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerEngineDataSelector_Tests.cls
@@ -34,14 +34,14 @@ private class LoggerEngineDataSelector_Tests {
             WHERE UsersId = :System.UserInfo.getUserId() AND IsCurrent = TRUE AND ParentId = NULL
         ];
         LoggerSObjectProxy.AuthSession expectedAuthSessionProxy = sessions.isEmpty() ? null : new LoggerSObjectProxy.AuthSession(sessions.get(0));
-        System.assertEquals(1, System.Limits.getQueries());
+        System.Assert.areEqual(1, System.Limits.getQueries());
 
         LoggerSObjectProxy.AuthSession returnedAuthSessionProxy = LoggerEngineDataSelector.getInstance().getCachedAuthSessionProxy();
 
-        System.assertEquals(2, System.Limits.getQueries());
+        System.Assert.areEqual(2, System.Limits.getQueries());
         LoggerEngineDataSelector.getInstance().getCachedAuthSessionProxy();
-        System.assertEquals(2, System.Limits.getQueries(), 'Query results should have been cached');
-        System.assertEquals(expectedAuthSessionProxy, returnedAuthSessionProxy);
+        System.Assert.areEqual(2, System.Limits.getQueries(), 'Query results should have been cached');
+        System.Assert.areEqual(expectedAuthSessionProxy, returnedAuthSessionProxy);
     }
 
     @IsTest

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerEngineDataSelector_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerEngineDataSelector_Tests.cls
@@ -9,11 +9,11 @@ private class LoggerEngineDataSelector_Tests {
     @IsTest
     static void it_loads_mock_instance() {
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
-        System.assertNotEquals(mockSelector, LoggerEngineDataSelector.getInstance());
+        System.Assert.areNotEqual(mockSelector, LoggerEngineDataSelector.getInstance());
 
         LoggerEngineDataSelector.setMock(mockSelector);
 
-        System.assertEquals(mockSelector, LoggerEngineDataSelector.getInstance());
+        System.Assert.areEqual(mockSelector, LoggerEngineDataSelector.getInstance());
     }
 
     @IsTest
@@ -33,7 +33,7 @@ private class LoggerEngineDataSelector_Tests {
             FROM AuthSession
             WHERE UsersId = :UserInfo.getUserId() AND IsCurrent = TRUE AND ParentId = NULL
         ];
-        LoggerSObjectProxy.AuthSession expectedAuthSession = sessions.isEmpty() ? null : new LoggerSObjectProxy.AuthSession(sessions.get(0));
+        LoggerSObjectProxy.AuthSession expectedAuthSessionProxy = sessions.isEmpty() ? null : new LoggerSObjectProxy.AuthSession(sessions.get(0));
         System.assertEquals(1, System.Limits.getQueries());
 
         LoggerSObjectProxy.AuthSession returnedAuthSessionProxy = LoggerEngineDataSelector.getInstance().getCachedAuthSessionProxy();
@@ -41,21 +41,21 @@ private class LoggerEngineDataSelector_Tests {
         System.assertEquals(2, System.Limits.getQueries());
         LoggerEngineDataSelector.getInstance().getCachedAuthSessionProxy();
         System.assertEquals(2, System.Limits.getQueries(), 'Query results should have been cached');
-        System.assertEquals(expectedAuthSession, returnedAuthSessionProxy);
+        System.assertEquals(expectedAuthSessionProxy, returnedAuthSessionProxy);
     }
 
     @IsTest
     static void it_does_not_query_auth_session_when_disabled_via_logger_parameter() {
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
         LoggerEngineDataSelector.setMock(mockSelector);
-        System.assertEquals(mockSelector, LoggerEngineDataSelector.getInstance());
-        System.assertEquals(0, mockSelector.getCachedAuthSessionQueryCount());
+        System.Assert.areEqual(mockSelector, LoggerEngineDataSelector.getInstance());
+        System.Assert.areEqual(0, mockSelector.getCachedAuthSessionQueryCount());
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryAuthSessionData', Value__c = String.valueOf(false)));
 
         LoggerSObjectProxy.AuthSession returnedAuthSessionProxy = LoggerEngineDataSelector.getInstance().getCachedAuthSessionProxy();
 
-        System.assertEquals(0, mockSelector.getCachedAuthSessionQueryCount());
-        System.assertEquals(null, returnedAuthSessionProxy);
+        System.Assert.areEqual(0, mockSelector.getCachedAuthSessionQueryCount());
+        System.Assert.isNull(returnedAuthSessionProxy);
     }
 
     @IsTest
@@ -65,16 +65,16 @@ private class LoggerEngineDataSelector_Tests {
             FROM LoggerSObjectHandler__mdt
             WHERE IsEnabled__c = TRUE
         ];
-        System.assertEquals(0, System.Limits.getQueries());
+        System.Assert.areEqual(0, System.Limits.getQueries());
 
         List<LoggerSObjectHandler__mdt> returnedSObjectHandlers = LoggerEngineDataSelector.getInstance().getCachedLoggerSObjectHandlers();
 
         // The specific query used for LoggerSObjectHandler__mdt shouldn't count towards the SOQL query limits,
         // so 0 queries are expected here
-        System.assertEquals(0, System.Limits.getQueries());
+        System.Assert.areEqual(0, System.Limits.getQueries());
         LoggerEngineDataSelector.getInstance().getCachedLoggerSObjectHandlers();
-        System.assertEquals(0, System.Limits.getQueries(), 'Query results should have been cached');
-        System.assertEquals(expectedSObjectHandlers, returnedSObjectHandlers);
+        System.Assert.areEqual(0, System.Limits.getQueries(), 'Query results should have been cached');
+        System.Assert.areEqual(expectedSObjectHandlers, returnedSObjectHandlers);
     }
 
     @IsTest
@@ -85,28 +85,28 @@ private class LoggerEngineDataSelector_Tests {
         ];
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
         LoggerEngineDataSelector.setMock(mockSelector);
-        System.assertEquals(mockSelector, LoggerEngineDataSelector.getInstance());
-        System.assertEquals(0, mockSelector.getCachedOrganizationQueryCount());
+        System.Assert.areEqual(mockSelector, LoggerEngineDataSelector.getInstance());
+        System.Assert.areEqual(0, mockSelector.getCachedOrganizationQueryCount());
 
         Organization returnedOrganization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
 
-        System.assertEquals(1, mockSelector.getCachedOrganizationQueryCount());
+        System.Assert.areEqual(1, mockSelector.getCachedOrganizationQueryCount());
         LoggerEngineDataSelector.getInstance().getCachedOrganization();
-        System.assertEquals(1, mockSelector.getCachedOrganizationQueryCount(), 'Query results should have been cached');
-        System.assertEquals(expectedOrganization, returnedOrganization);
+        System.Assert.areEqual(1, mockSelector.getCachedOrganizationQueryCount(), 'Query results should have been cached');
+        System.Assert.areEqual(expectedOrganization, returnedOrganization);
     }
 
     @IsTest
     static void it_does_not_query_organization_when_disabled_via_logger_parameter() {
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
-        System.assertNotEquals(mockSelector, LoggerEngineDataSelector.getInstance());
-        System.assertEquals(0, mockSelector.getCachedOrganizationQueryCount());
+        System.Assert.areNotEqual(mockSelector, LoggerEngineDataSelector.getInstance());
+        System.Assert.areEqual(0, mockSelector.getCachedOrganizationQueryCount());
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryOrganizationData', Value__c = String.valueOf(false)));
 
         Organization returnedOrganization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
 
-        System.assertEquals(0, mockSelector.getCachedOrganizationQueryCount());
-        System.assertEquals(null, returnedOrganization);
+        System.Assert.areEqual(0, mockSelector.getCachedOrganizationQueryCount());
+        System.Assert.isNull(returnedOrganization);
     }
 
     @IsTest
@@ -116,14 +116,14 @@ private class LoggerEngineDataSelector_Tests {
             FROM LogEntryTagRule__mdt
             WHERE IsEnabled__c = TRUE AND SObjectType__r.DeveloperName = 'LogEntry'
         ];
-        System.assertEquals(1, System.Limits.getQueries());
+        System.Assert.areEqual(1, System.Limits.getQueries());
 
         List<LogEntryTagRule__mdt> returnedTagAssignmentRules = LoggerEngineDataSelector.getInstance().getCachedTagAssignmentRules();
 
-        System.assertEquals(2, System.Limits.getQueries());
+        System.Assert.areEqual(2, System.Limits.getQueries());
         LoggerEngineDataSelector.getInstance().getCachedTagAssignmentRules();
-        System.assertEquals(2, System.Limits.getQueries(), 'Query results should have been cached');
-        System.assertEquals(expectedTagAssignmentRules, returnedTagAssignmentRules);
+        System.Assert.areEqual(2, System.Limits.getQueries(), 'Query results should have been cached');
+        System.Assert.areEqual(expectedTagAssignmentRules, returnedTagAssignmentRules);
     }
 
     @IsTest
@@ -133,14 +133,14 @@ private class LoggerEngineDataSelector_Tests {
             FROM User
             WHERE Id = :UserInfo.getUserId()
         ];
-        System.assertEquals(1, System.Limits.getQueries());
+        System.Assert.areEqual(1, System.Limits.getQueries());
 
         User returnedUser = LoggerEngineDataSelector.getInstance().getCachedUser();
 
-        System.assertEquals(2, System.Limits.getQueries());
+        System.Assert.areEqual(2, System.Limits.getQueries());
         LoggerEngineDataSelector.getInstance().getCachedUser();
-        System.assertEquals(2, System.Limits.getQueries(), 'Query results should have been cached');
-        System.assertEquals(expectedUser, returnedUser);
+        System.Assert.areEqual(2, System.Limits.getQueries(), 'Query results should have been cached');
+        System.Assert.areEqual(expectedUser, returnedUser);
     }
 
     private class MockLoggerEngineDataSelector extends LoggerEngineDataSelector {

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerSObjectHandler_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerSObjectHandler_Tests.cls
@@ -26,9 +26,9 @@ private class LoggerSObjectHandler_Tests {
 
         LoggerSObjectHandler configuredInstance = LoggerSObjectHandler.getHandler(sobjectType);
 
-        System.assertEquals(
-            true,
-            configuredInstance instanceof MockSObjectHandler,
+        System.Assert.isInstanceOfType(
+            configuredInstance,
+            MockSObjectHandler.class,
             'The returned handler should be an instance of the configured class, MockSObjectHandler'
         );
     }
@@ -46,9 +46,9 @@ private class LoggerSObjectHandler_Tests {
 
         LoggerSObjectHandler configuredInstance = LoggerSObjectHandler.getHandler(sobjectType);
 
-        System.assertEquals(
-            true,
-            configuredInstance instanceof MockSObjectHandler,
+        System.Assert.isInstanceOfType(
+            configuredInstance,
+            MockSObjectHandler.class,
             'The handler returned via override should be an instance of the configured class, MockSObjectHandler'
         );
     }
@@ -60,9 +60,9 @@ private class LoggerSObjectHandler_Tests {
 
         LoggerSObjectHandler configuredInstance = LoggerSObjectHandler.getHandler(sobjectType, defaultImplementation);
 
-        System.assertEquals(
-            true,
-            configuredInstance instanceof MockDefaultImplementationSObjectHandler,
+        System.Assert.isInstanceOfType(
+            configuredInstance,
+            MockDefaultImplementationSObjectHandler.class,
             'The returned handler should be an instance of the default implementation class, MockDefaultImplementationSObjectHandler'
         );
     }
@@ -76,12 +76,12 @@ private class LoggerSObjectHandler_Tests {
             TriggerOperation.BEFORE_INSERT,
             new List<User>{ new User(Id = UserInfo.getUserId(), Email = UserInfo.getUserEmail()) }
         );
-        System.assertNotEquals(originalContext, customContext);
+        System.Assert.areNotEqual(originalContext, customContext);
 
         mockHandler.overrideTriggerableContext(customContext);
 
-        System.assertNotEquals(originalContext, mockHandler.input);
-        System.assertEquals(customContext, mockHandler.input);
+        System.Assert.areNotEqual(originalContext, mockHandler.input);
+        System.Assert.areEqual(customContext, mockHandler.input);
     }
 
     @IsTest
@@ -98,7 +98,7 @@ private class LoggerSObjectHandler_Tests {
 
         mockHandler.execute();
 
-        System.assertEquals(0, mockHandler.executionCount, mockHandler);
+        System.Assert.areEqual(0, mockHandler.executionCount, mockHandler.toString());
     }
 
     @IsTest
@@ -116,7 +116,7 @@ private class LoggerSObjectHandler_Tests {
         LoggerSObjectHandler.shouldExecute(false);
         mockHandler.execute();
 
-        System.assertEquals(0, mockHandler.executionCount, mockHandler);
+        System.Assert.areEqual(0, mockHandler.executionCount, mockHandler.toString());
     }
 
     @IsTest
@@ -132,11 +132,11 @@ private class LoggerSObjectHandler_Tests {
 
         mockHandler.execute();
 
-        System.assertEquals(1, mockHandler.executionCount);
-        System.assertEquals(TriggerOperation.BEFORE_INSERT, mockHandler.executedTriggerOperationType);
-        System.assertEquals(mockHandler.triggerNew, mockHandler.executedTriggerNew);
-        System.assertEquals(null, mockHandler.executedTriggerNewMap);
-        System.assertEquals(null, mockHandler.executedTriggerOldMap);
+        System.Assert.areEqual(1, mockHandler.executionCount);
+        System.Assert.areEqual(TriggerOperation.BEFORE_INSERT, mockHandler.executedTriggerOperationType);
+        System.Assert.areEqual(mockHandler.triggerNew, mockHandler.executedTriggerNew);
+        System.Assert.isNull(mockHandler.executedTriggerNewMap);
+        System.Assert.isNull(mockHandler.executedTriggerOldMap);
     }
 
     @IsTest
@@ -152,11 +152,11 @@ private class LoggerSObjectHandler_Tests {
 
         mockHandler.execute();
 
-        System.assertEquals(1, mockHandler.executionCount);
-        System.assertEquals(TriggerOperation.BEFORE_UPDATE, mockHandler.executedTriggerOperationType);
-        System.assertEquals(null, mockHandler.executedTriggerNew);
-        System.assertEquals(mockHandler.triggerNewMap, mockHandler.executedTriggerNewMap);
-        System.assertEquals(mockHandler.triggerOldMap, mockHandler.executedTriggerOldMap);
+        System.Assert.areEqual(1, mockHandler.executionCount);
+        System.Assert.areEqual(TriggerOperation.BEFORE_UPDATE, mockHandler.executedTriggerOperationType);
+        System.Assert.isNull(mockHandler.executedTriggerNew);
+        System.Assert.areEqual(mockHandler.triggerNewMap, mockHandler.executedTriggerNewMap);
+        System.Assert.areEqual(mockHandler.triggerOldMap, mockHandler.executedTriggerOldMap);
     }
 
     @IsTest
@@ -172,11 +172,11 @@ private class LoggerSObjectHandler_Tests {
 
         mockHandler.execute();
 
-        System.assertEquals(1, mockHandler.executionCount);
-        System.assertEquals(TriggerOperation.BEFORE_DELETE, mockHandler.executedTriggerOperationType);
-        System.assertEquals(null, mockHandler.executedTriggerNew);
-        System.assertEquals(mockHandler.triggerNewMap, mockHandler.executedTriggerNewMap);
-        System.assertEquals(null, mockHandler.executedTriggerOldMap);
+        System.Assert.areEqual(1, mockHandler.executionCount);
+        System.Assert.areEqual(TriggerOperation.BEFORE_DELETE, mockHandler.executedTriggerOperationType);
+        System.Assert.isNull(mockHandler.executedTriggerNew);
+        System.Assert.areEqual(mockHandler.triggerNewMap, mockHandler.executedTriggerNewMap);
+        System.Assert.isNull(mockHandler.executedTriggerOldMap);
     }
 
     @IsTest
@@ -194,11 +194,11 @@ private class LoggerSObjectHandler_Tests {
 
         mockHandler.execute();
 
-        System.assertEquals(2, mockHandler.executionCount);
-        System.assertEquals(TriggerOperation.AFTER_INSERT, mockHandler.executedTriggerOperationType);
-        System.assertEquals(mockHandler.triggerNew, mockHandler.executedTriggerNew);
-        System.assertEquals(mockHandler.triggerNewMap, mockHandler.executedTriggerNewMap);
-        System.assertEquals(null, mockHandler.executedTriggerOldMap);
+        System.Assert.areEqual(2, mockHandler.executionCount);
+        System.Assert.areEqual(TriggerOperation.AFTER_INSERT, mockHandler.executedTriggerOperationType);
+        System.Assert.areEqual(mockHandler.triggerNew, mockHandler.executedTriggerNew);
+        System.Assert.areEqual(mockHandler.triggerNewMap, mockHandler.executedTriggerNewMap);
+        System.Assert.isNull(mockHandler.executedTriggerOldMap);
     }
 
     @IsTest
@@ -214,11 +214,11 @@ private class LoggerSObjectHandler_Tests {
 
         mockHandler.execute();
 
-        System.assertEquals(1, mockHandler.executionCount);
-        System.assertEquals(TriggerOperation.AFTER_UPDATE, mockHandler.executedTriggerOperationType);
-        System.assertEquals(null, mockHandler.executedTriggerNew);
-        System.assertEquals(mockHandler.triggerNewMap, mockHandler.executedTriggerNewMap);
-        System.assertEquals(mockHandler.triggerOldMap, mockHandler.executedTriggerOldMap);
+        System.Assert.areEqual(1, mockHandler.executionCount);
+        System.Assert.areEqual(TriggerOperation.AFTER_UPDATE, mockHandler.executedTriggerOperationType);
+        System.Assert.isNull(mockHandler.executedTriggerNew);
+        System.Assert.areEqual(mockHandler.triggerNewMap, mockHandler.executedTriggerNewMap);
+        System.Assert.areEqual(mockHandler.triggerOldMap, mockHandler.executedTriggerOldMap);
     }
 
     @IsTest
@@ -234,11 +234,11 @@ private class LoggerSObjectHandler_Tests {
 
         mockHandler.execute();
 
-        System.assertEquals(1, mockHandler.executionCount);
-        System.assertEquals(TriggerOperation.AFTER_DELETE, mockHandler.executedTriggerOperationType);
-        System.assertEquals(null, mockHandler.executedTriggerNew);
-        System.assertEquals(mockHandler.triggerNewMap, mockHandler.executedTriggerNewMap);
-        System.assertEquals(null, mockHandler.executedTriggerOldMap);
+        System.Assert.areEqual(1, mockHandler.executionCount);
+        System.Assert.areEqual(TriggerOperation.AFTER_DELETE, mockHandler.executedTriggerOperationType);
+        System.Assert.isNull(mockHandler.executedTriggerNew);
+        System.Assert.areEqual(mockHandler.triggerNewMap, mockHandler.executedTriggerNewMap);
+        System.Assert.isNull(mockHandler.executedTriggerOldMap);
     }
 
     @IsTest
@@ -254,11 +254,11 @@ private class LoggerSObjectHandler_Tests {
 
         mockHandler.execute();
 
-        System.assertEquals(1, mockHandler.executionCount);
-        System.assertEquals(TriggerOperation.AFTER_UNDELETE, mockHandler.executedTriggerOperationType);
-        System.assertEquals(null, mockHandler.executedTriggerNew);
-        System.assertEquals(mockHandler.triggerNewMap, mockHandler.executedTriggerNewMap);
-        System.assertEquals(null, mockHandler.executedTriggerOldMap);
+        System.Assert.areEqual(1, mockHandler.executionCount);
+        System.Assert.areEqual(TriggerOperation.AFTER_UNDELETE, mockHandler.executedTriggerOperationType);
+        System.Assert.isNull(mockHandler.executedTriggerNew);
+        System.Assert.areEqual(mockHandler.triggerNewMap, mockHandler.executedTriggerNewMap);
+        System.Assert.isNull(mockHandler.executedTriggerOldMap);
     }
 
     @IsTest
@@ -280,9 +280,9 @@ private class LoggerSObjectHandler_Tests {
 
         mockHandler.execute();
 
-        System.assertEquals(1, mockHandler.executionCount);
-        System.assertEquals(1, mockHandler.getPluginConfigurations().size(), mockHandler.getPluginConfigurations());
-        System.assertEquals(0, mockHandler.getExecutedApexPlugins().size(), mockHandler.getExecutedApexPlugins());
+        System.Assert.areEqual(1, mockHandler.executionCount);
+        System.Assert.areEqual(1, mockHandler.getPluginConfigurations().size(), mockHandler.getPluginConfigurations().toString());
+        System.Assert.areEqual(0, mockHandler.getExecutedApexPlugins().size(), mockHandler.getExecutedApexPlugins().toString());
     }
 
     @IsTest
@@ -304,12 +304,12 @@ private class LoggerSObjectHandler_Tests {
 
         mockHandler.execute();
 
-        System.assertEquals(1, mockHandler.executionCount);
-        System.assertEquals(1, mockHandler.getPluginConfigurations().size(), mockHandler.getPluginConfigurations());
-        System.assertEquals(1, mockHandler.getExecutedApexPlugins().size(), mockHandler.getExecutedApexPlugins());
+        System.Assert.areEqual(1, mockHandler.executionCount);
+        System.Assert.areEqual(1, mockHandler.getPluginConfigurations().size(), mockHandler.getPluginConfigurations().toString());
+        System.Assert.areEqual(1, mockHandler.getExecutedApexPlugins().size(), mockHandler.getExecutedApexPlugins().toString());
         MockTriggerablePlugin executedApexPlugin = (MockTriggerablePlugin) mockHandler.getExecutedApexPlugins().get(0);
-        System.assertEquals(mockPluginConfiguration, executedApexPlugin.configuration);
-        System.assertEquals(mockHandler.input, executedApexPlugin.input);
+        System.Assert.areEqual(mockPluginConfiguration, executedApexPlugin.configuration);
+        System.Assert.areEqual(mockHandler.input, executedApexPlugin.input);
     }
 
     @IsTest
@@ -331,9 +331,9 @@ private class LoggerSObjectHandler_Tests {
 
         mockHandler.execute();
 
-        System.assertEquals(1, mockHandler.executionCount);
-        System.assertEquals(1, mockHandler.getPluginConfigurations().size(), mockHandler.getPluginConfigurations());
-        System.assertEquals(0, mockHandler.getExecutedApexPlugins().size(), mockHandler.getExecutedApexPlugins());
+        System.Assert.areEqual(1, mockHandler.executionCount);
+        System.Assert.areEqual(1, mockHandler.getPluginConfigurations().size(), mockHandler.getPluginConfigurations().toString());
+        System.Assert.areEqual(0, mockHandler.getExecutedApexPlugins().size(), mockHandler.getExecutedApexPlugins().toString());
     }
 
     public class MockDefaultImplementationSObjectHandler extends LoggerSObjectHandler {

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerSObjectHandler_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerSObjectHandler_Tests.cls
@@ -74,7 +74,7 @@ private class LoggerSObjectHandler_Tests {
         LoggerTriggerableContext customContext = new LoggerTriggerableContext(
             Schema.User.SObjectType,
             TriggerOperation.BEFORE_INSERT,
-            new List<User>{ new User(Id = UserInfo.getUserId(), Email = UserInfo.getUserEmail()) }
+            new List<User>{ new User(Id = System.UserInfo.getUserId(), Email = System.UserInfo.getUserEmail()) }
         );
         System.Assert.areNotEqual(originalContext, customContext);
 

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerTriggerableContext_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerTriggerableContext_Tests.cls
@@ -26,16 +26,16 @@ private class LoggerTriggerableContext_Tests {
 
         LoggerTriggerableContext context = new LoggerTriggerableContext(sobjectType, triggerOperationType, newUsers, null, null);
 
-        System.assertEquals(sobjectType, context.sobjectType);
-        System.assertEquals(sobjectType.getDescribe().getName(), context.sobjectTypeName);
-        System.assertEquals(triggerOperationType, context.triggerOperationType);
-        System.assertEquals(newUsers, context.triggerNew);
-        System.assertEquals(null, context.triggerNewMap);
-        System.assertEquals(null, context.triggerOldMap);
-        System.assertEquals(newUsers.size(), context.triggerRecords.size());
+        System.Assert.areEqual(sobjectType, context.sobjectType);
+        System.Assert.areEqual(sobjectType.getDescribe().getName(), context.sobjectTypeName);
+        System.Assert.areEqual(triggerOperationType, context.triggerOperationType);
+        System.Assert.areEqual(newUsers, context.triggerNew);
+        System.Assert.isNull(context.triggerNewMap);
+        System.Assert.isNull(context.triggerOldMap);
+        System.Assert.areEqual(newUsers.size(), context.triggerRecords.size());
         for (Integer i = 0; i < newUsers.size(); i++) {
-            System.assertEquals(newUsers.get(i), context.triggerRecords.get(i).triggerRecordNew);
-            System.assertEquals(null, context.triggerRecords.get(i).triggerRecordOld);
+            System.Assert.areEqual(newUsers.get(i), context.triggerRecords.get(i).triggerRecordNew);
+            System.Assert.isNull(context.triggerRecords.get(i).triggerRecordOld);
         }
     }
 
@@ -54,17 +54,17 @@ private class LoggerTriggerableContext_Tests {
 
         LoggerTriggerableContext context = new LoggerTriggerableContext(sobjectType, triggerOperationType, updatedUsers, newUsersMap, oldUsersMap);
 
-        System.assertEquals(sobjectType, context.sobjectType);
-        System.assertEquals(sobjectType.getDescribe().getName(), context.sobjectTypeName);
-        System.assertEquals(triggerOperationType, context.triggerOperationType);
-        System.assertEquals(updatedUsers, context.triggerNew);
-        System.assertEquals(newUsersMap, context.triggerNewMap);
-        System.assertEquals(oldUsersMap, context.triggerOldMap);
-        System.assertEquals(updatedUsers.size(), context.triggerRecords.size());
+        System.Assert.areEqual(sobjectType, context.sobjectType);
+        System.Assert.areEqual(sobjectType.getDescribe().getName(), context.sobjectTypeName);
+        System.Assert.areEqual(triggerOperationType, context.triggerOperationType);
+        System.Assert.areEqual(updatedUsers, context.triggerNew);
+        System.Assert.areEqual(newUsersMap, context.triggerNewMap);
+        System.Assert.areEqual(oldUsersMap, context.triggerOldMap);
+        System.Assert.areEqual(updatedUsers.size(), context.triggerRecords.size());
         for (Integer i = 0; i < updatedUsers.size(); i++) {
             User user = updatedUsers.get(i);
-            System.assertEquals(user, context.triggerRecords.get(i).triggerRecordNew);
-            System.assertEquals(oldUsersMap.get(user.Id), context.triggerRecords.get(i).triggerRecordOld);
+            System.Assert.areEqual(user, context.triggerRecords.get(i).triggerRecordNew);
+            System.Assert.areEqual(oldUsersMap.get(user.Id), context.triggerRecords.get(i).triggerRecordOld);
         }
     }
 
@@ -81,17 +81,17 @@ private class LoggerTriggerableContext_Tests {
 
         LoggerTriggerableContext context = new LoggerTriggerableContext(sobjectType, triggerOperationType, null, null, deletedLogsMap);
 
-        System.assertEquals(sobjectType, context.sobjectType);
-        System.assertEquals(sobjectType.getDescribe().getName(), context.sobjectTypeName);
-        System.assertEquals(triggerOperationType, context.triggerOperationType);
-        System.assertEquals(null, context.triggerNew);
-        System.assertEquals(null, context.triggerNewMap);
-        System.assertEquals(deletedLogsMap, context.triggerOldMap);
-        System.assertEquals(deletedLogsMap.size(), context.triggerRecords.size());
+        System.Assert.areEqual(sobjectType, context.sobjectType);
+        System.Assert.areEqual(sobjectType.getDescribe().getName(), context.sobjectTypeName);
+        System.Assert.areEqual(triggerOperationType, context.triggerOperationType);
+        System.Assert.isNull(context.triggerNew);
+        System.Assert.isNull(context.triggerNewMap);
+        System.Assert.areEqual(deletedLogsMap, context.triggerOldMap);
+        System.Assert.areEqual(deletedLogsMap.size(), context.triggerRecords.size());
         for (Integer i = 0; i < deletedLogsMap.size(); i++) {
             User deletedLog = deletedLogsMap.values().get(i);
-            System.assertEquals(null, context.triggerRecords.get(i).triggerRecordNew);
-            System.assertEquals(deletedLog, context.triggerRecords.get(i).triggerRecordOld);
+            System.Assert.isNull(context.triggerRecords.get(i).triggerRecordNew);
+            System.Assert.areEqual(deletedLog, context.triggerRecords.get(i).triggerRecordOld);
         }
     }
 }

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -41,7 +41,7 @@ private class Logger_Tests {
     @IsTest
     static void it_should_use_org_default_settings_when_configured() {
         LoggerSettings__c expectedSettings = LoggerSettings__c.getOrgDefaults();
-        expectedSettings.LoggingLevel__c = LoggingLevel.FINEST.name();
+        expectedSettings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
         insert expectedSettings;
         expectedSettings = LoggerSettings__c.getOrgDefaults();
         expectedSettings.Id = null;
@@ -60,7 +60,7 @@ private class Logger_Tests {
         insert LoggerSettings__c.getOrgDefaults();
         LoggerSettings__c expectedSettings = LoggerSettings__c.getOrgDefaults();
         expectedSettings.Id = null;
-        expectedSettings.LoggingLevel__c = LoggingLevel.FINEST.name();
+        expectedSettings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
         expectedSettings.SetupOwnerId = System.UserInfo.getProfileId();
         insert expectedSettings;
         expectedSettings = LoggerSettings__c.getValues(System.UserInfo.getProfileId());
@@ -80,12 +80,12 @@ private class Logger_Tests {
         insert LoggerSettings__c.getOrgDefaults();
         LoggerSettings__c profileSettings = LoggerSettings__c.getOrgDefaults();
         profileSettings.Id = null;
-        profileSettings.LoggingLevel__c = LoggingLevel.DEBUG.name();
+        profileSettings.LoggingLevel__c = System.LoggingLevel.DEBUG.name();
         profileSettings.SetupOwnerId = System.UserInfo.getProfileId();
         insert profileSettings;
         LoggerSettings__c expectedSettings = LoggerSettings__c.getOrgDefaults();
         expectedSettings.Id = null;
-        expectedSettings.LoggingLevel__c = LoggingLevel.FINEST.name();
+        expectedSettings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
         expectedSettings.SetupOwnerId = System.UserInfo.getUserId();
         insert expectedSettings;
         expectedSettings = LoggerSettings__c.getValues(System.UserInfo.getUserId());
@@ -275,13 +275,13 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_revert_to_previous_scenario_rule_when_current_scenario_is_ended() {
-        LoggingLevel originalLoggingLevel = Logger.getUserLoggingLevel();
+        System.LoggingLevel originalLoggingLevel = Logger.getUserLoggingLevel();
         System.Assert.isNull(Logger.getScenario());
         String firstMockScenario = 'some test scenario ';
         LoggerScenarioRule__mdt firstMockScenarioRule = new LoggerScenarioRule__mdt(
             IsEnabled__c = true,
             Scenario__c = firstMockScenario,
-            UserLoggingLevel__c = LoggingLevel.ERROR.name()
+            UserLoggingLevel__c = System.LoggingLevel.ERROR.name()
         );
         LoggerScenarioRule.setMock(firstMockScenarioRule);
         System.Assert.areNotEqual(originalLoggingLevel.name(), firstMockScenarioRule.UserLoggingLevel__c);
@@ -291,7 +291,7 @@ private class Logger_Tests {
         LoggerScenarioRule__mdt secondMockScenarioRule = new LoggerScenarioRule__mdt(
             IsEnabled__c = true,
             Scenario__c = secondMockScenario,
-            UserLoggingLevel__c = LoggingLevel.WARN.name()
+            UserLoggingLevel__c = System.LoggingLevel.WARN.name()
         );
         LoggerScenarioRule.setMock(secondMockScenarioRule);
         System.Assert.areNotEqual(firstMockScenarioRule.UserLoggingLevel__c, secondMockScenarioRule.UserLoggingLevel__c);
@@ -486,10 +486,10 @@ private class Logger_Tests {
         LoggerScenarioRule__mdt scenarioRule = new LoggerScenarioRule__mdt(
             IsEnabled__c = true,
             Scenario__c = 'Some scenario',
-            UserLoggingLevel__c = LoggingLevel.FINER.name()
+            UserLoggingLevel__c = System.LoggingLevel.FINER.name()
         );
         LoggerScenarioRule.setMock(scenarioRule);
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         System.Assert.areNotEqual(scenarioRule.UserLoggingLevel__c, Logger.getUserSettings().LoggingLevel__c);
 
         Logger.setScenario(scenarioRule.Scenario__c);
@@ -527,10 +527,10 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_return_user_logging_level() {
-        LoggingLevel expectedLoggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel expectedLoggingLevel = System.LoggingLevel.FINE;
         Logger.getUserSettings().LoggingLevel__c = expectedLoggingLevel.name();
 
-        LoggingLevel returnedLoggingLevel = Logger.getUserLoggingLevel();
+        System.LoggingLevel returnedLoggingLevel = Logger.getUserLoggingLevel();
 
         System.Assert.areEqual(expectedLoggingLevel, returnedLoggingLevel);
     }
@@ -547,7 +547,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_return_true_when_provided_logging_level_is_enabled() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         Boolean expectedValue = true;
         Logger.getUserSettings().IsEnabled__c = expectedValue;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
@@ -561,7 +561,7 @@ private class Logger_Tests {
     static void it_should_return_true_when_error_logging_level_is_enabled() {
         Boolean expectedValue = true;
         Logger.getUserSettings().IsEnabled__c = expectedValue;
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
 
         Boolean returnedValue = Logger.isErrorEnabled();
 
@@ -572,7 +572,7 @@ private class Logger_Tests {
     static void it_should_return_true_when_warn_logging_level_is_enabled() {
         Boolean expectedValue = true;
         Logger.getUserSettings().IsEnabled__c = expectedValue;
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.WARN.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.WARN.name();
 
         Boolean returnedValue = Logger.isWarnEnabled();
 
@@ -583,7 +583,7 @@ private class Logger_Tests {
     static void it_should_return_true_when_info_logging_level_is_enabled() {
         Boolean expectedValue = true;
         Logger.getUserSettings().IsEnabled__c = expectedValue;
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.INFO.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.INFO.name();
 
         Boolean returnedValue = Logger.isInfoEnabled();
 
@@ -594,7 +594,7 @@ private class Logger_Tests {
     static void it_should_return_true_when_debug_logging_level_is_enabled() {
         Boolean expectedValue = true;
         Logger.getUserSettings().IsEnabled__c = expectedValue;
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.DEBUG.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.DEBUG.name();
 
         Boolean returnedValue = Logger.isDebugEnabled();
 
@@ -605,7 +605,7 @@ private class Logger_Tests {
     static void it_should_return_true_when_fine_logging_level_is_enabled() {
         Boolean expectedValue = true;
         Logger.getUserSettings().IsEnabled__c = expectedValue;
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.FINE.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.FINE.name();
 
         Boolean returnedValue = Logger.isFineEnabled();
 
@@ -616,7 +616,7 @@ private class Logger_Tests {
     static void it_should_return_true_when_finer_logging_level_is_enabled() {
         Boolean expectedValue = true;
         Logger.getUserSettings().IsEnabled__c = expectedValue;
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.FINER.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.FINER.name();
 
         Boolean returnedValue = Logger.isFinerEnabled();
 
@@ -627,7 +627,7 @@ private class Logger_Tests {
     static void it_should_return_true_when_finest_logging_level_is_enabled() {
         Boolean expectedValue = true;
         Logger.getUserSettings().IsEnabled__c = expectedValue;
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.FINEST.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.FINEST.name();
 
         Boolean returnedValue = Logger.isFinestEnabled();
 
@@ -652,7 +652,7 @@ private class Logger_Tests {
         System.Test.startTest();
 
         Logger.getUserSettings().IsEnabled__c = true;
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.DEBUG.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.DEBUG.name();
 
         Logger.suspendSaving();
 
@@ -674,7 +674,7 @@ private class Logger_Tests {
         System.Test.startTest();
 
         Logger.getUserSettings().IsEnabled__c = true;
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.FINEST.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.FINEST.name();
 
         Integer logEntriesToCreate = 4;
 
@@ -725,7 +725,7 @@ private class Logger_Tests {
         Datetime originalTimestamp;
         System.runAs(currentUser) {
             Logger.getUserSettings().IsEnabled__c = true;
-            Logger.getUserSettings().LoggingLevel__c = LoggingLevel.INFO.name();
+            Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.INFO.name();
 
             LogEntryEventBuilder builder = Logger.info('test log entry');
 
@@ -756,7 +756,7 @@ private class Logger_Tests {
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
 
-        setUserLoggingLevel(LoggingLevel.DEBUG);
+        setUserLoggingLevel(System.LoggingLevel.DEBUG);
 
         Logger.getUserSettings().IsSavingEnabled__c = false;
 
@@ -787,7 +787,7 @@ private class Logger_Tests {
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
 
-        setUserLoggingLevel(LoggingLevel.DEBUG);
+        setUserLoggingLevel(System.LoggingLevel.DEBUG);
 
         Logger.getUserSettings().DefaultSaveMethod__c = 'EVENT_BUS';
 
@@ -818,7 +818,7 @@ private class Logger_Tests {
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
 
-        setUserLoggingLevel(LoggingLevel.DEBUG);
+        setUserLoggingLevel(System.LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
@@ -845,7 +845,7 @@ private class Logger_Tests {
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
 
-        setUserLoggingLevel(LoggingLevel.DEBUG);
+        setUserLoggingLevel(System.LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
@@ -875,7 +875,7 @@ private class Logger_Tests {
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.DEBUG.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.DEBUG.name();
         Logger.getUserSettings().DefaultSaveMethod__c = 'QUEUEABLE';
         upsert Logger.getUserSettings();
 
@@ -908,7 +908,7 @@ private class Logger_Tests {
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
 
-        setUserLoggingLevel(LoggingLevel.DEBUG);
+        setUserLoggingLevel(System.LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
@@ -937,7 +937,7 @@ private class Logger_Tests {
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
 
-        setUserLoggingLevel(LoggingLevel.DEBUG);
+        setUserLoggingLevel(System.LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
@@ -971,7 +971,7 @@ private class Logger_Tests {
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
 
-        setUserLoggingLevel(LoggingLevel.DEBUG);
+        setUserLoggingLevel(System.LoggingLevel.DEBUG);
 
         Logger.getUserSettings().DefaultSaveMethod__c = 'REST';
 
@@ -1001,7 +1001,7 @@ private class Logger_Tests {
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
 
-        setUserLoggingLevel(LoggingLevel.DEBUG);
+        setUserLoggingLevel(System.LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
@@ -1027,7 +1027,7 @@ private class Logger_Tests {
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
 
-        setUserLoggingLevel(LoggingLevel.DEBUG);
+        setUserLoggingLevel(System.LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
@@ -1056,7 +1056,7 @@ private class Logger_Tests {
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
 
-        setUserLoggingLevel(LoggingLevel.DEBUG);
+        setUserLoggingLevel(System.LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
@@ -1090,8 +1090,8 @@ private class Logger_Tests {
             )
         );
         Logger.getUserSettings().DefaultSaveMethod__c = Logger.SaveMethod.SYNCHRONOUS_DML.name();
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.DEBUG.name();
-        System.Assert.areEqual(LoggingLevel.DEBUG, Logger.getUserLoggingLevel());
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.DEBUG.name();
+        System.Assert.areEqual(System.LoggingLevel.DEBUG, Logger.getUserLoggingLevel());
         System.Assert.areEqual(Logger.SaveMethod.SYNCHRONOUS_DML, Logger.getSaveMethod());
         List<LogEntryEvent__e> logEntryEvents = new List<LogEntryEvent__e>();
         logEntryEvents.add(Logger.debug('test log entry').getLogEntryEvent());
@@ -1250,7 +1250,7 @@ private class Logger_Tests {
     // Start ERROR methods for LogMessage
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_successful_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1274,7 +1274,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_failed_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1298,7 +1298,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_deleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1322,7 +1322,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_successful_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1346,7 +1346,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_failed_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1370,7 +1370,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_saveResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1394,7 +1394,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_successful_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1418,7 +1418,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_failed_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1442,7 +1442,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_undeleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1466,7 +1466,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_successful_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1490,7 +1490,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_failed_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1514,7 +1514,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_successful_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1538,7 +1538,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_failed_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1562,7 +1562,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_upsertResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1586,7 +1586,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1608,7 +1608,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_recordId_and_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1630,7 +1630,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1652,7 +1652,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_record_and_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1674,7 +1674,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1696,7 +1696,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_recordList_and_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1719,7 +1719,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1742,7 +1742,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1766,7 +1766,7 @@ private class Logger_Tests {
     // Start ERROR methods for String
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_successful_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1790,7 +1790,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_failed_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1814,7 +1814,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_successful_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1838,7 +1838,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_failed_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1862,7 +1862,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_successful_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1886,7 +1886,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_failed_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1910,7 +1910,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_successful_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1934,7 +1934,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_failed_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1958,7 +1958,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_successful_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -1982,7 +1982,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_failed_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2006,7 +2006,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_deleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2030,7 +2030,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_saveResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2054,7 +2054,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_undeleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2078,7 +2078,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_upsertResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2102,7 +2102,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2124,7 +2124,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_recordId_and_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2146,7 +2146,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2168,7 +2168,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_record_and_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2190,7 +2190,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2212,7 +2212,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_recordList_and_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2235,7 +2235,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2258,7 +2258,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2281,7 +2281,7 @@ private class Logger_Tests {
     // Start WARN methods for LogMessage
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_successful_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2305,7 +2305,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_failed_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2329,7 +2329,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_successful_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2353,7 +2353,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_failed_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2377,7 +2377,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_successful_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2401,7 +2401,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_failed_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2425,7 +2425,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_successful_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2449,7 +2449,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_failed_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2473,7 +2473,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_successful_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2497,7 +2497,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_failed_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2521,7 +2521,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2543,7 +2543,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_recordId_and_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2565,7 +2565,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2587,7 +2587,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_record_and_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2609,7 +2609,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2631,7 +2631,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_recordList_and_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2654,7 +2654,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2677,7 +2677,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2701,7 +2701,7 @@ private class Logger_Tests {
     // Start WARN methods for String
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_successful_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2725,7 +2725,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_failed_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2749,7 +2749,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_successful_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2773,7 +2773,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_failed_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2797,7 +2797,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_successful_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2821,7 +2821,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_failed_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2845,7 +2845,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_successful_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2869,7 +2869,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_failed_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2893,7 +2893,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_successful_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2917,7 +2917,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_failed_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2941,7 +2941,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2963,7 +2963,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_recordId_and_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -2985,7 +2985,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3007,7 +3007,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_record_and_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3029,7 +3029,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3051,7 +3051,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_recordList_and_exception() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3074,7 +3074,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3097,7 +3097,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3121,7 +3121,7 @@ private class Logger_Tests {
     // Start INFO methods for LogMessage
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3145,7 +3145,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3169,7 +3169,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3193,7 +3193,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3217,7 +3217,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3241,7 +3241,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_deleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3265,7 +3265,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_saveResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3289,7 +3289,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_undeleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3313,7 +3313,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_upsertResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3337,7 +3337,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3359,7 +3359,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3381,7 +3381,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3404,7 +3404,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3428,7 +3428,7 @@ private class Logger_Tests {
     // Start INFO methods for String
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3452,7 +3452,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3476,7 +3476,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3500,7 +3500,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3524,7 +3524,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3548,7 +3548,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_deleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3572,7 +3572,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_saveResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3596,7 +3596,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_undeleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3620,7 +3620,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_upsertResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3644,7 +3644,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3666,7 +3666,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3688,7 +3688,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3711,7 +3711,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3735,7 +3735,7 @@ private class Logger_Tests {
     // Start DEBUG methods for LogMessage
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3759,7 +3759,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3783,7 +3783,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3807,7 +3807,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3831,7 +3831,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3855,7 +3855,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_deleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3879,7 +3879,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_saveResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3903,7 +3903,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_undeleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3927,7 +3927,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_upsertResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3951,7 +3951,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3973,7 +3973,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -3995,7 +3995,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4018,7 +4018,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4042,7 +4042,7 @@ private class Logger_Tests {
     // Start DEBUG methods for String
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4066,7 +4066,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4090,7 +4090,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4114,7 +4114,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4138,7 +4138,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4162,7 +4162,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_deleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4186,7 +4186,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_saveResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4210,7 +4210,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_undeleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4234,7 +4234,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_upsertResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4258,7 +4258,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4280,7 +4280,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4302,7 +4302,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4325,7 +4325,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4349,7 +4349,7 @@ private class Logger_Tests {
     // Start FINE methods for LogMessage
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4373,7 +4373,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4397,7 +4397,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4421,7 +4421,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4445,7 +4445,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4469,7 +4469,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_deleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4493,7 +4493,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_saveResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4517,7 +4517,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_undeleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4541,7 +4541,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_upsertResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4565,7 +4565,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4587,7 +4587,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4609,7 +4609,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4632,7 +4632,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4656,7 +4656,7 @@ private class Logger_Tests {
     // Start FINE methods for String
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4680,7 +4680,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4704,7 +4704,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4728,7 +4728,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4752,7 +4752,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4776,7 +4776,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_deleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4800,7 +4800,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_saveResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4824,7 +4824,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_undeleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4848,7 +4848,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_upsertResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4872,7 +4872,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4894,7 +4894,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4916,7 +4916,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4939,7 +4939,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4963,7 +4963,7 @@ private class Logger_Tests {
     // Start FINER methods for LogMessage
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -4987,7 +4987,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5011,7 +5011,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5035,7 +5035,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5059,7 +5059,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5083,7 +5083,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_deleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5107,7 +5107,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_saveResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5131,7 +5131,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_undeleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5155,7 +5155,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_upsertResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5179,7 +5179,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5201,7 +5201,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5223,7 +5223,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5246,7 +5246,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5270,7 +5270,7 @@ private class Logger_Tests {
     // Start FINER methods for String
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5294,7 +5294,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5318,7 +5318,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5342,7 +5342,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5366,7 +5366,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5390,7 +5390,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_deleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5414,7 +5414,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_saveResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5438,7 +5438,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_undeleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5462,7 +5462,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_upsertResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5486,7 +5486,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5508,7 +5508,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5530,7 +5530,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5553,7 +5553,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5577,7 +5577,7 @@ private class Logger_Tests {
     // Start FINEST methods for LogMessage
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5601,7 +5601,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5625,7 +5625,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5649,7 +5649,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5673,7 +5673,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5697,7 +5697,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_deleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5721,7 +5721,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_saveResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5745,7 +5745,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_undeleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5769,7 +5769,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_upsertResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5793,7 +5793,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5815,7 +5815,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5837,7 +5837,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5860,7 +5860,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5884,7 +5884,7 @@ private class Logger_Tests {
     // Start FINEST methods for String
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_deleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5908,7 +5908,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_saveResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5932,7 +5932,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_undeleteResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5956,7 +5956,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_upsertResult_when_insert() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -5980,7 +5980,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_upsertResult_when_update() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6004,7 +6004,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_deleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6028,7 +6028,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_saveResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6052,7 +6052,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_undeleteResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6076,7 +6076,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_upsertResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6100,7 +6100,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_recordId() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6122,7 +6122,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_record() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6144,7 +6144,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_recordList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6167,7 +6167,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6191,7 +6191,7 @@ private class Logger_Tests {
     // Start logDatabaseErrors() test methods
     @IsTest
     static void it_should_skip_logging_database_deleteResult_for_logMessage_when_logging_level_is_disabled() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
@@ -6200,7 +6200,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, deleteResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, deleteResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6209,7 +6209,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_deleteResult_for_logMessage_when_no_errors_found() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
@@ -6218,7 +6218,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, deleteResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, deleteResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6227,7 +6227,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_log_database_deleteResult_for_logMessage_when_isSuccess_is_false() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
@@ -6248,7 +6248,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_deleteResult_for_string_message_when_logging_level_is_disabled() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
@@ -6257,7 +6257,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, deleteResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, deleteResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6266,7 +6266,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_deleteResult_for_string_message_when_no_errors_found() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
@@ -6275,7 +6275,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, deleteResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, deleteResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6284,7 +6284,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_log_database_deleteResult_for_string_message_when_isSuccess_is_false() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
@@ -6305,7 +6305,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_mergeResult_for_logMessage_when_logging_level_is_disabled() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
@@ -6314,7 +6314,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, mergeResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, mergeResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6323,7 +6323,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_mergeResult_for_logMessage_when_no_errors_found() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
@@ -6332,7 +6332,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, mergeResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, mergeResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6341,7 +6341,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_log_database_mergeResult_for_logMessage_when_isSuccess_is_false() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
@@ -6362,7 +6362,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_mergeResult_for_string_message_when_logging_level_is_disabled() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
@@ -6371,7 +6371,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, mergeResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, mergeResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6380,7 +6380,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_mergeResult_for_string_message_when_no_errors_found() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
@@ -6389,7 +6389,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, mergeResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, mergeResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6398,7 +6398,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_log_database_mergeResult_for_string_message_when_isSuccess_is_false() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
@@ -6419,7 +6419,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_saveResult_for_logMessage_when_logging_level_is_disabled() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
@@ -6428,7 +6428,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, saveResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, saveResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6437,7 +6437,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_saveResult_for_logMessage_when_no_errors_found() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
@@ -6446,7 +6446,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, saveResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, saveResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6455,7 +6455,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_log_database_saveResult_for_logMessage_when_isSuccess_is_false() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
@@ -6476,7 +6476,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_saveResult_for_string_message_when_logging_level_is_disabled() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
@@ -6485,7 +6485,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, saveResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, saveResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6494,7 +6494,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_saveResult_for_string_message_when_no_errors_found() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
@@ -6503,7 +6503,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, saveResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, saveResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6512,7 +6512,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_log_database_saveResult_for_string_message_when_isSuccess_is_false() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
@@ -6533,7 +6533,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_upsertResult_for_logMessage_when_logging_level_is_disabled() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
@@ -6542,7 +6542,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, upsertResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, upsertResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6551,7 +6551,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_upsertResult_for_logMessage_when_no_errors_found() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
@@ -6560,7 +6560,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, upsertResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, upsertResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6569,7 +6569,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_log_database_upsertResult_for_logMessage_when_isSuccess_is_false() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
@@ -6590,7 +6590,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_upsertResult_for_string_message_when_logging_level_is_disabled() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
@@ -6599,7 +6599,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, upsertResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, upsertResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6608,7 +6608,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_upsertResult_for_string_message_when_no_errors_found() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
@@ -6617,7 +6617,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, upsertResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, upsertResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6626,7 +6626,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_log_database_upsertResult_for_string_message_when_isSuccess_is_false() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
@@ -6647,7 +6647,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_undeleteResult_for_logMessage_when_logging_level_is_disabled() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
@@ -6656,7 +6656,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, undeleteResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, undeleteResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6665,7 +6665,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_undeleteResult_for_logMessage_when_no_errors_found() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
@@ -6674,7 +6674,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, undeleteResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, undeleteResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6683,7 +6683,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_log_database_undeleteResult_for_logMessage_when_isSuccess_is_false() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
         Id recordId = System.UserInfo.getUserId();
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
@@ -6704,7 +6704,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_undeleteResult_for_string_message_when_logging_level_is_disabled() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
@@ -6713,7 +6713,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, undeleteResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, undeleteResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6722,7 +6722,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_skip_logging_database_undeleteResult_for_string_message_when_no_errors_found() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
@@ -6731,7 +6731,7 @@ private class Logger_Tests {
         System.Assert.areEqual(2, undeleteResults.size());
         System.Assert.areEqual(0, Logger.getBufferSize());
 
-        Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
+        Logger.getUserSettings().LoggingLevel__c = System.LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, undeleteResults);
 
         System.Assert.areEqual(0, Logger.getBufferSize());
@@ -6740,7 +6740,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_log_database_undeleteResult_for_string_message_when_isSuccess_is_false() {
-        LoggingLevel logEntryLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLevel = System.LoggingLevel.WARN;
         String message = 'Some message';
         Id recordId = System.UserInfo.getUserId();
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
@@ -6763,9 +6763,9 @@ private class Logger_Tests {
     // Start newEntry for LogMessage test methods
     @IsTest
     static void it_should_add_a_new_entry_for_loggingLevel_with_logMessage_and_shouldSave_override() {
-        LoggingLevel userLoggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(userLoggingLevel);
-        LoggingLevel logEntryLoggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel logEntryLoggingLevel = System.LoggingLevel.FINEST;
         System.Assert.isFalse(Logger.meetsUserLoggingLevel(logEntryLoggingLevel));
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6789,9 +6789,9 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_not_add_a_new_entry_for_loggingLevel_with_logMessage_and_shouldNotSave_override() {
-        LoggingLevel userLoggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(userLoggingLevel);
-        LoggingLevel logEntryLoggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel logEntryLoggingLevel = System.LoggingLevel.FINEST;
         System.Assert.isFalse(Logger.meetsUserLoggingLevel(logEntryLoggingLevel));
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6809,7 +6809,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_new_entry_for_loggingLevel_with_logMessage() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6834,9 +6834,9 @@ private class Logger_Tests {
     // Start newEntry for String test methods
     @IsTest
     static void it_should_add_a_new_entry_for_loggingLevel_with_string_and_shouldSave_override() {
-        LoggingLevel userLoggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(userLoggingLevel);
-        LoggingLevel logEntryLoggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel logEntryLoggingLevel = System.LoggingLevel.FINEST;
         System.Assert.isFalse(Logger.meetsUserLoggingLevel(logEntryLoggingLevel));
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6860,9 +6860,9 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_not_add_a_new_entry_for_loggingLevel_with_string_and_shouldNotSave_override() {
-        LoggingLevel userLoggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel userLoggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(userLoggingLevel);
-        LoggingLevel logEntryLoggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel logEntryLoggingLevel = System.LoggingLevel.FINEST;
         System.Assert.isFalse(Logger.meetsUserLoggingLevel(logEntryLoggingLevel));
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6880,7 +6880,7 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_add_a_new_entry_for_loggingLevel_with_string() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
         System.Assert.areEqual(0, Logger.getBufferSize());
 
@@ -6905,20 +6905,20 @@ private class Logger_Tests {
     // Start tests for utility methods
     @IsTest
     static void it_should_return_logging_levels_for_string_names() {
-        System.Assert.areEqual(LoggingLevel.DEBUG, Logger.getLoggingLevel('fake'));
-        System.Assert.areEqual(LoggingLevel.NONE, Logger.getLoggingLevel('none'));
-        System.Assert.areEqual(LoggingLevel.ERROR, Logger.getLoggingLevel('error'));
-        System.Assert.areEqual(LoggingLevel.WARN, Logger.getLoggingLevel('warn'));
-        System.Assert.areEqual(LoggingLevel.INFO, Logger.getLoggingLevel('info'));
-        System.Assert.areEqual(LoggingLevel.DEBUG, Logger.getLoggingLevel('debug'));
-        System.Assert.areEqual(LoggingLevel.FINE, Logger.getLoggingLevel('fine'));
-        System.Assert.areEqual(LoggingLevel.FINER, Logger.getLoggingLevel('finer'));
-        System.Assert.areEqual(LoggingLevel.FINEST, Logger.getLoggingLevel('finest'));
+        System.Assert.areEqual(System.LoggingLevel.DEBUG, Logger.getLoggingLevel('fake'));
+        System.Assert.areEqual(System.LoggingLevel.NONE, Logger.getLoggingLevel('none'));
+        System.Assert.areEqual(System.LoggingLevel.ERROR, Logger.getLoggingLevel('error'));
+        System.Assert.areEqual(System.LoggingLevel.WARN, Logger.getLoggingLevel('warn'));
+        System.Assert.areEqual(System.LoggingLevel.INFO, Logger.getLoggingLevel('info'));
+        System.Assert.areEqual(System.LoggingLevel.DEBUG, Logger.getLoggingLevel('debug'));
+        System.Assert.areEqual(System.LoggingLevel.FINE, Logger.getLoggingLevel('fine'));
+        System.Assert.areEqual(System.LoggingLevel.FINER, Logger.getLoggingLevel('finer'));
+        System.Assert.areEqual(System.LoggingLevel.FINEST, Logger.getLoggingLevel('finest'));
     }
     // End tests for utility methods
 
     // Helper methods
-    static void setUserLoggingLevel(LoggingLevel loggingLevel) {
+    static void setUserLoggingLevel(System.LoggingLevel loggingLevel) {
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
     }
 

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -12,7 +12,7 @@ private class Logger_Tests {
 
         String returnedVersionNumber = Logger.getVersionNumber();
 
-        System.assertEquals(expectedVersionNumber, returnedVersionNumber);
+        System.Assert.areEqual(expectedVersionNumber, returnedVersionNumber);
     }
 
     @IsTest
@@ -22,7 +22,7 @@ private class Logger_Tests {
 
         String returnedNamespacePrefix = Logger.getNamespacePrefix();
 
-        System.assertEquals(expectedNamespacePrefix, returnedNamespacePrefix);
+        System.Assert.areEqual(expectedNamespacePrefix, returnedNamespacePrefix);
     }
 
     @IsTest
@@ -33,9 +33,9 @@ private class Logger_Tests {
         LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
         List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
-        System.assertEquals(0, existingSettings.size(), 'LoggerSettings__c record should not have been saved');
-        System.assertEquals(expectedSettings, returnedSettings);
-        System.assertEquals(null, returnedSettings.Id);
+        System.Assert.areEqual(0, existingSettings.size(), 'LoggerSettings__c record should not have been saved');
+        System.Assert.areEqual(expectedSettings, returnedSettings);
+        System.Assert.isNull(returnedSettings.Id);
     }
 
     @IsTest
@@ -50,9 +50,9 @@ private class Logger_Tests {
         LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
         List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
-        System.assertEquals(1, existingSettings.size(), 'LoggerSettings__c org defaults should have been saved');
-        System.assertEquals(expectedSettings, returnedSettings);
-        System.assertEquals(null, returnedSettings.Id);
+        System.Assert.areEqual(1, existingSettings.size(), 'LoggerSettings__c org defaults should have been saved');
+        System.Assert.areEqual(expectedSettings, returnedSettings);
+        System.Assert.isNull(returnedSettings.Id);
     }
 
     @IsTest
@@ -70,9 +70,9 @@ private class Logger_Tests {
         LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
         List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
-        System.assertEquals(2, existingSettings.size(), 'LoggerSettings__c org defaults and profile settings should have been saved');
-        System.assertEquals(expectedSettings, returnedSettings);
-        System.assertEquals(null, returnedSettings.Id);
+        System.Assert.areEqual(2, existingSettings.size(), 'LoggerSettings__c org defaults and profile settings should have been saved');
+        System.Assert.areEqual(expectedSettings, returnedSettings);
+        System.Assert.isNull(returnedSettings.Id);
     }
 
     @IsTest
@@ -93,9 +93,9 @@ private class Logger_Tests {
         LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
         List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
-        System.assertEquals(3, existingSettings.size(), 'LoggerSettings__c org defaults, profile settings, and user settings should have been saved');
-        System.assertEquals(expectedSettings, returnedSettings);
-        System.assertEquals(expectedSettings.Id, returnedSettings.Id);
+        System.Assert.areEqual(3, existingSettings.size(), 'LoggerSettings__c org defaults, profile settings, and user settings should have been saved');
+        System.Assert.areEqual(expectedSettings, returnedSettings);
+        System.Assert.areEqual(expectedSettings.Id, returnedSettings.Id);
     }
 
     @IsTest
@@ -104,9 +104,9 @@ private class Logger_Tests {
 
         Logger.Uuid uuid = new Logger.Uuid();
 
-        System.assertEquals(36, uuid.getValue().length());
+        System.Assert.areEqual(36, uuid.getValue().length());
         Matcher matcher = pattern.matcher(uuid.getValue());
-        System.assert(matcher.matches(), 'Generated UUID=' + uuid.getValue());
+        System.Assert.isTrue(matcher.matches(), 'Generated UUID=' + uuid.getValue());
     }
 
     @IsTest
@@ -115,10 +115,10 @@ private class Logger_Tests {
 
         String transactionId = Logger.getTransactionId();
 
-        System.assert(String.isNotBlank(transactionId));
-        System.assertEquals(36, transactionId.length());
+        System.Assert.isTrue(String.isNotBlank(transactionId));
+        System.Assert.areEqual(36, transactionId.length());
         Matcher matcher = pattern.matcher(transactionId);
-        System.assert(matcher.matches(), 'Generated UUID=' + transactionId);
+        System.Assert.isTrue(matcher.matches(), 'Generated UUID=' + transactionId);
     }
 
     @IsTest
@@ -126,8 +126,8 @@ private class Logger_Tests {
         for (Integer i = 0; i < 10; i++) {
             LogEntryEventBuilder builder = Logger.info('my log entry');
 
-            System.assertNotEquals(null, builder.getLogEntryEvent().LoggerVersionNumber__c);
-            System.assertEquals(Logger.CURRENT_VERSION_NUMBER, builder.getLogEntryEvent().LoggerVersionNumber__c);
+            System.Assert.isNotNull(builder.getLogEntryEvent().LoggerVersionNumber__c);
+            System.Assert.areEqual(Logger.CURRENT_VERSION_NUMBER, builder.getLogEntryEvent().LoggerVersionNumber__c);
         }
     }
 
@@ -136,7 +136,7 @@ private class Logger_Tests {
         for (Integer i = 0; i < 5; i++) {
             LogEntryEventBuilder builder = Logger.info('my log entry');
 
-            System.assertEquals(i + 1, builder.getLogEntryEvent().TransactionEntryNumber__c);
+            System.Assert.areEqual(i + 1, builder.getLogEntryEvent().TransactionEntryNumber__c);
         }
     }
 
@@ -146,7 +146,7 @@ private class Logger_Tests {
         for (Integer i = 0; i < 5; i++) {
             LogEntryEventBuilder builder = Logger.info('my log entry');
 
-            System.assertEquals(expectedRequestId, builder.getLogEntryEvent().RequestId__c);
+            System.Assert.areEqual(expectedRequestId, builder.getLogEntryEvent().RequestId__c);
         }
     }
 
@@ -159,7 +159,7 @@ private class Logger_Tests {
 
         String currentScenario = Logger.getScenario();
 
-        System.assertEquals(
+        System.Assert.areEqual(
             mockScenario,
             currentScenario,
             'The value of LoggerSettings__c.DefaultScenario__c should have been used as the current transaction scenario'
@@ -172,14 +172,14 @@ private class Logger_Tests {
 
         Logger.setScenario(mockScenario);
 
-        System.assertEquals(mockScenario, Logger.getScenario(), 'The mock scenario should have been used as the current transaction scenario');
+        System.Assert.areEqual(mockScenario, Logger.getScenario(), 'The mock scenario should have been used as the current transaction scenario');
     }
 
     @IsTest
     static void it_should_use_the_first_specified_scenario_as_transaction_scenario_when_parameter_is_true() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'UseFirstSpecifiedScenario', Value__c = String.valueOf(true)));
-        System.assertEquals(true, LoggerParameter.USE_FIRST_SCENARIO_FOR_TRANSACTION);
+        System.Assert.isTrue(LoggerParameter.USE_FIRST_SCENARIO_FOR_TRANSACTION);
         String firstMockScenario = 'the first test scenario specified for this transaction';
         String secondMockScenario = 'the second test scenario specified for this transaction';
 
@@ -189,9 +189,9 @@ private class Logger_Tests {
         Logger.info('world');
         Logger.saveLog();
 
-        System.assertEquals(2, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(2, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         for (LogEntryEvent__e logEntryEvent : (List<LogEntryEvent__e>) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents()) {
-            System.assertEquals(firstMockScenario, logEntryEvent.TransactionScenario__c);
+            System.Assert.areEqual(firstMockScenario, logEntryEvent.TransactionScenario__c);
         }
     }
 
@@ -199,7 +199,7 @@ private class Logger_Tests {
     static void it_should_use_the_last_specified_scenario_as_transaction_scenario_when_parameter_is_false() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'UseFirstSpecifiedScenario', Value__c = String.valueOf(false)));
-        System.assertEquals(false, LoggerParameter.USE_FIRST_SCENARIO_FOR_TRANSACTION);
+        System.Assert.isFalse(LoggerParameter.USE_FIRST_SCENARIO_FOR_TRANSACTION);
         String firstMockScenario = 'the first test scenario specified for this transaction';
         String secondMockScenario = 'the second test scenario specified for this transaction';
 
@@ -209,9 +209,9 @@ private class Logger_Tests {
         Logger.info('world');
         Logger.saveLog();
 
-        System.assertEquals(2, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(2, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         for (LogEntryEvent__e logEntryEvent : (List<LogEntryEvent__e>) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents()) {
-            System.assertEquals(secondMockScenario, logEntryEvent.TransactionScenario__c, 'The last specified scenario should have been used');
+            System.Assert.areEqual(secondMockScenario, logEntryEvent.TransactionScenario__c, 'The last specified scenario should have been used');
         }
     }
 
@@ -227,56 +227,56 @@ private class Logger_Tests {
         Logger.info('world');
         Logger.saveLog();
 
-        System.assertEquals(2, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(2, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         List<LogEntryEvent__e> publishedLogEntryEvents = (List<LogEntryEvent__e>) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents();
         LogEntryEvent__e firstLogEntryEvent = publishedLogEntryEvents.get(0);
-        System.assertEquals(firstMockScenario, firstLogEntryEvent.EntryScenario__c);
-        System.assertEquals(firstMockScenario, firstLogEntryEvent.TransactionScenario__c);
+        System.Assert.areEqual(firstMockScenario, firstLogEntryEvent.EntryScenario__c);
+        System.Assert.areEqual(firstMockScenario, firstLogEntryEvent.TransactionScenario__c);
         LogEntryEvent__e secondLogEntryEvent = publishedLogEntryEvents.get(1);
-        System.assertEquals(secondMockScenario, secondLogEntryEvent.EntryScenario__c);
-        System.assertEquals(firstMockScenario, secondLogEntryEvent.TransactionScenario__c);
+        System.Assert.areEqual(secondMockScenario, secondLogEntryEvent.EntryScenario__c);
+        System.Assert.areEqual(firstMockScenario, secondLogEntryEvent.TransactionScenario__c);
     }
 
     @IsTest
     static void it_should_end_scenario_when_no_scenario_was_previously_set() {
-        System.assertEquals(null, Logger.getScenario());
+        System.Assert.isNull(Logger.getScenario());
 
         Logger.endScenario('some scenario that was never set');
 
-        System.assertEquals(null, Logger.getScenario());
+        System.Assert.isNull(Logger.getScenario());
     }
 
     @IsTest
     static void it_should_end_scenario_when_specified_scenario_matches() {
-        System.assertEquals(null, Logger.getScenario());
+        System.Assert.isNull(Logger.getScenario());
         String mockScenario = 'some test scenario for this transaction';
         Logger.setScenario(mockScenario);
-        System.assertEquals(mockScenario, Logger.getScenario(), 'The mock scenario should have been set as the current scenario');
+        System.Assert.areEqual(mockScenario, Logger.getScenario(), 'The mock scenario should have been set as the current scenario');
 
         Logger.endScenario(mockScenario);
 
-        System.assertEquals(null, Logger.getScenario(), 'The mock scenario should have been cleared');
+        System.Assert.isNull(Logger.getScenario(), 'The mock scenario should have been cleared');
     }
 
     @IsTest
     static void it_should_revert_to_previous_scenario_when_current_scenario_is_ended() {
-        System.assertEquals(null, Logger.getScenario());
+        System.Assert.isNull(Logger.getScenario());
         String firstMockScenario = 'some test scenario ';
         Logger.setScenario(firstMockScenario);
-        System.assertEquals(firstMockScenario, Logger.getScenario());
+        System.Assert.areEqual(firstMockScenario, Logger.getScenario());
         String secondMockScenario = 'another test scenario ';
         Logger.setScenario(secondMockScenario);
-        System.assertEquals(secondMockScenario, Logger.getScenario());
+        System.Assert.areEqual(secondMockScenario, Logger.getScenario());
 
         Logger.endScenario(secondMockScenario);
 
-        System.assertEquals(firstMockScenario, Logger.getScenario(), 'The scenario should have reverted to the first scenario');
+        System.Assert.areEqual(firstMockScenario, Logger.getScenario(), 'The scenario should have reverted to the first scenario');
     }
 
     @IsTest
     static void it_should_revert_to_previous_scenario_rule_when_current_scenario_is_ended() {
         LoggingLevel originalLoggingLevel = Logger.getUserLoggingLevel();
-        System.assertEquals(null, Logger.getScenario());
+        System.Assert.isNull(Logger.getScenario());
         String firstMockScenario = 'some test scenario ';
         LoggerScenarioRule__mdt firstMockScenarioRule = new LoggerScenarioRule__mdt(
             IsEnabled__c = true,
@@ -284,9 +284,9 @@ private class Logger_Tests {
             UserLoggingLevel__c = LoggingLevel.ERROR.name()
         );
         LoggerScenarioRule.setMock(firstMockScenarioRule);
-        System.assertNotEquals(originalLoggingLevel.name(), firstMockScenarioRule.UserLoggingLevel__c);
+        System.Assert.areNotEqual(originalLoggingLevel.name(), firstMockScenarioRule.UserLoggingLevel__c);
         Logger.setScenario(firstMockScenario);
-        System.assertEquals(firstMockScenario, Logger.getScenario());
+        System.Assert.areEqual(firstMockScenario, Logger.getScenario());
         String secondMockScenario = 'another test scenario ';
         LoggerScenarioRule__mdt secondMockScenarioRule = new LoggerScenarioRule__mdt(
             IsEnabled__c = true,
@@ -294,17 +294,17 @@ private class Logger_Tests {
             UserLoggingLevel__c = LoggingLevel.WARN.name()
         );
         LoggerScenarioRule.setMock(secondMockScenarioRule);
-        System.assertNotEquals(firstMockScenarioRule.UserLoggingLevel__c, secondMockScenarioRule.UserLoggingLevel__c);
+        System.Assert.areNotEqual(firstMockScenarioRule.UserLoggingLevel__c, secondMockScenarioRule.UserLoggingLevel__c);
         Logger.setScenario(secondMockScenario);
-        System.assertEquals(secondMockScenario, Logger.getScenario());
-        System.assertEquals(secondMockScenarioRule.UserLoggingLevel__c, Logger.getUserLoggingLevel().name());
+        System.Assert.areEqual(secondMockScenario, Logger.getScenario());
+        System.Assert.areEqual(secondMockScenarioRule.UserLoggingLevel__c, Logger.getUserLoggingLevel().name());
 
         Logger.endScenario(secondMockScenario);
 
-        System.assertEquals(firstMockScenario, Logger.getScenario(), 'The scenario should have reverted to the first scenario');
-        System.assertEquals(firstMockScenarioRule, LoggerScenarioRule.getInstance(firstMockScenario));
-        System.assertNotEquals(null, LoggerScenarioRule.getInstance(secondMockScenario));
-        System.assertEquals(firstMockScenarioRule.UserLoggingLevel__c, Logger.getUserLoggingLevel().name());
+        System.Assert.areEqual(firstMockScenario, Logger.getScenario(), 'The scenario should have reverted to the first scenario');
+        System.Assert.areEqual(firstMockScenarioRule, LoggerScenarioRule.getInstance(firstMockScenario));
+        System.Assert.isNotNull(LoggerScenarioRule.getInstance(secondMockScenario));
+        System.Assert.areEqual(firstMockScenarioRule.UserLoggingLevel__c, Logger.getUserLoggingLevel().name());
     }
 
     @IsTest
@@ -321,7 +321,7 @@ private class Logger_Tests {
 
         LogEntryEventBuilder builder = new MockClassWithLogging().logSomething();
 
-        System.assertEquals(expectedOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.areEqual(expectedOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
     }
 
     @IsTest
@@ -339,7 +339,7 @@ private class Logger_Tests {
         Logger.ignoreOrigin(ignoredApexClassType);
         LogEntryEventBuilder builder = new MockClassWithLogging().logSomething();
 
-        System.assertEquals(expectedOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
+        System.Assert.areEqual(expectedOriginLocation, builder.getLogEntryEvent().OriginLocation__c);
     }
 
     @IsTest
@@ -350,14 +350,14 @@ private class Logger_Tests {
             Scenario__c = 'Some scenario'
         );
         LoggerScenarioRule.setMock(scenarioRule);
-        System.assertNotEquals(null, LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
-        System.assertNotEquals(Boolean.valueOf(scenarioRule.IsLoggerEnabled__c), Logger.getUserSettings().IsEnabled__c);
-        System.assertNotEquals(Boolean.valueOf(scenarioRule.IsLoggerEnabled__c), Logger.isEnabled());
+        System.Assert.isNotNull(LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
+        System.Assert.areNotEqual(Boolean.valueOf(scenarioRule.IsLoggerEnabled__c), Logger.getUserSettings().IsEnabled__c);
+        System.Assert.areNotEqual(Boolean.valueOf(scenarioRule.IsLoggerEnabled__c), Logger.isEnabled());
 
         Logger.setScenario(scenarioRule.Scenario__c);
 
-        System.assertEquals(Boolean.valueOf(scenarioRule.IsLoggerEnabled__c), Logger.getUserSettings().IsEnabled__c);
-        System.assertEquals(Boolean.valueOf(scenarioRule.IsLoggerEnabled__c), Logger.isEnabled());
+        System.Assert.areEqual(Boolean.valueOf(scenarioRule.IsLoggerEnabled__c), Logger.getUserSettings().IsEnabled__c);
+        System.Assert.areEqual(Boolean.valueOf(scenarioRule.IsLoggerEnabled__c), Logger.isEnabled());
     }
 
     @IsTest
@@ -368,12 +368,12 @@ private class Logger_Tests {
             Scenario__c = 'Some scenario'
         );
         LoggerScenarioRule.setMock(scenarioRule);
-        System.assertNotEquals(null, LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
-        System.assertNotEquals(Boolean.valueOf(scenarioRule.IsAnonymousModeEnabled__c), Logger.getUserSettings().IsAnonymousModeEnabled__c);
+        System.Assert.isNotNull(LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
+        System.Assert.areNotEqual(Boolean.valueOf(scenarioRule.IsAnonymousModeEnabled__c), Logger.getUserSettings().IsAnonymousModeEnabled__c);
 
         Logger.setScenario(scenarioRule.Scenario__c);
 
-        System.assertEquals(Boolean.valueOf(scenarioRule.IsAnonymousModeEnabled__c), Logger.getUserSettings().IsAnonymousModeEnabled__c);
+        System.Assert.areEqual(Boolean.valueOf(scenarioRule.IsAnonymousModeEnabled__c), Logger.getUserSettings().IsAnonymousModeEnabled__c);
     }
 
     @IsTest
@@ -384,12 +384,15 @@ private class Logger_Tests {
             Scenario__c = 'Some scenario'
         );
         LoggerScenarioRule.setMock(scenarioRule);
-        System.assertNotEquals(null, LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
-        System.assertNotEquals(Boolean.valueOf(scenarioRule.IsApexSystemDebugLoggingEnabled__c), Logger.getUserSettings().IsApexSystemDebugLoggingEnabled__c);
+        System.Assert.isNotNull(LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
+        System.Assert.areNotEqual(
+            Boolean.valueOf(scenarioRule.IsApexSystemDebugLoggingEnabled__c),
+            Logger.getUserSettings().IsApexSystemDebugLoggingEnabled__c
+        );
 
         Logger.setScenario(scenarioRule.Scenario__c);
 
-        System.assertEquals(Boolean.valueOf(scenarioRule.IsApexSystemDebugLoggingEnabled__c), Logger.getUserSettings().IsApexSystemDebugLoggingEnabled__c);
+        System.Assert.areEqual(Boolean.valueOf(scenarioRule.IsApexSystemDebugLoggingEnabled__c), Logger.getUserSettings().IsApexSystemDebugLoggingEnabled__c);
     }
 
     @IsTest
@@ -400,12 +403,12 @@ private class Logger_Tests {
             Scenario__c = 'Some scenario'
         );
         LoggerScenarioRule.setMock(scenarioRule);
-        System.assertNotEquals(null, LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
-        System.assertNotEquals(Boolean.valueOf(scenarioRule.IsDataMaskingEnabled__c), Logger.getUserSettings().IsDataMaskingEnabled__c);
+        System.Assert.isNotNull(LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
+        System.Assert.areNotEqual(Boolean.valueOf(scenarioRule.IsDataMaskingEnabled__c), Logger.getUserSettings().IsDataMaskingEnabled__c);
 
         Logger.setScenario(scenarioRule.Scenario__c);
 
-        System.assertEquals(Boolean.valueOf(scenarioRule.IsDataMaskingEnabled__c), Logger.getUserSettings().IsDataMaskingEnabled__c);
+        System.Assert.areEqual(Boolean.valueOf(scenarioRule.IsDataMaskingEnabled__c), Logger.getUserSettings().IsDataMaskingEnabled__c);
     }
 
     @IsTest
@@ -416,15 +419,18 @@ private class Logger_Tests {
             Scenario__c = 'Some scenario'
         );
         LoggerScenarioRule.setMock(scenarioRule);
-        System.assertNotEquals(null, LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
-        System.assertNotEquals(
+        System.Assert.isNotNull(LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
+        System.Assert.areNotEqual(
             Boolean.valueOf(scenarioRule.IsJavaScriptConsoleLoggingEnabled__c),
             Logger.getUserSettings().IsJavaScriptConsoleLoggingEnabled__c
         );
 
         Logger.setScenario(scenarioRule.Scenario__c);
 
-        System.assertEquals(Boolean.valueOf(scenarioRule.IsJavaScriptConsoleLoggingEnabled__c), Logger.getUserSettings().IsJavaScriptConsoleLoggingEnabled__c);
+        System.Assert.areEqual(
+            Boolean.valueOf(scenarioRule.IsJavaScriptConsoleLoggingEnabled__c),
+            Logger.getUserSettings().IsJavaScriptConsoleLoggingEnabled__c
+        );
     }
 
     @IsTest
@@ -435,12 +441,12 @@ private class Logger_Tests {
             Scenario__c = 'Some scenario'
         );
         LoggerScenarioRule.setMock(scenarioRule);
-        System.assertNotEquals(null, LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
-        System.assertNotEquals(Boolean.valueOf(scenarioRule.IsRecordFieldStrippingEnabled__c), Logger.getUserSettings().IsRecordFieldStrippingEnabled__c);
+        System.Assert.isNotNull(LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
+        System.Assert.areNotEqual(Boolean.valueOf(scenarioRule.IsRecordFieldStrippingEnabled__c), Logger.getUserSettings().IsRecordFieldStrippingEnabled__c);
 
         Logger.setScenario(scenarioRule.Scenario__c);
 
-        System.assertEquals(Boolean.valueOf(scenarioRule.IsRecordFieldStrippingEnabled__c), Logger.getUserSettings().IsRecordFieldStrippingEnabled__c);
+        System.Assert.areEqual(Boolean.valueOf(scenarioRule.IsRecordFieldStrippingEnabled__c), Logger.getUserSettings().IsRecordFieldStrippingEnabled__c);
     }
 
     @IsTest
@@ -451,12 +457,12 @@ private class Logger_Tests {
             Scenario__c = 'Some scenario'
         );
         LoggerScenarioRule.setMock(scenarioRule);
-        System.assertNotEquals(null, LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
-        System.assertNotEquals(Boolean.valueOf(scenarioRule.IsSavingEnabled__c), Logger.getUserSettings().IsSavingEnabled__c);
+        System.Assert.isNotNull(LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
+        System.Assert.areNotEqual(Boolean.valueOf(scenarioRule.IsSavingEnabled__c), Logger.getUserSettings().IsSavingEnabled__c);
 
         Logger.setScenario(scenarioRule.Scenario__c);
 
-        System.assertEquals(Boolean.valueOf(scenarioRule.IsSavingEnabled__c), Logger.getUserSettings().IsSavingEnabled__c);
+        System.Assert.areEqual(Boolean.valueOf(scenarioRule.IsSavingEnabled__c), Logger.getUserSettings().IsSavingEnabled__c);
     }
 
     @IsTest
@@ -467,12 +473,12 @@ private class Logger_Tests {
             Scenario__c = 'Some scenario'
         );
         LoggerScenarioRule.setMock(scenarioRule);
-        System.assertNotEquals(null, LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
-        System.assertNotEquals(scenarioRule.SaveMethod__c, Logger.getSaveMethod().name());
+        System.Assert.isNotNull(LoggerScenarioRule.getInstance(scenarioRule.Scenario__c));
+        System.Assert.areNotEqual(scenarioRule.SaveMethod__c, Logger.getSaveMethod().name());
 
         Logger.setScenario(scenarioRule.Scenario__c);
 
-        System.assertEquals(scenarioRule.SaveMethod__c, Logger.getSaveMethod().name());
+        System.Assert.areEqual(scenarioRule.SaveMethod__c, Logger.getSaveMethod().name());
     }
 
     @IsTest
@@ -484,11 +490,11 @@ private class Logger_Tests {
         );
         LoggerScenarioRule.setMock(scenarioRule);
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
-        System.assertNotEquals(scenarioRule.UserLoggingLevel__c, Logger.getUserSettings().LoggingLevel__c);
+        System.Assert.areNotEqual(scenarioRule.UserLoggingLevel__c, Logger.getUserSettings().LoggingLevel__c);
 
         Logger.setScenario(scenarioRule.Scenario__c);
 
-        System.assertEquals(scenarioRule.UserLoggingLevel__c, Logger.getUserSettings().LoggingLevel__c);
+        System.Assert.areEqual(scenarioRule.UserLoggingLevel__c, Logger.getUserSettings().LoggingLevel__c);
     }
 
     @IsTest
@@ -497,7 +503,7 @@ private class Logger_Tests {
 
         Logger.setParentLogTransactionId(expectedParentTransactionId);
 
-        System.assertEquals(expectedParentTransactionId, Logger.getParentLogTransactionId());
+        System.Assert.areEqual(expectedParentTransactionId, Logger.getParentLogTransactionId());
     }
 
     @IsTest
@@ -506,7 +512,7 @@ private class Logger_Tests {
 
         Logger.setParentLogTransactionId(currentTransactionId);
 
-        System.assertEquals(null, Logger.getParentLogTransactionId());
+        System.Assert.isNull(Logger.getParentLogTransactionId());
     }
 
     @IsTest
@@ -515,8 +521,8 @@ private class Logger_Tests {
 
         Quiddity currentQuiddity = Logger.getCurrentQuiddity();
 
-        System.assertEquals(true, acceptableDefaultQuidditiesForTests.contains(currentQuiddity));
-        System.assertEquals(System.Request.getCurrent().getQuiddity(), currentQuiddity);
+        System.Assert.isTrue(acceptableDefaultQuidditiesForTests.contains(currentQuiddity));
+        System.Assert.areEqual(System.Request.getCurrent().getQuiddity(), currentQuiddity);
     }
 
     @IsTest
@@ -526,7 +532,7 @@ private class Logger_Tests {
 
         LoggingLevel returnedLoggingLevel = Logger.getUserLoggingLevel();
 
-        System.assertEquals(expectedLoggingLevel, returnedLoggingLevel);
+        System.Assert.areEqual(expectedLoggingLevel, returnedLoggingLevel);
     }
 
     @IsTest
@@ -536,7 +542,7 @@ private class Logger_Tests {
 
         Boolean returnedValue = Logger.isEnabled();
 
-        System.assertEquals(expectedValue, returnedValue);
+        System.Assert.areEqual(expectedValue, returnedValue);
     }
 
     @IsTest
@@ -548,7 +554,7 @@ private class Logger_Tests {
 
         Boolean returnedValue = Logger.isEnabled(loggingLevel);
 
-        System.assertEquals(expectedValue, returnedValue);
+        System.Assert.areEqual(expectedValue, returnedValue);
     }
 
     @IsTest
@@ -559,7 +565,7 @@ private class Logger_Tests {
 
         Boolean returnedValue = Logger.isErrorEnabled();
 
-        System.assertEquals(expectedValue, returnedValue);
+        System.Assert.areEqual(expectedValue, returnedValue);
     }
 
     @IsTest
@@ -570,7 +576,7 @@ private class Logger_Tests {
 
         Boolean returnedValue = Logger.isWarnEnabled();
 
-        System.assertEquals(expectedValue, returnedValue);
+        System.Assert.areEqual(expectedValue, returnedValue);
     }
 
     @IsTest
@@ -581,7 +587,7 @@ private class Logger_Tests {
 
         Boolean returnedValue = Logger.isInfoEnabled();
 
-        System.assertEquals(expectedValue, returnedValue);
+        System.Assert.areEqual(expectedValue, returnedValue);
     }
 
     @IsTest
@@ -592,7 +598,7 @@ private class Logger_Tests {
 
         Boolean returnedValue = Logger.isDebugEnabled();
 
-        System.assertEquals(expectedValue, returnedValue);
+        System.Assert.areEqual(expectedValue, returnedValue);
     }
 
     @IsTest
@@ -603,7 +609,7 @@ private class Logger_Tests {
 
         Boolean returnedValue = Logger.isFineEnabled();
 
-        System.assertEquals(expectedValue, returnedValue);
+        System.Assert.areEqual(expectedValue, returnedValue);
     }
 
     @IsTest
@@ -614,7 +620,7 @@ private class Logger_Tests {
 
         Boolean returnedValue = Logger.isFinerEnabled();
 
-        System.assertEquals(expectedValue, returnedValue);
+        System.Assert.areEqual(expectedValue, returnedValue);
     }
 
     @IsTest
@@ -625,23 +631,23 @@ private class Logger_Tests {
 
         Boolean returnedValue = Logger.isFinestEnabled();
 
-        System.assertEquals(expectedValue, returnedValue);
+        System.Assert.areEqual(expectedValue, returnedValue);
     }
 
     @IsTest
     static void it_should_return_true_when_saving_is_suspended() {
-        System.assertEquals(false, Logger.isSavingSuspended());
+        System.Assert.isFalse(Logger.isSavingSuspended());
 
         Logger.suspendSaving();
 
-        System.assertEquals(true, Logger.isSavingSuspended());
+        System.Assert.isTrue(Logger.isSavingSuspended());
     }
 
     @IsTest
     static void it_should_suspend_saving() {
         // TODO eliminate references to Log__c, find alternative way to assert on expected data
         Integer countOfExistingLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfExistingLogEntries);
+        System.Assert.areEqual(0, countOfExistingLogEntries);
 
         System.Test.startTest();
 
@@ -656,14 +662,14 @@ private class Logger_Tests {
         System.Test.stopTest();
 
         countOfExistingLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfExistingLogEntries);
+        System.Assert.areEqual(0, countOfExistingLogEntries);
     }
 
     @IsTest
     static void it_should_resume_saving() {
         // TODO eliminate references to Log__c, find alternative way to assert on expected data
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         System.Test.startTest();
 
@@ -673,20 +679,20 @@ private class Logger_Tests {
         Integer logEntriesToCreate = 4;
 
         Logger.suspendSaving();
-        System.assertEquals(true, Logger.isSavingSuspended());
+        System.Assert.isTrue(Logger.isSavingSuspended());
 
         for (Integer i = 0; i < logEntriesToCreate; i++) {
             Logger.info('test log entry #' + i);
         }
-        System.assertEquals(logEntriesToCreate, Logger.getBufferSize());
+        System.Assert.areEqual(logEntriesToCreate, Logger.getBufferSize());
         Logger.saveLog();
 
-        System.assertEquals(logEntriesToCreate, Logger.getBufferSize());
+        System.Assert.areEqual(logEntriesToCreate, Logger.getBufferSize());
         countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         Logger.resumeSaving();
-        System.assertEquals(false, Logger.isSavingSuspended());
+        System.Assert.isFalse(Logger.isSavingSuspended());
 
         Logger.saveLog();
 
@@ -695,7 +701,7 @@ private class Logger_Tests {
         System.Test.stopTest();
 
         countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(logEntriesToCreate, countOfLogEntries);
+        System.Assert.areEqual(logEntriesToCreate, countOfLogEntries);
     }
 
     @IsTest
@@ -713,7 +719,7 @@ private class Logger_Tests {
                     currentUser.TimeZoneSidKey = 'America/Los_Angeles';
                 }
             }
-            System.assertNotEquals(automatedProcessUser.TimeZoneSidKey, currentUser.TimeZoneSidKey);
+            System.Assert.areNotEqual(automatedProcessUser.TimeZoneSidKey, currentUser.TimeZoneSidKey);
         }
 
         Datetime originalTimestamp;
@@ -724,150 +730,150 @@ private class Logger_Tests {
             LogEntryEventBuilder builder = Logger.info('test log entry');
 
             originalTimestamp = builder.getLogEntryEvent().TimeStamp__c;
-            System.assertNotEquals(null, originalTimestamp);
-            System.assertEquals(1, Logger.getBufferSize());
+            System.Assert.isNotNull(originalTimestamp);
+            System.Assert.areEqual(1, Logger.getBufferSize());
             Logger.saveLog();
             System.Test.getEventBus().deliver();
         }
 
         LogEntry__c logEntry = [SELECT Id, Timestamp__c FROM LogEntry__c];
-        System.assertEquals(originalTimestamp, logEntry.Timestamp__c);
+        System.Assert.areEqual(originalTimestamp, logEntry.Timestamp__c);
     }
 
     @IsTest
     static void it_should_return_the_buffer_size() {
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.debug('test log entry');
         Logger.warn('another test log entry');
 
-        System.assertEquals(2, Logger.getBufferSize());
+        System.Assert.areEqual(2, Logger.getBufferSize());
     }
 
     @IsTest
     static void it_should_not_save_when_saving_is_disabled() {
         // TODO eliminate references to Log__c, find alternative way to assert on expected data
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         setUserLoggingLevel(LoggingLevel.DEBUG);
 
         Logger.getUserSettings().IsSavingEnabled__c = false;
 
-        System.assertEquals(Logger.SaveMethod.EVENT_BUS, Logger.getSaveMethod());
+        System.Assert.areEqual(Logger.SaveMethod.EVENT_BUS, Logger.getSaveMethod());
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
 
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
 
         System.Test.startTest();
 
         Logger.saveLog();
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(0, System.Limits.getCallouts());
-        System.assertEquals(0, System.Limits.getDmlStatements());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getDmlStatements());
 
         System.Test.stopTest();
 
         countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
     }
 
     @IsTest
     static void it_should_save_via_event_bus_when_defaulted() {
         // TODO eliminate references to Log__c, find alternative way to assert on expected data
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         setUserLoggingLevel(LoggingLevel.DEBUG);
 
         Logger.getUserSettings().DefaultSaveMethod__c = 'EVENT_BUS';
 
-        System.assertEquals(Logger.SaveMethod.EVENT_BUS, Logger.getSaveMethod());
+        System.Assert.areEqual(Logger.SaveMethod.EVENT_BUS, Logger.getSaveMethod());
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
 
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
 
         System.Test.startTest();
 
         Logger.saveLog();
-        System.assertEquals(1, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(0, System.Limits.getCallouts());
-        System.assertEquals(0, System.Limits.getDmlStatements());
+        System.Assert.areEqual(1, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getDmlStatements());
 
         System.Test.stopTest();
 
         countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(2, countOfLogEntries);
+        System.Assert.areEqual(2, countOfLogEntries);
     }
 
     @IsTest
     static void it_should_save_via_event_bus_when_specified_via_settings() {
         // TODO eliminate references to Log__c, find alternative way to assert on expected data
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         setUserLoggingLevel(LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
 
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
 
         System.Test.startTest();
 
         Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
-        System.assertEquals(1, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(0, System.Limits.getCallouts());
-        System.assertEquals(0, System.Limits.getDmlStatements());
+        System.Assert.areEqual(1, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getDmlStatements());
 
         System.Test.stopTest();
 
         countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(2, countOfLogEntries);
+        System.Assert.areEqual(2, countOfLogEntries);
     }
 
     @IsTest
     static void it_should_save_via_event_bus_when_specified_via_setSaveMethod() {
         // TODO eliminate references to Log__c, find alternative way to assert on expected data
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         setUserLoggingLevel(LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
 
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
 
         System.Test.startTest();
 
         Logger.SaveMethod expectedSaveMethod = Logger.SaveMethod.EVENT_BUS;
         Logger.setSaveMethod(expectedSaveMethod);
-        System.assertEquals(expectedSaveMethod, Logger.getSaveMethod());
+        System.Assert.areEqual(expectedSaveMethod, Logger.getSaveMethod());
         Logger.saveLog();
-        System.assertEquals(1, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(0, System.Limits.getCallouts());
-        System.assertEquals(0, System.Limits.getDmlStatements());
+        System.Assert.areEqual(1, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getDmlStatements());
 
         System.Test.stopTest();
 
         countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(2, countOfLogEntries);
+        System.Assert.areEqual(2, countOfLogEntries);
     }
 
     @IsTest
     static void it_should_save_via_queueable_when_defaulted() {
         // TODO eliminate references to Log__c, find alternative way to assert on expected data
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.DEBUG.name();
         Logger.getUserSettings().DefaultSaveMethod__c = 'QUEUEABLE';
@@ -875,86 +881,86 @@ private class Logger_Tests {
 
         System.Test.startTest();
 
-        System.assertEquals(Logger.SaveMethod.QUEUEABLE, Logger.getSaveMethod());
+        System.Assert.areEqual(Logger.SaveMethod.QUEUEABLE, Logger.getSaveMethod());
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
 
-        System.assertEquals(2, Logger.getBufferSize());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(2, Logger.getBufferSize());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
 
         Logger.saveLog();
 
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(1, System.Limits.getQueueableJobs());
-        System.assertEquals(0, System.Limits.getCallouts());
-        System.assertEquals(0, System.Limits.getDmlStatements());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(1, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getDmlStatements());
 
         System.Test.stopTest();
 
         countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(2, countOfLogEntries);
+        System.Assert.areEqual(2, countOfLogEntries);
     }
 
     @IsTest
     static void it_should_save_via_queueable_when_specified_via_settings() {
         // TODO eliminate references to Log__c, find alternative way to assert on expected data
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         setUserLoggingLevel(LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
 
-        System.assertEquals(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
 
         System.Test.startTest();
 
         Logger.saveLog(Logger.SaveMethod.QUEUEABLE);
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(1, System.Limits.getQueueableJobs());
-        System.assertEquals(0, System.Limits.getCallouts());
-        System.assertEquals(0, System.Limits.getDmlStatements());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(1, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getDmlStatements());
 
         System.Test.getEventBus().deliver();
 
         System.Test.stopTest();
 
         countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(2, countOfLogEntries);
+        System.Assert.areEqual(2, countOfLogEntries);
     }
 
     @IsTest
     static void it_should_save_via_queueable_when_specified_via_setSaveMethod() {
         // TODO eliminate references to Log__c, find alternative way to assert on expected data
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         setUserLoggingLevel(LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
 
-        System.assertEquals(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
 
         System.Test.startTest();
 
         Logger.SaveMethod expectedSaveMethod = Logger.SaveMethod.QUEUEABLE;
         Logger.setSaveMethod(expectedSaveMethod);
-        System.assertEquals(expectedSaveMethod, Logger.getSaveMethod());
+        System.Assert.areEqual(expectedSaveMethod, Logger.getSaveMethod());
         Logger.saveLog();
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(1, System.Limits.getQueueableJobs());
-        System.assertEquals(0, System.Limits.getCallouts());
-        System.assertEquals(0, System.Limits.getDmlStatements());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(1, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getDmlStatements());
 
         System.Test.getEventBus().deliver();
 
         System.Test.stopTest();
 
         countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(2, countOfLogEntries);
+        System.Assert.areEqual(2, countOfLogEntries);
     }
 
     @IsTest
@@ -963,26 +969,26 @@ private class Logger_Tests {
         System.Test.setMock(HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(200));
 
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         setUserLoggingLevel(LoggingLevel.DEBUG);
 
         Logger.getUserSettings().DefaultSaveMethod__c = 'REST';
 
-        System.assertEquals(Logger.SaveMethod.REST, Logger.getSaveMethod());
+        System.Assert.areEqual(Logger.SaveMethod.REST, Logger.getSaveMethod());
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
 
-        System.assertEquals(0, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
 
         System.Test.startTest();
 
         Logger.saveLog();
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(1, System.Limits.getCallouts());
-        System.assertEquals(0, System.Limits.getDmlStatements());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(1, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getDmlStatements());
 
         System.Test.stopTest();
     }
@@ -993,22 +999,22 @@ private class Logger_Tests {
         System.Test.setMock(HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(200));
 
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         setUserLoggingLevel(LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
 
-        System.assertEquals(0, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
 
         System.Test.startTest();
 
         Logger.saveLog(Logger.SaveMethod.REST);
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(1, System.Limits.getCallouts());
-        System.assertEquals(0, System.Limits.getDmlStatements());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(1, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getDmlStatements());
 
         System.Test.stopTest();
     }
@@ -1019,25 +1025,25 @@ private class Logger_Tests {
         System.Test.setMock(HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(200));
 
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         setUserLoggingLevel(LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
 
-        System.assertEquals(0, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
 
         System.Test.startTest();
 
         Logger.SaveMethod expectedSaveMethod = Logger.SaveMethod.REST;
         Logger.setSaveMethod(expectedSaveMethod);
-        System.assertEquals(expectedSaveMethod, Logger.getSaveMethod());
+        System.Assert.areEqual(expectedSaveMethod, Logger.getSaveMethod());
         Logger.saveLog();
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(1, System.Limits.getCallouts());
-        System.assertEquals(0, System.Limits.getDmlStatements());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(1, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getDmlStatements());
 
         System.Test.stopTest();
     }
@@ -1048,26 +1054,26 @@ private class Logger_Tests {
         System.Test.setMock(HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(400));
 
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(0, countOfLogEntries);
+        System.Assert.areEqual(0, countOfLogEntries);
 
         setUserLoggingLevel(LoggingLevel.DEBUG);
 
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
 
-        System.assertEquals(0, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
 
         System.Test.startTest();
 
         try {
             Logger.saveLog(Logger.SaveMethod.REST);
         } catch (Exception ex) {
-            System.assertEquals(CalloutException.class.getName(), ex.getTypeName());
+            System.Assert.areEqual(CalloutException.class.getName(), ex.getTypeName());
         }
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(1, System.Limits.getCallouts());
-        System.assertEquals(0, System.Limits.getDmlStatements());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(1, System.Limits.getCallouts());
+        System.Assert.areEqual(0, System.Limits.getDmlStatements());
 
         System.Test.stopTest();
     }
@@ -1085,24 +1091,24 @@ private class Logger_Tests {
         );
         Logger.getUserSettings().DefaultSaveMethod__c = Logger.SaveMethod.SYNCHRONOUS_DML.name();
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.DEBUG.name();
-        System.assertEquals(LoggingLevel.DEBUG, Logger.getUserLoggingLevel());
-        System.assertEquals(Logger.SaveMethod.SYNCHRONOUS_DML, Logger.getSaveMethod());
+        System.Assert.areEqual(LoggingLevel.DEBUG, Logger.getUserLoggingLevel());
+        System.Assert.areEqual(Logger.SaveMethod.SYNCHRONOUS_DML, Logger.getSaveMethod());
         List<LogEntryEvent__e> logEntryEvents = new List<LogEntryEvent__e>();
         logEntryEvents.add(Logger.debug('test log entry').getLogEntryEvent());
         logEntryEvents.add(Logger.debug('another test log entry').getLogEntryEvent());
         System.Test.startTest();
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(0, System.Limits.getCallouts());
-        System.assertEquals(logEntryEvents.size(), Logger.getBufferSize());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
+        System.Assert.areEqual(logEntryEvents.size(), Logger.getBufferSize());
 
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(0, System.Limits.getCallouts());
-        System.assertEquals(
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
@@ -1110,19 +1116,19 @@ private class Logger_Tests {
         MockSObjectHandler mockLogEntryEventBeforeInsertHandler = (MockSObjectHandler) LoggerSObjectHandler.getExecutedHandlers()
             .get(Schema.LogEntryEvent__e.SObjectType)
             .get(0);
-        // System.assertEquals(1, mockLogEntryEventBeforeInsertHandler.executionCount);
-        System.assertEquals(TriggerOperation.BEFORE_INSERT, mockLogEntryEventBeforeInsertHandler.executedTriggerOperationType);
-        System.assertEquals(logEntryEvents.size(), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.size());
-        System.assertEquals(logEntryEvents.get(0), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.get(0));
-        System.assertEquals(logEntryEvents.get(1), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.get(1));
+        // System.Assert.areEqual(1, mockLogEntryEventBeforeInsertHandler.executionCount);
+        System.Assert.areEqual(TriggerOperation.BEFORE_INSERT, mockLogEntryEventBeforeInsertHandler.executedTriggerOperationType);
+        System.Assert.areEqual(logEntryEvents.size(), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.size());
+        System.Assert.areEqual(logEntryEvents.get(0), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.get(0));
+        System.Assert.areEqual(logEntryEvents.get(1), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.get(1));
         MockSObjectHandler mockLogEntryEventAfterInsertHandler = (MockSObjectHandler) LoggerSObjectHandler.getExecutedHandlers()
             .get(Schema.LogEntryEvent__e.SObjectType)
             .get(1);
-        // System.assertEquals(1, mockLogEntryEventAfterInsertHandler.executionCount);
-        System.assertEquals(TriggerOperation.AFTER_INSERT, mockLogEntryEventAfterInsertHandler.executedTriggerOperationType);
-        System.assertEquals(logEntryEvents.size(), mockLogEntryEventAfterInsertHandler.executedTriggerNew.size());
-        System.assertEquals(logEntryEvents.get(0), mockLogEntryEventAfterInsertHandler.executedTriggerNew.get(0));
-        System.assertEquals(logEntryEvents.get(1), mockLogEntryEventAfterInsertHandler.executedTriggerNew.get(1));
+        // System.Assert.areEqual(1, mockLogEntryEventAfterInsertHandler.executionCount);
+        System.Assert.areEqual(TriggerOperation.AFTER_INSERT, mockLogEntryEventAfterInsertHandler.executedTriggerOperationType);
+        System.Assert.areEqual(logEntryEvents.size(), mockLogEntryEventAfterInsertHandler.executedTriggerNew.size());
+        System.Assert.areEqual(logEntryEvents.get(0), mockLogEntryEventAfterInsertHandler.executedTriggerNew.get(0));
+        System.Assert.areEqual(logEntryEvents.get(1), mockLogEntryEventAfterInsertHandler.executedTriggerNew.get(1));
         System.Test.stopTest();
     }
 
@@ -1141,20 +1147,20 @@ private class Logger_Tests {
         logEntryEvents.add(Logger.debug('test log entry').getLogEntryEvent());
         logEntryEvents.add(Logger.debug('another test log entry').getLogEntryEvent());
         System.Test.startTest();
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(0, System.Limits.getCallouts());
-        System.assertEquals(logEntryEvents.size(), Logger.getBufferSize());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
+        System.Assert.areEqual(logEntryEvents.size(), Logger.getBufferSize());
 
         Logger.getUserSettings().DefaultSaveMethod__c = Logger.SaveMethod.SYNCHRONOUS_DML.name();
-        System.assertEquals(Logger.SaveMethod.SYNCHRONOUS_DML, Logger.getSaveMethod());
+        System.Assert.areEqual(Logger.SaveMethod.SYNCHRONOUS_DML, Logger.getSaveMethod());
         Logger.saveLog();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(0, System.Limits.getCallouts());
-        System.assertEquals(
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
@@ -1162,19 +1168,19 @@ private class Logger_Tests {
         MockSObjectHandler mockLogEntryEventBeforeInsertHandler = (MockSObjectHandler) LoggerSObjectHandler.getExecutedHandlers()
             .get(Schema.LogEntryEvent__e.SObjectType)
             .get(0);
-        // System.assertEquals(1, mockLogEntryEventBeforeInsertHandler.executionCount);
-        System.assertEquals(TriggerOperation.BEFORE_INSERT, mockLogEntryEventBeforeInsertHandler.executedTriggerOperationType);
-        System.assertEquals(logEntryEvents.size(), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.size());
-        System.assertEquals(logEntryEvents.get(0), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.get(0));
-        System.assertEquals(logEntryEvents.get(1), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.get(1));
+        // System.Assert.areEqual(1, mockLogEntryEventBeforeInsertHandler.executionCount);
+        System.Assert.areEqual(TriggerOperation.BEFORE_INSERT, mockLogEntryEventBeforeInsertHandler.executedTriggerOperationType);
+        System.Assert.areEqual(logEntryEvents.size(), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.size());
+        System.Assert.areEqual(logEntryEvents.get(0), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.get(0));
+        System.Assert.areEqual(logEntryEvents.get(1), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.get(1));
         MockSObjectHandler mockLogEntryEventAfterInsertHandler = (MockSObjectHandler) LoggerSObjectHandler.getExecutedHandlers()
             .get(Schema.LogEntryEvent__e.SObjectType)
             .get(1);
-        // System.assertEquals(1, mockLogEntryEventAfterInsertHandler.executionCount);
-        System.assertEquals(TriggerOperation.AFTER_INSERT, mockLogEntryEventAfterInsertHandler.executedTriggerOperationType);
-        System.assertEquals(logEntryEvents.size(), mockLogEntryEventAfterInsertHandler.executedTriggerNew.size());
-        System.assertEquals(logEntryEvents.get(0), mockLogEntryEventAfterInsertHandler.executedTriggerNew.get(0));
-        System.assertEquals(logEntryEvents.get(1), mockLogEntryEventAfterInsertHandler.executedTriggerNew.get(1));
+        // System.Assert.areEqual(1, mockLogEntryEventAfterInsertHandler.executionCount);
+        System.Assert.areEqual(TriggerOperation.AFTER_INSERT, mockLogEntryEventAfterInsertHandler.executedTriggerOperationType);
+        System.Assert.areEqual(logEntryEvents.size(), mockLogEntryEventAfterInsertHandler.executedTriggerNew.size());
+        System.Assert.areEqual(logEntryEvents.get(0), mockLogEntryEventAfterInsertHandler.executedTriggerNew.get(0));
+        System.Assert.areEqual(logEntryEvents.get(1), mockLogEntryEventAfterInsertHandler.executedTriggerNew.get(1));
         System.Test.stopTest();
     }
 
@@ -1193,20 +1199,20 @@ private class Logger_Tests {
         logEntryEvents.add(Logger.debug('test log entry').getLogEntryEvent());
         logEntryEvents.add(Logger.debug('another test log entry').getLogEntryEvent());
         System.Test.startTest();
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(0, System.Limits.getCallouts());
-        System.assertEquals(logEntryEvents.size(), Logger.getBufferSize());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
+        System.Assert.areEqual(logEntryEvents.size(), Logger.getBufferSize());
 
         Logger.SaveMethod expectedSaveMethod = Logger.SaveMethod.SYNCHRONOUS_DML;
         Logger.setSaveMethod(expectedSaveMethod);
-        System.assertEquals(expectedSaveMethod, Logger.getSaveMethod());
+        System.Assert.areEqual(expectedSaveMethod, Logger.getSaveMethod());
         Logger.saveLog();
 
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(0, System.Limits.getQueueableJobs());
-        System.assertEquals(0, System.Limits.getCallouts());
-        System.assertEquals(
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getQueueableJobs());
+        System.Assert.areEqual(0, System.Limits.getCallouts());
+        System.Assert.areEqual(
             2,
             LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
             'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
@@ -1214,19 +1220,19 @@ private class Logger_Tests {
         MockSObjectHandler mockLogEntryEventBeforeInsertHandler = (MockSObjectHandler) LoggerSObjectHandler.getExecutedHandlers()
             .get(Schema.LogEntryEvent__e.SObjectType)
             .get(0);
-        // System.assertEquals(1, mockLogEntryEventBeforeInsertHandler.executionCount);
-        System.assertEquals(TriggerOperation.BEFORE_INSERT, mockLogEntryEventBeforeInsertHandler.executedTriggerOperationType);
-        System.assertEquals(logEntryEvents.size(), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.size());
-        System.assertEquals(logEntryEvents.get(0), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.get(0));
-        System.assertEquals(logEntryEvents.get(1), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.get(1));
+        // System.Assert.areEqual(1, mockLogEntryEventBeforeInsertHandler.executionCount);
+        System.Assert.areEqual(TriggerOperation.BEFORE_INSERT, mockLogEntryEventBeforeInsertHandler.executedTriggerOperationType);
+        System.Assert.areEqual(logEntryEvents.size(), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.size());
+        System.Assert.areEqual(logEntryEvents.get(0), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.get(0));
+        System.Assert.areEqual(logEntryEvents.get(1), mockLogEntryEventBeforeInsertHandler.executedTriggerNew.get(1));
         MockSObjectHandler mockLogEntryEventAfterInsertHandler = (MockSObjectHandler) LoggerSObjectHandler.getExecutedHandlers()
             .get(Schema.LogEntryEvent__e.SObjectType)
             .get(1);
-        // System.assertEquals(1, mockLogEntryEventAfterInsertHandler.executionCount);
-        System.assertEquals(TriggerOperation.AFTER_INSERT, mockLogEntryEventAfterInsertHandler.executedTriggerOperationType);
-        System.assertEquals(logEntryEvents.size(), mockLogEntryEventAfterInsertHandler.executedTriggerNew.size());
-        System.assertEquals(logEntryEvents.get(0), mockLogEntryEventAfterInsertHandler.executedTriggerNew.get(0));
-        System.assertEquals(logEntryEvents.get(1), mockLogEntryEventAfterInsertHandler.executedTriggerNew.get(1));
+        // System.Assert.areEqual(1, mockLogEntryEventAfterInsertHandler.executionCount);
+        System.Assert.areEqual(TriggerOperation.AFTER_INSERT, mockLogEntryEventAfterInsertHandler.executedTriggerOperationType);
+        System.Assert.areEqual(logEntryEvents.size(), mockLogEntryEventAfterInsertHandler.executedTriggerNew.size());
+        System.Assert.areEqual(logEntryEvents.get(0), mockLogEntryEventAfterInsertHandler.executedTriggerNew.get(0));
+        System.Assert.areEqual(logEntryEvents.get(1), mockLogEntryEventAfterInsertHandler.executedTriggerNew.get(1));
         System.Test.stopTest();
     }
 
@@ -1234,11 +1240,11 @@ private class Logger_Tests {
     static void it_should_flush_buffer() {
         Logger.debug('test log entry');
         Logger.debug('another test log entry');
-        System.assertEquals(2, Logger.getBufferSize());
+        System.Assert.areEqual(2, Logger.getBufferSize());
 
         Logger.flushBuffer();
 
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
     }
 
     // Start ERROR methods for LogMessage
@@ -1246,7 +1252,7 @@ private class Logger_Tests {
     static void it_should_add_an_error_entry_for_logMessage_with_successful_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -1256,21 +1262,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_failed_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(false);
 
@@ -1280,21 +1286,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_deleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.DeleteResult> deleteResults = getDeleteResultList();
 
@@ -1304,21 +1310,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_successful_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -1328,21 +1334,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_failed_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(false);
 
@@ -1352,21 +1358,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_saveResultList() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.SaveResult> saveResults = getSaveResultList();
 
@@ -1376,21 +1382,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_successful_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -1400,21 +1406,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_failed_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -1424,21 +1430,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_undeleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UndeleteResult> undeleteResults = getUndeleteResultList();
 
@@ -1448,21 +1454,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_successful_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -1472,21 +1478,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_failed_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true);
 
@@ -1496,21 +1502,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_successful_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -1520,21 +1526,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_failed_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, false);
 
@@ -1544,21 +1550,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_upsertResultList() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UpsertResult> upsertResults = getUpsertResultList();
 
@@ -1568,21 +1574,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_exception() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -1590,21 +1596,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_recordId_and_exception() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -1612,21 +1618,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -1634,21 +1640,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_record_and_exception() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -1656,21 +1662,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -1678,21 +1684,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_recordList_and_exception() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -1701,21 +1707,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -1724,21 +1730,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_logMessage() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -1746,14 +1752,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End ERROR methods for LogMessage
 
@@ -1762,7 +1768,7 @@ private class Logger_Tests {
     static void it_should_add_an_error_entry_for_string_message_with_successful_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -1772,21 +1778,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_failed_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(false);
 
@@ -1796,21 +1802,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_successful_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -1820,21 +1826,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_failed_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(false);
 
@@ -1844,21 +1850,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_successful_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -1868,21 +1874,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_failed_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -1892,21 +1898,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_successful_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -1916,21 +1922,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_failed_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true);
 
@@ -1940,21 +1946,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_successful_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -1964,21 +1970,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_failed_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, false);
 
@@ -1988,21 +1994,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_deleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.DeleteResult> deleteResults = getDeleteResultList();
 
@@ -2012,21 +2018,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_saveResultList() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.SaveResult> saveResults = getSaveResultList();
 
@@ -2036,21 +2042,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_undeleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UndeleteResult> undeleteResults = getUndeleteResultList();
 
@@ -2060,21 +2066,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_upsertResultList() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UpsertResult> upsertResults = getUpsertResultList();
 
@@ -2084,21 +2090,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_exception() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2106,21 +2112,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_recordId_and_exception() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2128,21 +2134,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2150,21 +2156,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_record_and_exception() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2172,21 +2178,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2194,21 +2200,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_recordList_and_exception() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2217,21 +2223,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2240,21 +2246,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_error_entry_for_string_message() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2262,14 +2268,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     // Start WARN methods for LogMessage
@@ -2277,7 +2283,7 @@ private class Logger_Tests {
     static void it_should_add_a_warn_entry_for_logMessage_with_successful_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -2287,21 +2293,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_failed_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(false);
 
@@ -2311,21 +2317,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_successful_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -2335,21 +2341,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_failed_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(false);
 
@@ -2359,21 +2365,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_successful_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -2383,21 +2389,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_failed_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -2407,21 +2413,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_successful_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -2431,21 +2437,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_failed_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true);
 
@@ -2455,21 +2461,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_successful_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -2479,21 +2485,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_failed_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, false);
 
@@ -2503,21 +2509,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_exception() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2525,21 +2531,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_recordId_and_exception() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2547,21 +2553,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2569,21 +2575,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_record_and_exception() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2591,21 +2597,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2613,21 +2619,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_recordList_and_exception() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2636,21 +2642,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2659,21 +2665,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_logMessage() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2681,14 +2687,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End WARN methods for LogMessage
 
@@ -2697,7 +2703,7 @@ private class Logger_Tests {
     static void it_should_add_a_warn_entry_for_string_message_with_successful_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -2707,21 +2713,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_failed_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(false);
 
@@ -2731,21 +2737,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_successful_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -2755,21 +2761,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_failed_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(false);
 
@@ -2779,21 +2785,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_successful_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -2803,21 +2809,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_failed_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -2827,21 +2833,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_successful_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -2851,21 +2857,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_failed_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true);
 
@@ -2875,21 +2881,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_successful_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -2899,21 +2905,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_failed_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, false);
 
@@ -2923,21 +2929,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_exception() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2945,21 +2951,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_recordId_and_exception() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2967,21 +2973,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -2989,21 +2995,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_record_and_exception() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3011,21 +3017,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3033,21 +3039,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_recordList_and_exception() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3056,21 +3062,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(getException().getMessage(), entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.areEqual(getException().getTypeName(), entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3079,21 +3085,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_a_warn_entry_for_string_message() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3101,14 +3107,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End WARN methods for String
 
@@ -3117,7 +3123,7 @@ private class Logger_Tests {
     static void it_should_add_an_info_entry_for_logMessage_with_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -3127,21 +3133,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -3151,21 +3157,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -3175,21 +3181,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -3199,21 +3205,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -3223,21 +3229,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_deleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.DeleteResult> deleteResults = getDeleteResultList();
 
@@ -3247,21 +3253,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_saveResultList() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.SaveResult> saveResults = getSaveResultList();
 
@@ -3271,21 +3277,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_undeleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UndeleteResult> undeleteResults = getUndeleteResultList();
 
@@ -3295,21 +3301,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_upsertResultList() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UpsertResult> upsertResults = getUpsertResultList();
 
@@ -3319,21 +3325,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3341,21 +3347,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3363,21 +3369,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3386,21 +3392,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_logMessage() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3408,14 +3414,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End INFO methods for LogMessage
 
@@ -3424,7 +3430,7 @@ private class Logger_Tests {
     static void it_should_add_an_info_entry_for_string_message_with_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -3434,21 +3440,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -3458,21 +3464,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -3482,21 +3488,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -3506,21 +3512,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -3530,21 +3536,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_deleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.DeleteResult> deleteResults = getDeleteResultList();
 
@@ -3554,21 +3560,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_saveResultList() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.SaveResult> saveResults = getSaveResultList();
 
@@ -3578,21 +3584,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_undeleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UndeleteResult> undeleteResults = getUndeleteResultList();
 
@@ -3602,21 +3608,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_upsertResultList() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UpsertResult> upsertResults = getUpsertResultList();
 
@@ -3626,21 +3632,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3648,21 +3654,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3670,21 +3676,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3693,21 +3699,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_info_entry_for_string_message() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3715,14 +3721,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End INFO methods for String
 
@@ -3731,7 +3737,7 @@ private class Logger_Tests {
     static void it_should_add_an_debug_entry_for_logMessage_with_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -3741,21 +3747,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -3765,21 +3771,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -3789,21 +3795,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -3813,21 +3819,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -3837,21 +3843,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_deleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.DeleteResult> deleteResults = getDeleteResultList();
 
@@ -3861,21 +3867,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_saveResultList() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.SaveResult> saveResults = getSaveResultList();
 
@@ -3885,21 +3891,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_undeleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UndeleteResult> undeleteResults = getUndeleteResultList();
 
@@ -3909,21 +3915,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_upsertResultList() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UpsertResult> upsertResults = getUpsertResultList();
 
@@ -3933,21 +3939,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3955,21 +3961,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -3977,21 +3983,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4000,21 +4006,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_logMessage() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4022,14 +4028,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End DEBUG methods for LogMessage
 
@@ -4038,7 +4044,7 @@ private class Logger_Tests {
     static void it_should_add_an_debug_entry_for_string_message_with_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -4048,21 +4054,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -4072,21 +4078,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -4096,21 +4102,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -4120,21 +4126,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -4144,21 +4150,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_deleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.DeleteResult> deleteResults = getDeleteResultList();
 
@@ -4168,21 +4174,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_saveResultList() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.SaveResult> saveResults = getSaveResultList();
 
@@ -4192,21 +4198,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_undeleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UndeleteResult> undeleteResults = getUndeleteResultList();
 
@@ -4216,21 +4222,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_upsertResultList() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UpsertResult> upsertResults = getUpsertResultList();
 
@@ -4240,21 +4246,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4262,21 +4268,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4284,21 +4290,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4307,21 +4313,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_debug_entry_for_string_message() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4329,14 +4335,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End DEBUG methods for String
 
@@ -4345,7 +4351,7 @@ private class Logger_Tests {
     static void it_should_add_an_fine_entry_for_logMessage_with_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -4355,21 +4361,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -4379,21 +4385,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -4403,21 +4409,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -4427,21 +4433,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -4451,21 +4457,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_deleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.DeleteResult> deleteResults = getDeleteResultList();
 
@@ -4475,21 +4481,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_saveResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.SaveResult> saveResults = getSaveResultList();
 
@@ -4499,21 +4505,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_undeleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UndeleteResult> undeleteResults = getUndeleteResultList();
 
@@ -4523,21 +4529,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_upsertResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UpsertResult> upsertResults = getUpsertResultList();
 
@@ -4547,21 +4553,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4569,21 +4575,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4591,21 +4597,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4614,21 +4620,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_logMessage() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4636,14 +4642,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End FINE methods for LogMessage
 
@@ -4652,7 +4658,7 @@ private class Logger_Tests {
     static void it_should_add_an_fine_entry_for_string_message_with_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -4662,21 +4668,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -4686,21 +4692,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -4710,21 +4716,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -4734,21 +4740,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -4758,21 +4764,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_deleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.DeleteResult> deleteResults = getDeleteResultList();
 
@@ -4782,21 +4788,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_saveResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.SaveResult> saveResults = getSaveResultList();
 
@@ -4806,21 +4812,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_undeleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UndeleteResult> undeleteResults = getUndeleteResultList();
 
@@ -4830,21 +4836,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_upsertResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UpsertResult> upsertResults = getUpsertResultList();
 
@@ -4854,21 +4860,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4876,21 +4882,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4898,21 +4904,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4921,21 +4927,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_fine_entry_for_string_message() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -4943,14 +4949,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End FINE methods for String
 
@@ -4959,7 +4965,7 @@ private class Logger_Tests {
     static void it_should_add_an_finer_entry_for_logMessage_with_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -4969,21 +4975,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -4993,21 +4999,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -5017,21 +5023,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -5041,21 +5047,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -5065,21 +5071,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_deleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.DeleteResult> deleteResults = getDeleteResultList();
 
@@ -5089,21 +5095,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_saveResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.SaveResult> saveResults = getSaveResultList();
 
@@ -5113,21 +5119,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_undeleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UndeleteResult> undeleteResults = getUndeleteResultList();
 
@@ -5137,21 +5143,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_upsertResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UpsertResult> upsertResults = getUpsertResultList();
 
@@ -5161,21 +5167,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -5183,21 +5189,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -5205,21 +5211,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -5228,21 +5234,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_logMessage() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -5250,14 +5256,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End FINER methods for LogMessage
 
@@ -5266,7 +5272,7 @@ private class Logger_Tests {
     static void it_should_add_an_finer_entry_for_string_message_with_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -5276,21 +5282,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -5300,21 +5306,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -5324,21 +5330,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -5348,21 +5354,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -5372,21 +5378,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_deleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.DeleteResult> deleteResults = getDeleteResultList();
 
@@ -5396,21 +5402,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_saveResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.SaveResult> saveResults = getSaveResultList();
 
@@ -5420,21 +5426,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_undeleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UndeleteResult> undeleteResults = getUndeleteResultList();
 
@@ -5444,21 +5450,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_upsertResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UpsertResult> upsertResults = getUpsertResultList();
 
@@ -5468,21 +5474,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -5490,21 +5496,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -5512,21 +5518,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -5535,21 +5541,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finer_entry_for_string_message() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -5557,14 +5563,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End FINER methods for String
 
@@ -5573,7 +5579,7 @@ private class Logger_Tests {
     static void it_should_add_an_finest_entry_for_logMessage_with_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -5583,21 +5589,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -5607,21 +5613,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -5631,21 +5637,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -5655,21 +5661,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -5679,21 +5685,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_deleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.DeleteResult> deleteResults = getDeleteResultList();
 
@@ -5703,21 +5709,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_saveResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.SaveResult> saveResults = getSaveResultList();
 
@@ -5727,21 +5733,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_undeleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UndeleteResult> undeleteResults = getUndeleteResultList();
 
@@ -5751,21 +5757,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_upsertResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UpsertResult> upsertResults = getUpsertResultList();
 
@@ -5775,21 +5781,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -5797,21 +5803,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -5819,21 +5825,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -5842,21 +5848,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_logMessage() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -5864,14 +5870,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End FINEST methods for LogMessage
 
@@ -5880,7 +5886,7 @@ private class Logger_Tests {
     static void it_should_add_an_finest_entry_for_string_message_with_deleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.DeleteResult deleteResult = LoggerMockDataCreator.createDatabaseDeleteResult(true);
 
@@ -5890,21 +5896,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(deleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_saveResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.SaveResult saveResult = LoggerMockDataCreator.createDatabaseSaveResult(true);
 
@@ -5914,21 +5920,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(saveResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_undeleteResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UndeleteResult undeleteResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true);
 
@@ -5938,21 +5944,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(undeleteResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_upsertResult_when_insert() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true);
 
@@ -5962,21 +5968,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Insert', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_upsertResult_when_update() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Database.UpsertResult upsertResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, false);
 
@@ -5986,21 +5992,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(upsertResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResult), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName() + '.Update', entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_deleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.DeleteResult> deleteResults = getDeleteResultList();
 
@@ -6010,21 +6016,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(deleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.DeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_saveResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.SaveResult> saveResults = getSaveResultList();
 
@@ -6034,21 +6040,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(saveResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.SaveResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_undeleteResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UndeleteResult> undeleteResults = getUndeleteResultList();
 
@@ -6058,21 +6064,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(undeleteResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UndeleteResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_upsertResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         List<Database.UpsertResult> upsertResults = getUpsertResultList();
 
@@ -6082,21 +6088,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
-        System.assertEquals(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.areEqual(JSON.serializePretty(upsertResults), entryBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(Database.UpsertResult.class.getName(), entryBuilder.getLogEntryEvent().DatabaseResultType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_recordId() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -6104,21 +6110,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_record() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -6126,21 +6132,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(getRecord().Id, entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(getRecord()), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message_with_recordList() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -6149,21 +6155,21 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.areEqual(JSON.serializePretty(users), entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
     static void it_should_add_an_finest_entry_for_string_message() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -6171,14 +6177,14 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End FINEST methods for String
 
@@ -6191,14 +6197,14 @@ private class Logger_Tests {
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         Database.DeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(false, recordId);
         List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, deleteResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, deleteResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, deleteResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6209,14 +6215,14 @@ private class Logger_Tests {
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         Database.DeleteResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, anotherSuccessfulResult };
-        System.assertEquals(2, deleteResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, deleteResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, deleteResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6227,17 +6233,17 @@ private class Logger_Tests {
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         Database.DeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(false, recordId);
         List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, deleteResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, deleteResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, deleteResults);
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(true, returnedBuilder.shouldSave());
-        System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.isTrue(returnedBuilder.shouldSave());
+        System.Assert.areEqual(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.DeleteResult>{ unsuccessfulResult });
-        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
@@ -6248,14 +6254,14 @@ private class Logger_Tests {
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         Database.DeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(false, recordId);
         List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, deleteResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, deleteResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, deleteResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6266,14 +6272,14 @@ private class Logger_Tests {
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         Database.DeleteResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, anotherSuccessfulResult };
-        System.assertEquals(2, deleteResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, deleteResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, deleteResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6284,17 +6290,17 @@ private class Logger_Tests {
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         Database.DeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(false, recordId);
         List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, deleteResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, deleteResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, deleteResults);
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(true, returnedBuilder.shouldSave());
-        System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.isTrue(returnedBuilder.shouldSave());
+        System.Assert.areEqual(message, returnedBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.DeleteResult>{ unsuccessfulResult });
-        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
@@ -6305,14 +6311,14 @@ private class Logger_Tests {
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         Database.MergeResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(false, recordId);
         List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, mergeResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, mergeResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, mergeResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6323,14 +6329,14 @@ private class Logger_Tests {
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         Database.MergeResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, anotherSuccessfulResult };
-        System.assertEquals(2, mergeResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, mergeResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, mergeResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6341,17 +6347,17 @@ private class Logger_Tests {
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         Database.MergeResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(false, recordId);
         List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, mergeResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, mergeResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, mergeResults);
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(true, returnedBuilder.shouldSave());
-        System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.isTrue(returnedBuilder.shouldSave());
+        System.Assert.areEqual(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.MergeResult>{ unsuccessfulResult });
-        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
@@ -6362,14 +6368,14 @@ private class Logger_Tests {
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         Database.MergeResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(false, recordId);
         List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, mergeResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, mergeResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, mergeResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6380,14 +6386,14 @@ private class Logger_Tests {
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         Database.MergeResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, anotherSuccessfulResult };
-        System.assertEquals(2, mergeResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, mergeResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, mergeResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6398,17 +6404,17 @@ private class Logger_Tests {
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         Database.MergeResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(false, recordId);
         List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, mergeResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, mergeResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, mergeResults);
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(true, returnedBuilder.shouldSave());
-        System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.isTrue(returnedBuilder.shouldSave());
+        System.Assert.areEqual(message, returnedBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.MergeResult>{ unsuccessfulResult });
-        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
@@ -6419,14 +6425,14 @@ private class Logger_Tests {
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         Database.SaveResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(false, recordId);
         List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, saveResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, saveResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, saveResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6437,14 +6443,14 @@ private class Logger_Tests {
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         Database.SaveResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, anotherSuccessfulResult };
-        System.assertEquals(2, saveResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, saveResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, saveResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6455,17 +6461,17 @@ private class Logger_Tests {
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         Database.SaveResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(false, recordId);
         List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, saveResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, saveResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, saveResults);
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(true, returnedBuilder.shouldSave());
-        System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.isTrue(returnedBuilder.shouldSave());
+        System.Assert.areEqual(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.SaveResult>{ unsuccessfulResult });
-        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
@@ -6476,14 +6482,14 @@ private class Logger_Tests {
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         Database.SaveResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(false, recordId);
         List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, saveResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, saveResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, saveResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6494,14 +6500,14 @@ private class Logger_Tests {
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         Database.SaveResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, anotherSuccessfulResult };
-        System.assertEquals(2, saveResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, saveResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, saveResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6512,17 +6518,17 @@ private class Logger_Tests {
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         Database.SaveResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(false, recordId);
         List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, saveResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, saveResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, saveResults);
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(true, returnedBuilder.shouldSave());
-        System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.isTrue(returnedBuilder.shouldSave());
+        System.Assert.areEqual(message, returnedBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.SaveResult>{ unsuccessfulResult });
-        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
@@ -6533,14 +6539,14 @@ private class Logger_Tests {
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         Database.UpsertResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true, recordId);
         List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, upsertResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, upsertResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, upsertResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6551,14 +6557,14 @@ private class Logger_Tests {
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         Database.UpsertResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, anotherSuccessfulResult };
-        System.assertEquals(2, upsertResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, upsertResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, upsertResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6569,17 +6575,17 @@ private class Logger_Tests {
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         Database.UpsertResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true, recordId);
         List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, upsertResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, upsertResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, upsertResults);
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(true, returnedBuilder.shouldSave());
-        System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.isTrue(returnedBuilder.shouldSave());
+        System.Assert.areEqual(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.UpsertResult>{ unsuccessfulResult });
-        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
@@ -6590,14 +6596,14 @@ private class Logger_Tests {
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         Database.UpsertResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true, recordId);
         List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, upsertResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, upsertResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, upsertResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6608,14 +6614,14 @@ private class Logger_Tests {
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         Database.UpsertResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, anotherSuccessfulResult };
-        System.assertEquals(2, upsertResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, upsertResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, upsertResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6626,17 +6632,17 @@ private class Logger_Tests {
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         Database.UpsertResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true, recordId);
         List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, upsertResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, upsertResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, upsertResults);
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(true, returnedBuilder.shouldSave());
-        System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.isTrue(returnedBuilder.shouldSave());
+        System.Assert.areEqual(message, returnedBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.UpsertResult>{ unsuccessfulResult });
-        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
@@ -6647,14 +6653,14 @@ private class Logger_Tests {
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         Database.UndeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(false, recordId);
         List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, undeleteResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, undeleteResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, undeleteResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6665,14 +6671,14 @@ private class Logger_Tests {
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         Database.UndeleteResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, anotherSuccessfulResult };
-        System.assertEquals(2, undeleteResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, undeleteResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, undeleteResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6683,17 +6689,17 @@ private class Logger_Tests {
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         Database.UndeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(false, recordId);
         List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, undeleteResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, undeleteResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, logMessage, undeleteResults);
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(true, returnedBuilder.shouldSave());
-        System.assertEquals(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.isTrue(returnedBuilder.shouldSave());
+        System.Assert.areEqual(logMessage.getMessage(), returnedBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.UndeleteResult>{ unsuccessfulResult });
-        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
 
     @IsTest
@@ -6704,14 +6710,14 @@ private class Logger_Tests {
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         Database.UndeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(false, recordId);
         List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, undeleteResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, undeleteResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, undeleteResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6722,14 +6728,14 @@ private class Logger_Tests {
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         Database.UndeleteResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, anotherSuccessfulResult };
-        System.assertEquals(2, undeleteResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, undeleteResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         Logger.getUserSettings().LoggingLevel__c = LoggingLevel.ERROR.name();
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, undeleteResults);
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(false, returnedBuilder.shouldSave());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isFalse(returnedBuilder.shouldSave());
     }
 
     @IsTest
@@ -6740,17 +6746,17 @@ private class Logger_Tests {
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         Database.UndeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(false, recordId);
         List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, unsuccessfulResult };
-        System.assertEquals(2, undeleteResults.size());
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(2, undeleteResults.size());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         LogEntryEventBuilder returnedBuilder = Logger.logDatabaseErrors(logEntryLevel, message, undeleteResults);
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(true, returnedBuilder.shouldSave());
-        System.assertEquals(message, returnedBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.isTrue(returnedBuilder.shouldSave());
+        System.Assert.areEqual(message, returnedBuilder.getLogEntryEvent().Message__c);
+        System.Assert.areEqual(1, returnedBuilder.getLogEntryEvent().DatabaseResultCollectionSize__c);
         String expectedDatabaseResultJson = JSON.serializePretty(new List<Database.UndeleteResult>{ unsuccessfulResult });
-        System.assertEquals(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
+        System.Assert.areEqual(expectedDatabaseResultJson, returnedBuilder.getLogEntryEvent().DatabaseResultJson__c);
     }
     // End logDatabaseErrors() test methods
 
@@ -6760,8 +6766,8 @@ private class Logger_Tests {
         LoggingLevel userLoggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(userLoggingLevel);
         LoggingLevel logEntryLoggingLevel = LoggingLevel.FINEST;
-        System.assertEquals(false, Logger.meetsUserLoggingLevel(logEntryLoggingLevel));
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.isFalse(Logger.meetsUserLoggingLevel(logEntryLoggingLevel));
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -6770,15 +6776,15 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(shouldSave, entryBuilder.shouldSave());
-        System.assertEquals(logEntryLoggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(shouldSave, entryBuilder.shouldSave());
+        System.Assert.areEqual(logEntryLoggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
@@ -6786,8 +6792,8 @@ private class Logger_Tests {
         LoggingLevel userLoggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(userLoggingLevel);
         LoggingLevel logEntryLoggingLevel = LoggingLevel.FINEST;
-        System.assertEquals(false, Logger.meetsUserLoggingLevel(logEntryLoggingLevel));
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.isFalse(Logger.meetsUserLoggingLevel(logEntryLoggingLevel));
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -6796,16 +6802,16 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(shouldSave, entryBuilder.shouldSave());
-        System.assertEquals(null, entryBuilder.getLogEntryEvent());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(shouldSave, entryBuilder.shouldSave());
+        System.Assert.isNull(entryBuilder.getLogEntryEvent());
     }
 
     @IsTest
     static void it_should_add_a_new_entry_for_loggingLevel_with_logMessage() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -6813,15 +6819,15 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(true, entryBuilder.shouldSave());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.isTrue(entryBuilder.shouldSave());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End newEntry for LogMessage test methods
 
@@ -6831,8 +6837,8 @@ private class Logger_Tests {
         LoggingLevel userLoggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(userLoggingLevel);
         LoggingLevel logEntryLoggingLevel = LoggingLevel.FINEST;
-        System.assertEquals(false, Logger.meetsUserLoggingLevel(logEntryLoggingLevel));
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.isFalse(Logger.meetsUserLoggingLevel(logEntryLoggingLevel));
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -6841,15 +6847,15 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(shouldSave, entryBuilder.shouldSave());
-        System.assertEquals(logEntryLoggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(shouldSave, entryBuilder.shouldSave());
+        System.Assert.areEqual(logEntryLoggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
 
     @IsTest
@@ -6857,8 +6863,8 @@ private class Logger_Tests {
         LoggingLevel userLoggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(userLoggingLevel);
         LoggingLevel logEntryLoggingLevel = LoggingLevel.FINEST;
-        System.assertEquals(false, Logger.meetsUserLoggingLevel(logEntryLoggingLevel));
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.isFalse(Logger.meetsUserLoggingLevel(logEntryLoggingLevel));
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -6867,16 +6873,16 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(0, Logger.getBufferSize());
-        System.assertEquals(shouldSave, entryBuilder.shouldSave());
-        System.assertEquals(null, entryBuilder.getLogEntryEvent());
+        System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.areEqual(shouldSave, entryBuilder.shouldSave());
+        System.Assert.isNull(entryBuilder.getLogEntryEvent());
     }
 
     @IsTest
     static void it_should_add_a_new_entry_for_loggingLevel_with_string() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         setUserLoggingLevel(loggingLevel);
-        System.assertEquals(0, Logger.getBufferSize());
+        System.Assert.areEqual(0, Logger.getBufferSize());
 
         System.Test.startTest();
 
@@ -6884,30 +6890,30 @@ private class Logger_Tests {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize());
-        System.assertEquals(true, entryBuilder.shouldSave());
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionMessage__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().ExceptionType__c);
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.isTrue(entryBuilder.shouldSave());
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c);
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionMessage__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().ExceptionType__c);
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c);
     }
     // End newEntry for String test methods
 
     // Start tests for utility methods
     @IsTest
     static void it_should_return_logging_levels_for_string_names() {
-        System.assertEquals(LoggingLevel.DEBUG, Logger.getLoggingLevel('fake'));
-        System.assertEquals(LoggingLevel.NONE, Logger.getLoggingLevel('none'));
-        System.assertEquals(LoggingLevel.ERROR, Logger.getLoggingLevel('error'));
-        System.assertEquals(LoggingLevel.WARN, Logger.getLoggingLevel('warn'));
-        System.assertEquals(LoggingLevel.INFO, Logger.getLoggingLevel('info'));
-        System.assertEquals(LoggingLevel.DEBUG, Logger.getLoggingLevel('debug'));
-        System.assertEquals(LoggingLevel.FINE, Logger.getLoggingLevel('fine'));
-        System.assertEquals(LoggingLevel.FINER, Logger.getLoggingLevel('finer'));
-        System.assertEquals(LoggingLevel.FINEST, Logger.getLoggingLevel('finest'));
+        System.Assert.areEqual(LoggingLevel.DEBUG, Logger.getLoggingLevel('fake'));
+        System.Assert.areEqual(LoggingLevel.NONE, Logger.getLoggingLevel('none'));
+        System.Assert.areEqual(LoggingLevel.ERROR, Logger.getLoggingLevel('error'));
+        System.Assert.areEqual(LoggingLevel.WARN, Logger.getLoggingLevel('warn'));
+        System.Assert.areEqual(LoggingLevel.INFO, Logger.getLoggingLevel('info'));
+        System.Assert.areEqual(LoggingLevel.DEBUG, Logger.getLoggingLevel('debug'));
+        System.Assert.areEqual(LoggingLevel.FINE, Logger.getLoggingLevel('fine'));
+        System.Assert.areEqual(LoggingLevel.FINER, Logger.getLoggingLevel('finer'));
+        System.Assert.areEqual(LoggingLevel.FINEST, Logger.getLoggingLevel('finest'));
     }
     // End tests for utility methods
 

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -28,7 +28,7 @@ private class Logger_Tests {
     @IsTest
     static void it_should_use_in_memory_default_settings_when_not_configured() {
         LoggerSettings__c expectedSettings = (LoggerSettings__c) LoggerSettings__c.SObjectType.newSObject(null, true);
-        expectedSettings.SetupOwnerId = UserInfo.getUserId();
+        expectedSettings.SetupOwnerId = System.UserInfo.getUserId();
 
         LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
@@ -45,7 +45,7 @@ private class Logger_Tests {
         insert expectedSettings;
         expectedSettings = LoggerSettings__c.getOrgDefaults();
         expectedSettings.Id = null;
-        expectedSettings.SetupOwnerId = UserInfo.getUserId();
+        expectedSettings.SetupOwnerId = System.UserInfo.getUserId();
 
         LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
@@ -61,11 +61,11 @@ private class Logger_Tests {
         LoggerSettings__c expectedSettings = LoggerSettings__c.getOrgDefaults();
         expectedSettings.Id = null;
         expectedSettings.LoggingLevel__c = LoggingLevel.FINEST.name();
-        expectedSettings.SetupOwnerId = UserInfo.getProfileId();
+        expectedSettings.SetupOwnerId = System.UserInfo.getProfileId();
         insert expectedSettings;
-        expectedSettings = LoggerSettings__c.getValues(UserInfo.getProfileId());
+        expectedSettings = LoggerSettings__c.getValues(System.UserInfo.getProfileId());
         expectedSettings.Id = null;
-        expectedSettings.SetupOwnerId = UserInfo.getUserId();
+        expectedSettings.SetupOwnerId = System.UserInfo.getUserId();
 
         LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
@@ -81,14 +81,14 @@ private class Logger_Tests {
         LoggerSettings__c profileSettings = LoggerSettings__c.getOrgDefaults();
         profileSettings.Id = null;
         profileSettings.LoggingLevel__c = LoggingLevel.DEBUG.name();
-        profileSettings.SetupOwnerId = UserInfo.getProfileId();
+        profileSettings.SetupOwnerId = System.UserInfo.getProfileId();
         insert profileSettings;
         LoggerSettings__c expectedSettings = LoggerSettings__c.getOrgDefaults();
         expectedSettings.Id = null;
         expectedSettings.LoggingLevel__c = LoggingLevel.FINEST.name();
-        expectedSettings.SetupOwnerId = UserInfo.getUserId();
+        expectedSettings.SetupOwnerId = System.UserInfo.getUserId();
         insert expectedSettings;
-        expectedSettings = LoggerSettings__c.getValues(UserInfo.getUserId());
+        expectedSettings = LoggerSettings__c.getValues(System.UserInfo.getUserId());
 
         LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
@@ -708,7 +708,7 @@ private class Logger_Tests {
     static void it_should_save_accurate_timestamp_when_logging_user_has_different_time_zone() {
         // TODO Move this test to LogEntryEventBuilder_Tests
         User automatedProcessUser = [SELECT Id, TimeZoneSidKey FROM User WHERE Name = 'Automated Process' AND Profile.Name = NULL];
-        User currentUser = new User(Id = UserInfo.getUserId());
+        User currentUser = new User(Id = System.UserInfo.getUserId());
         // Make sure that the test user has a different time zone from the automated process user
         if (automatedProcessUser.TimeZoneSidKey == currentUser.TimeZoneSidKey) {
             switch on automatedProcessUser.TimeZoneSidKey {
@@ -6192,8 +6192,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_skip_logging_database_deleteResult_for_logMessage_when_logging_level_is_disabled() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         Database.DeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(false, recordId);
         List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, unsuccessfulResult };
@@ -6210,8 +6210,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_skip_logging_database_deleteResult_for_logMessage_when_no_errors_found() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         Database.DeleteResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, anotherSuccessfulResult };
@@ -6228,8 +6228,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_log_database_deleteResult_for_logMessage_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         Database.DeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(false, recordId);
         List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, unsuccessfulResult };
@@ -6250,7 +6250,7 @@ private class Logger_Tests {
     static void it_should_skip_logging_database_deleteResult_for_string_message_when_logging_level_is_disabled() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         Database.DeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(false, recordId);
         List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, unsuccessfulResult };
@@ -6268,7 +6268,7 @@ private class Logger_Tests {
     static void it_should_skip_logging_database_deleteResult_for_string_message_when_no_errors_found() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         Database.DeleteResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, anotherSuccessfulResult };
@@ -6286,7 +6286,7 @@ private class Logger_Tests {
     static void it_should_log_database_deleteResult_for_string_message_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.DeleteResult successfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(true, recordId);
         Database.DeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseDeleteResult(false, recordId);
         List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>{ successfulResult, unsuccessfulResult };
@@ -6306,8 +6306,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_skip_logging_database_mergeResult_for_logMessage_when_logging_level_is_disabled() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         Database.MergeResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(false, recordId);
         List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, unsuccessfulResult };
@@ -6324,8 +6324,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_skip_logging_database_mergeResult_for_logMessage_when_no_errors_found() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         Database.MergeResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, anotherSuccessfulResult };
@@ -6342,8 +6342,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_log_database_mergeResult_for_logMessage_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         Database.MergeResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(false, recordId);
         List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, unsuccessfulResult };
@@ -6364,7 +6364,7 @@ private class Logger_Tests {
     static void it_should_skip_logging_database_mergeResult_for_string_message_when_logging_level_is_disabled() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         Database.MergeResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(false, recordId);
         List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, unsuccessfulResult };
@@ -6382,7 +6382,7 @@ private class Logger_Tests {
     static void it_should_skip_logging_database_mergeResult_for_string_message_when_no_errors_found() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         Database.MergeResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, anotherSuccessfulResult };
@@ -6400,7 +6400,7 @@ private class Logger_Tests {
     static void it_should_log_database_mergeResult_for_string_message_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.MergeResult successfulResult = LoggerMockDataCreator.createDatabaseMergeResult(true, recordId);
         Database.MergeResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseMergeResult(false, recordId);
         List<Database.MergeResult> mergeResults = new List<Database.MergeResult>{ successfulResult, unsuccessfulResult };
@@ -6420,8 +6420,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_skip_logging_database_saveResult_for_logMessage_when_logging_level_is_disabled() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         Database.SaveResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(false, recordId);
         List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, unsuccessfulResult };
@@ -6438,8 +6438,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_skip_logging_database_saveResult_for_logMessage_when_no_errors_found() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         Database.SaveResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, anotherSuccessfulResult };
@@ -6456,8 +6456,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_log_database_saveResult_for_logMessage_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         Database.SaveResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(false, recordId);
         List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, unsuccessfulResult };
@@ -6478,7 +6478,7 @@ private class Logger_Tests {
     static void it_should_skip_logging_database_saveResult_for_string_message_when_logging_level_is_disabled() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         Database.SaveResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(false, recordId);
         List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, unsuccessfulResult };
@@ -6496,7 +6496,7 @@ private class Logger_Tests {
     static void it_should_skip_logging_database_saveResult_for_string_message_when_no_errors_found() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         Database.SaveResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, anotherSuccessfulResult };
@@ -6514,7 +6514,7 @@ private class Logger_Tests {
     static void it_should_log_database_saveResult_for_string_message_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.SaveResult successfulResult = LoggerMockDataCreator.createDatabaseSaveResult(true, recordId);
         Database.SaveResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseSaveResult(false, recordId);
         List<Database.SaveResult> saveResults = new List<Database.SaveResult>{ successfulResult, unsuccessfulResult };
@@ -6534,8 +6534,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_skip_logging_database_upsertResult_for_logMessage_when_logging_level_is_disabled() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         Database.UpsertResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true, recordId);
         List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, unsuccessfulResult };
@@ -6552,8 +6552,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_skip_logging_database_upsertResult_for_logMessage_when_no_errors_found() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         Database.UpsertResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, anotherSuccessfulResult };
@@ -6570,8 +6570,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_log_database_upsertResult_for_logMessage_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         Database.UpsertResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true, recordId);
         List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, unsuccessfulResult };
@@ -6592,7 +6592,7 @@ private class Logger_Tests {
     static void it_should_skip_logging_database_upsertResult_for_string_message_when_logging_level_is_disabled() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         Database.UpsertResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true, recordId);
         List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, unsuccessfulResult };
@@ -6610,7 +6610,7 @@ private class Logger_Tests {
     static void it_should_skip_logging_database_upsertResult_for_string_message_when_no_errors_found() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         Database.UpsertResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, anotherSuccessfulResult };
@@ -6628,7 +6628,7 @@ private class Logger_Tests {
     static void it_should_log_database_upsertResult_for_string_message_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.UpsertResult successfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(true, true, recordId);
         Database.UpsertResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUpsertResult(false, true, recordId);
         List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>{ successfulResult, unsuccessfulResult };
@@ -6648,8 +6648,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_skip_logging_database_undeleteResult_for_logMessage_when_logging_level_is_disabled() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         Database.UndeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(false, recordId);
         List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, unsuccessfulResult };
@@ -6666,8 +6666,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_skip_logging_database_undeleteResult_for_logMessage_when_no_errors_found() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         Database.UndeleteResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, anotherSuccessfulResult };
@@ -6684,8 +6684,8 @@ private class Logger_Tests {
     @IsTest
     static void it_should_log_database_undeleteResult_for_logMessage_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
-        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', UserInfo.getUserId());
-        Id recordId = UserInfo.getUserId();
+        LogMessage logMessage = new LogMessage('Some logMessage for ID {0}', System.UserInfo.getUserId());
+        Id recordId = System.UserInfo.getUserId();
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         Database.UndeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(false, recordId);
         List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, unsuccessfulResult };
@@ -6706,7 +6706,7 @@ private class Logger_Tests {
     static void it_should_skip_logging_database_undeleteResult_for_string_message_when_logging_level_is_disabled() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         Database.UndeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(false, recordId);
         List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, unsuccessfulResult };
@@ -6724,7 +6724,7 @@ private class Logger_Tests {
     static void it_should_skip_logging_database_undeleteResult_for_string_message_when_no_errors_found() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         Database.UndeleteResult anotherSuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, anotherSuccessfulResult };
@@ -6742,7 +6742,7 @@ private class Logger_Tests {
     static void it_should_log_database_undeleteResult_for_string_message_when_isSuccess_is_false() {
         LoggingLevel logEntryLevel = LoggingLevel.WARN;
         String message = 'Some message';
-        Id recordId = UserInfo.getUserId();
+        Id recordId = System.UserInfo.getUserId();
         Database.UndeleteResult successfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(true, recordId);
         Database.UndeleteResult unsuccessfulResult = LoggerMockDataCreator.createDatabaseUndeleteResult(false, recordId);
         List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>{ successfulResult, unsuccessfulResult };
@@ -6932,10 +6932,10 @@ private class Logger_Tests {
 
     static SObject getRecord() {
         return new User(
-            Id = UserInfo.getUserId(),
-            ProfileId = UserInfo.getProfileId(),
-            Username = UserInfo.getUserName(),
-            UserRoleId = UserInfo.getUserRoleId()
+            Id = System.UserInfo.getUserId(),
+            ProfileId = System.UserInfo.getProfileId(),
+            Username = System.UserInfo.getUsername(),
+            UserRoleId = System.UserInfo.getUserRoleId()
         );
     }
 

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -966,7 +966,7 @@ private class Logger_Tests {
     @IsTest
     static void it_should_save_via_rest_api_when_defaulted() {
         // TODO eliminate references to Log__c, find alternative way to assert on expected data
-        System.Test.setMock(HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(200));
+        System.Test.setMock(System.HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(200));
 
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
@@ -996,7 +996,7 @@ private class Logger_Tests {
     @IsTest
     static void it_should_save_via_rest_api_when_specified_via_settings() {
         // TODO eliminate references to Log__c, find alternative way to assert on expected data
-        System.Test.setMock(HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(200));
+        System.Test.setMock(System.HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(200));
 
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
@@ -1022,7 +1022,7 @@ private class Logger_Tests {
     @IsTest
     static void it_should_save_via_rest_api_when_specified_via_setSaveMethod() {
         // TODO eliminate references to Log__c, find alternative way to assert on expected data
-        System.Test.setMock(HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(200));
+        System.Test.setMock(System.HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(200));
 
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
@@ -1051,7 +1051,7 @@ private class Logger_Tests {
     @IsTest
     static void it_should_throw_exception_when_save_via_rest_api_fails() {
         // TODO eliminate references to Log__c, find alternative way to assert on expected data
-        System.Test.setMock(HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(400));
+        System.Test.setMock(System.HttpCalloutMock.class, LoggerMockDataCreator.createHttpCallout().setStatusCode(400));
 
         Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
         System.Assert.areEqual(0, countOfLogEntries);
@@ -1067,8 +1067,8 @@ private class Logger_Tests {
 
         try {
             Logger.saveLog(Logger.SaveMethod.REST);
-        } catch (Exception ex) {
-            System.Assert.areEqual(CalloutException.class.getName(), ex.getTypeName());
+        } catch (System.Exception apexException) {
+            System.Assert.isInstanceOfType(apexException, System.CalloutException.class);
         }
         System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
         System.Assert.areEqual(0, System.Limits.getQueueableJobs());
@@ -6939,8 +6939,8 @@ private class Logger_Tests {
         );
     }
 
-    static Exception getException() {
-        return new DmlException('Example DML Exception');
+    static System.Exception getException() {
+        return new System.DmlException('Example DML System.Exception');
     }
 
     static List<Database.DeleteResult> getDeleteResultList() {
@@ -6977,7 +6977,7 @@ private class Logger_Tests {
 
     static String getOriginLocation() {
         String originLocation;
-        for (String currentStackTraceLine : new DmlException().getStackTraceString().split('\n')) {
+        for (String currentStackTraceLine : new System.DmlException().getStackTraceString().split('\n')) {
             if (currentStackTraceLine.contains('Logger_Tests.getOriginLocation')) {
                 continue;
             }

--- a/nebula-logger/extra-tests/classes/AccessType.cls
+++ b/nebula-logger/extra-tests/classes/AccessType.cls
@@ -1,0 +1,10 @@
+//------------------------------------------------------------------------------------------------//
+// This file is part of the Nebula Logger project, released under the MIT License.                //
+// See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    //
+//------------------------------------------------------------------------------------------------//
+
+// This class intentionally does nothing - it's here to ensure that any references
+// in Nebula Logger's codebase use `System.AccessType` instead of just `AccessType`
+@SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
+public without sharing class AccessType {
+}

--- a/nebula-logger/extra-tests/classes/AccessType.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/AccessType.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/classes/Assert.cls
+++ b/nebula-logger/extra-tests/classes/Assert.cls
@@ -1,0 +1,10 @@
+//------------------------------------------------------------------------------------------------//
+// This file is part of the Nebula Logger project, released under the MIT License.                //
+// See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    //
+//------------------------------------------------------------------------------------------------//
+
+// This class intentionally does nothing - it's here to ensure that any references
+// in Nebula Logger's codebase use `Schema.Assert` instead of just `Assert`
+@SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
+public without sharing class Assert {
+}

--- a/nebula-logger/extra-tests/classes/Assert.cls
+++ b/nebula-logger/extra-tests/classes/Assert.cls
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 
 // This class intentionally does nothing - it's here to ensure that any references
-// in Nebula Logger's codebase use `Schema.Assert` instead of just `Assert`
+// in Nebula Logger's codebase use `System.Assert` instead of just `Assert`
 @SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
 public without sharing class Assert {
 }

--- a/nebula-logger/extra-tests/classes/Assert.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/Assert.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/classes/AuraHandledException.cls
+++ b/nebula-logger/extra-tests/classes/AuraHandledException.cls
@@ -3,8 +3,8 @@
 // See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    //
 //------------------------------------------------------------------------------------------------//
 
-// This class intentionally does nothing - it's here to ensure that any references
-// in Nebula Logger's codebase use `Schema.Network` instead of just `Network`
+// This interface intentionally does nothing - it's here to ensure that any references
+// in Nebula Logger's codebase use `System.AuraHandledException` instead of just `AuraHandledException`
 @SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
-public without sharing class Network {
+public interface AuraHandledException {
 }

--- a/nebula-logger/extra-tests/classes/AuraHandledException.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/AuraHandledException.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/classes/CalloutException.cls
+++ b/nebula-logger/extra-tests/classes/CalloutException.cls
@@ -3,8 +3,8 @@
 // See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    //
 //------------------------------------------------------------------------------------------------//
 
-// This class intentionally does nothing - it's here to ensure that any references
-// in Nebula Logger's codebase use `Schema.Network` instead of just `Network`
+// This interface intentionally does nothing - it's here to ensure that any references
+// in Nebula Logger's codebase use `System.CalloutException` instead of just `CalloutException`
 @SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
-public without sharing class Network {
+public interface CalloutException {
 }

--- a/nebula-logger/extra-tests/classes/CalloutException.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/CalloutException.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/classes/DmlException.cls
+++ b/nebula-logger/extra-tests/classes/DmlException.cls
@@ -3,8 +3,8 @@
 // See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    //
 //------------------------------------------------------------------------------------------------//
 
-// This class intentionally does nothing - it's here to ensure that any references
-// in Nebula Logger's codebase use `Schema.Network` instead of just `Network`
+// This interface intentionally does nothing - it's here to ensure that any references
+// in Nebula Logger's codebase use `System.DmlException` instead of just `DmlException`
 @SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
-public without sharing class Network {
+public interface DmlException {
 }

--- a/nebula-logger/extra-tests/classes/DmlException.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/DmlException.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/classes/ExampleInboundEmailHandler.cls
+++ b/nebula-logger/extra-tests/classes/ExampleInboundEmailHandler.cls
@@ -23,7 +23,7 @@ global with sharing class ExampleInboundEmailHandler implements Messaging.Inboun
         try {
             String nullString = null;
             nullString.length();
-        } catch (Exception apexException) {
+        } catch (System.Exception apexException) {
             Logger.error(logEntryMessage, apexException);
         } finally {
             result.success = true;

--- a/nebula-logger/extra-tests/classes/Http.cls
+++ b/nebula-logger/extra-tests/classes/Http.cls
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 
 // This class intentionally does nothing - it's here to ensure that any references
-// in Nebula Logger's codebase use `Schema.Network` instead of just `Network`
+// in Nebula Logger's codebase use `System.Http` instead of just `Http`
 @SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
-public without sharing class Network {
+public without sharing class Http {
 }

--- a/nebula-logger/extra-tests/classes/Http.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/Http.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/classes/HttpCalloutMock.cls
+++ b/nebula-logger/extra-tests/classes/HttpCalloutMock.cls
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 
 // This class intentionally does nothing - it's here to ensure that any references
-// in Nebula Logger's codebase use `Schema.Network` instead of just `Network`
+// in Nebula Logger's codebase use `System.HttpCalloutMock` instead of just `HttpCalloutMock`
 @SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
-public without sharing class Network {
+public without sharing class HttpCalloutMock {
 }

--- a/nebula-logger/extra-tests/classes/HttpCalloutMock.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/HttpCalloutMock.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/classes/HttpRequest.cls
+++ b/nebula-logger/extra-tests/classes/HttpRequest.cls
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 
 // This class intentionally does nothing - it's here to ensure that any references
-// in Nebula Logger's codebase use `Schema.Network` instead of just `Network`
+// in Nebula Logger's codebase use `System.HttpRequest` instead of just `HttpRequest`
 @SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
-public without sharing class Network {
+public without sharing class HttpRequest {
 }

--- a/nebula-logger/extra-tests/classes/HttpRequest.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/HttpRequest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/classes/HttpResponse.cls
+++ b/nebula-logger/extra-tests/classes/HttpResponse.cls
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 
 // This class intentionally does nothing - it's here to ensure that any references
-// in Nebula Logger's codebase use `Schema.Network` instead of just `Network`
+// in Nebula Logger's codebase use `System.HttpResponse` instead of just `HttpResponse`
 @SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
-public without sharing class Network {
+public without sharing class HttpResponse {
 }

--- a/nebula-logger/extra-tests/classes/HttpResponse.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/HttpResponse.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/classes/IllegalArgumentException.cls
+++ b/nebula-logger/extra-tests/classes/IllegalArgumentException.cls
@@ -3,8 +3,8 @@
 // See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    //
 //------------------------------------------------------------------------------------------------//
 
-// This class intentionally does nothing - it's here to ensure that any references
-// in Nebula Logger's codebase use `Schema.Network` instead of just `Network`
+// This interface intentionally does nothing - it's here to ensure that any references
+// in Nebula Logger's codebase use `System.IllegalArgumentException` instead of just `System.IllegalArgumentException`
 @SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
-public without sharing class Network {
+public interface IllegalArgumentException {
 }

--- a/nebula-logger/extra-tests/classes/IllegalArgumentException.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/IllegalArgumentException.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/classes/LoggingLevel.cls
+++ b/nebula-logger/extra-tests/classes/LoggingLevel.cls
@@ -1,0 +1,10 @@
+//------------------------------------------------------------------------------------------------//
+// This file is part of the Nebula Logger project, released under the MIT License.                //
+// See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    //
+//------------------------------------------------------------------------------------------------//
+
+// This class intentionally does nothing - it's here to ensure that any references
+// in Nebula Logger's codebase use `Schema.LoggingLevel` instead of just `LoggingLevel`
+@SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
+public without sharing class LoggingLevel {
+}

--- a/nebula-logger/extra-tests/classes/LoggingLevel.cls
+++ b/nebula-logger/extra-tests/classes/LoggingLevel.cls
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 
 // This class intentionally does nothing - it's here to ensure that any references
-// in Nebula Logger's codebase use `Schema.LoggingLevel` instead of just `LoggingLevel`
+// in Nebula Logger's codebase use `System.LoggingLevel` instead of just `LoggingLevel`
 @SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
 public without sharing class LoggingLevel {
 }

--- a/nebula-logger/extra-tests/classes/LoggingLevel.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/LoggingLevel.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/classes/SObjectAccessDecision.cls
+++ b/nebula-logger/extra-tests/classes/SObjectAccessDecision.cls
@@ -1,0 +1,10 @@
+//------------------------------------------------------------------------------------------------//
+// This file is part of the Nebula Logger project, released under the MIT License.                //
+// See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    //
+//------------------------------------------------------------------------------------------------//
+
+// This class intentionally does nothing - it's here to ensure that any references
+// in Nebula Logger's codebase use `System.SObjectAccessDecision` instead of just `SObjectAccessDecision`
+@SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
+public without sharing class SObjectAccessDecision {
+}

--- a/nebula-logger/extra-tests/classes/SObjectAccessDecision.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/SObjectAccessDecision.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/classes/UserInfo.cls
+++ b/nebula-logger/extra-tests/classes/UserInfo.cls
@@ -1,0 +1,10 @@
+//------------------------------------------------------------------------------------------------//
+// This file is part of the Nebula Logger project, released under the MIT License.                //
+// See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    //
+//------------------------------------------------------------------------------------------------//
+
+// This class intentionally does nothing - it's here to ensure that any references
+// in Nebula Logger's codebase use `System.UserInfo` instead of just `UserInfo`
+@SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
+public without sharing class UserInfo {
+}

--- a/nebula-logger/extra-tests/classes/UserInfo.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/UserInfo.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Database.cls
+++ b/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Database.cls
@@ -13,7 +13,7 @@ private class LogBatchPurger_Tests_Database {
     static void setupData() {
         LoggerSettings__c settings = Logger.getUserSettings();
         settings.IsEnabled__c = false;
-        settings.LoggingLevel__c = LoggingLevel.FINEST.name();
+        settings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
         insert settings;
 
         Date scheduledDeletionDate = System.today().addDays(-7);
@@ -22,7 +22,7 @@ private class LogBatchPurger_Tests_Database {
 
         List<LogEntry__c> logEntries = new List<LogEntry__c>();
         for (Integer i = 0; i < NUMBER_OF_LOG_ENTRIES; i++) {
-            LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.INFO.name());
+            LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = System.LoggingLevel.INFO.name());
 
             logEntries.add(logEntry);
         }

--- a/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Database.cls
+++ b/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Database.cls
@@ -45,17 +45,17 @@ private class LogBatchPurger_Tests_Database {
 
         User standardUser = LoggerMockDataCreator.createUser(STANDARD_USER_PROFILE.Id);
         System.runAs(standardUser) {
-            System.assertEquals(false, Schema.Log__c.SObjectType.getDescribe().isDeletable());
+            System.Assert.isFalse(Schema.Log__c.SObjectType.getDescribe().isDeletable());
 
             try {
                 System.Test.startTest();
                 Database.executeBatch(new LogBatchPurger());
                 System.Test.stopTest();
             } catch (NoAccessException ex) {
-                System.assertEquals(LogBatchPurger.NO_DELETE_ACCESS_EXCEPTION_MESSAGE, ex.getMessage());
+                System.Assert.areEqual(LogBatchPurger.NO_DELETE_ACCESS_EXCEPTION_MESSAGE, ex.getMessage());
             }
         }
         Integer updatedCountOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(originalCountOfLogEntries, updatedCountOfLogEntries);
+        System.Assert.areEqual(originalCountOfLogEntries, updatedCountOfLogEntries);
     }
 }

--- a/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Flow.cls
+++ b/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Flow.cls
@@ -19,7 +19,7 @@ private class LogBatchPurger_Tests_Flow {
         LoggerSObjectHandler.shouldExecute(false);
         LoggerSettings__c settings = Logger.getUserSettings();
         settings.IsEnabled__c = false;
-        settings.LoggingLevel__c = LoggingLevel.FINEST.name();
+        settings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
         insert settings;
 
         Date scheduledDeletionDate = System.today().addDays(-7);
@@ -29,7 +29,7 @@ private class LogBatchPurger_Tests_Flow {
 
         List<LogEntry__c> logEntries = new List<LogEntry__c>();
         for (Integer i = 0; i < NUMBER_OF_LOG_ENTRIES_TO_CREATE; i++) {
-            LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.INFO.name());
+            LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = System.LoggingLevel.INFO.name());
             LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
             logEntries.add(logEntry);
         }

--- a/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Flow.cls
+++ b/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Flow.cls
@@ -64,32 +64,32 @@ private class LogBatchPurger_Tests_Flow {
         batchJobInstance.start(mockBatchableContext);
 
         LoggerBatchableContext expectedInput = new LoggerBatchableContext(mockBatchableContext, batchJobInstance.currentSObjectType);
-        System.assertEquals(
+        System.Assert.areEqual(
             3,
             batchJobInstance.getExecutedFlowPlugins().size(),
             'The map of executed Flow plugins should have 3 keys - one for each enum value in LogBatchPurger.BatchableMethod (START, EXECUTE, and FINISH)'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             1,
             batchJobInstance.getExecutedFlowPlugins().get(LogBatchPurger.BatchableMethod.START).size(),
             'One Flow plugin should have run in the batch job\'s start method'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             batchJobInstance.getExecutedFlowPlugins().get(LogBatchPurger.BatchableMethod.EXECUTE).size(),
             'No Flow plugins should have run in the batch job\'s execute method'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             batchJobInstance.getExecutedFlowPlugins().get(LogBatchPurger.BatchableMethod.FINISH).size(),
             'No Flow plugins should have run in the batch job\'s finish method'
         );
         Flow.Interview flowStartPlugin = batchJobInstance.getExecutedFlowPlugins().get(LogBatchPurger.BatchableMethod.START).get(0);
         LoggerPlugin__mdt returnedPluginConfiguration = (LoggerPlugin__mdt) flowStartPlugin.getVariableValue('pluginConfiguration');
-        System.assertEquals(mockPluginConfiguration, returnedPluginConfiguration, 'LoggerPlugin__mdt records should match');
+        System.Assert.areEqual(mockPluginConfiguration, returnedPluginConfiguration, 'LoggerPlugin__mdt records should match');
         LoggerBatchableContext returnedPluginInput = (LoggerBatchableContext) flowStartPlugin.getVariableValue('pluginInput');
-        System.assertEquals(JSON.serialize(expectedInput), JSON.serialize(returnedPluginInput), 'Plugin inputs should match');
-        System.assertEquals(
+        System.Assert.areEqual(JSON.serialize(expectedInput), JSON.serialize(returnedPluginInput), 'Plugin inputs should match');
+        System.Assert.areEqual(
             MOCK_FLOW_OUTPUT_VARIABLE_VALUE,
             flowStartPlugin.getVariableValue(MOCK_FLOW_OUTPUT_VARIABLE_NAME),
             'Flow should have returned the variable ' +
@@ -111,38 +111,38 @@ private class LogBatchPurger_Tests_Flow {
         LoggerTestConfigurator.setMock(mockPluginConfiguration);
         LogBatchPurger batchJobInstance = new LogBatchPurger();
         List<Log__c> logsToDelete = [SELECT Id FROM Log__c];
-        System.assertNotEquals(0, logsToDelete.size());
+        System.Assert.areNotEqual(0, logsToDelete.size());
         Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
 
         batchJobInstance.execute(mockBatchableContext, logsToDelete);
 
         LoggerBatchableContext expectedInput = new LoggerBatchableContext(mockBatchableContext, batchJobInstance.currentSObjectType);
-        System.assertEquals(
+        System.Assert.areEqual(
             3,
             batchJobInstance.getExecutedFlowPlugins().size(),
             'The map of executed Flow plugins should have 3 keys - one for each enum value in LogBatchPurger.BatchableMethod (START, EXECUTE, and FINISH)'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             batchJobInstance.getExecutedFlowPlugins().get(LogBatchPurger.BatchableMethod.START).size(),
             'No Flow plugins should have run in the batch job\'s start method'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             1,
             batchJobInstance.getExecutedFlowPlugins().get(LogBatchPurger.BatchableMethod.EXECUTE).size(),
             'One Flow plugin should have run in the batch job\'s execute method'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             batchJobInstance.getExecutedFlowPlugins().get(LogBatchPurger.BatchableMethod.FINISH).size(),
             'No Flow plugins should have run in the batch job\'s finish method'
         );
         Flow.Interview flowExecutePlugin = batchJobInstance.getExecutedFlowPlugins().get(LogBatchPurger.BatchableMethod.EXECUTE).get(0);
         LoggerPlugin__mdt returnedPluginConfiguration = (LoggerPlugin__mdt) flowExecutePlugin.getVariableValue('pluginConfiguration');
-        System.assertEquals(mockPluginConfiguration, returnedPluginConfiguration, 'LoggerPlugin__mdt records should match');
+        System.Assert.areEqual(mockPluginConfiguration, returnedPluginConfiguration, 'LoggerPlugin__mdt records should match');
         LoggerBatchableContext returnedPluginInput = (LoggerBatchableContext) flowExecutePlugin.getVariableValue('pluginInput');
-        System.assertEquals(JSON.serialize(expectedInput), JSON.serialize(returnedPluginInput), 'Plugin inputs should match');
-        System.assertEquals(
+        System.Assert.areEqual(JSON.serialize(expectedInput), JSON.serialize(returnedPluginInput), 'Plugin inputs should match');
+        System.Assert.areEqual(
             MOCK_FLOW_OUTPUT_VARIABLE_VALUE,
             flowExecutePlugin.getVariableValue(MOCK_FLOW_OUTPUT_VARIABLE_NAME),
             'Flow should have returned the variable ' +
@@ -165,38 +165,38 @@ private class LogBatchPurger_Tests_Flow {
     //     LoggerTestConfigurator.setMock(mockPluginConfiguration);
     //     LogBatchPurger batchJobInstance = new LogBatchPurger();
     //     List<Log__c> logsToDelete = [SELECT Id FROM Log__c];
-    //     System.assertNotEquals(0, logsToDelete.size(), 'There should be some records to delete');
+    //     System.Assert.areNotEqual(0, logsToDelete.size(), 'There should be some records to delete');
     //     Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
 
     //     batchJobInstance.finish(mockBatchableContext);
 
     //     LoggerBatchableContext expectedInput = new LoggerBatchableContext(mockBatchableContext, batchJobInstance.currentSObjectType);
-    //     System.assertEquals(
+    //     System.Assert.areEqual(
     //         3,
     //         batchJobInstance.getExecutedFlowPlugins().size(),
     //         'The map of executed Flow plugins should have 3 keys - one for each enum value in LogBatchPurger.BatchableMethod (START, EXECUTE, and FINISH)'
     //     );
-    //     System.assertEquals(
+    //     System.Assert.areEqual(
     //         0,
     //         batchJobInstance.getExecutedFlowPlugins().get(LogBatchPurger.BatchableMethod.START).size(),
     //         'No Flow plugins should have run in the batch job\'s start method'
     //     );
-    //     System.assertEquals(
+    //     System.Assert.areEqual(
     //         0,
     //         batchJobInstance.getExecutedFlowPlugins().get(LogBatchPurger.BatchableMethod.EXECUTE).size(),
     //         'No Flow plugins should have run in the batch job\'s execute method'
     //     );
-    //     System.assertEquals(
+    //     System.Assert.areEqual(
     //         1,
     //         batchJobInstance.getExecutedFlowPlugins().get(LogBatchPurger.BatchableMethod.FINISH).size(),
     //         'One Flow plugin should have run in the batch job\'s finish method'
     //     );
     //     Flow.Interview flowFinishPlugin = batchJobInstance.getExecutedFlowPlugins().get(LogBatchPurger.BatchableMethod.FINISH).get(0);
     //     LoggerPlugin__mdt returnedPluginConfiguration = (LoggerPlugin__mdt) flowFinishPlugin.getVariableValue('pluginConfiguration');
-    //     System.assertEquals(mockPluginConfiguration, returnedPluginConfiguration, 'LoggerPlugin__mdt records should match');
+    //     System.Assert.areEqual(mockPluginConfiguration, returnedPluginConfiguration, 'LoggerPlugin__mdt records should match');
     //     LoggerBatchableContext returnedPluginInput = (LoggerBatchableContext) flowFinishPlugin.getVariableValue('pluginInput');
-    //     System.assertEquals(JSON.serialize(expectedInput), JSON.serialize(returnedPluginInput), 'Plugin inputs should match');
-    //     System.assertEquals(
+    //     System.Assert.areEqual(JSON.serialize(expectedInput), JSON.serialize(returnedPluginInput), 'Plugin inputs should match');
+    //     System.Assert.areEqual(
     //         MOCK_FLOW_OUTPUT_VARIABLE_VALUE,
     //         flowFinishPlugin.getVariableValue(MOCK_FLOW_OUTPUT_VARIABLE_NAME),
     //         'Flow should have returned the variable ' +

--- a/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Network.cls
+++ b/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Network.cls
@@ -24,7 +24,7 @@ private class LogEntryEventBuilder_Tests_Network {
 
         LogEntryEvent__e logEntryEvent;
         System.runAs(experienceSiteUser) {
-            logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>()).getLogEntryEvent();
+            logEntryEvent = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>()).getLogEntryEvent();
         }
 
         System.Assert.areEqual(networkRecord.get('Id'), logEntryEvent.NetworkId__c);
@@ -51,7 +51,7 @@ private class LogEntryEventBuilder_Tests_Network {
 
         LogEntryEvent__e logEntryEvent;
         System.runAs(experienceSiteUser) {
-            logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>()).getLogEntryEvent();
+            logEntryEvent = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>()).getLogEntryEvent();
         }
 
         System.Assert.isNull(logEntryEvent.NetworkName__c);

--- a/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Network.cls
+++ b/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Network.cls
@@ -16,9 +16,9 @@ private class LogEntryEventBuilder_Tests_Network {
             return;
         }
 
-        System.assertEquals(true, LoggerParameter.QUERY_NETWORK_DATA);
+        System.Assert.isTrue(LoggerParameter.QUERY_NETWORK_DATA);
         SObject networkRecord = getExperienceCloudNetwork();
-        System.assertNotEquals(null, networkRecord.Id);
+        System.Assert.isNotNull(networkRecord.Id);
         LogEntryEventBuilder.networkId = networkRecord.Id;
         User experienceSiteUser = setupExperienceSiteUser();
 
@@ -27,12 +27,12 @@ private class LogEntryEventBuilder_Tests_Network {
             logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>()).getLogEntryEvent();
         }
 
-        System.assertEquals(networkRecord.get('Id'), logEntryEvent.NetworkId__c);
-        System.assertEquals((String) networkRecord.get('Name'), logEntryEvent.NetworkName__c);
-        System.assertEquals(System.Network.getLoginUrl(networkRecord.Id), logEntryEvent.NetworkLoginUrl__c);
-        System.assertEquals(System.Network.getLogoutUrl(networkRecord.Id), logEntryEvent.NetworkLogoutUrl__c);
-        System.assertEquals(System.Network.getSelfRegUrl(networkRecord.Id), logEntryEvent.NetworkSelfRegistrationUrl__c);
-        System.assertEquals((String) networkRecord.get('UrlPathPrefix'), logEntryEvent.NetworkUrlPathPrefix__c);
+        System.Assert.areEqual(networkRecord.get('Id'), logEntryEvent.NetworkId__c);
+        System.Assert.areEqual((String) networkRecord.get('Name'), logEntryEvent.NetworkName__c);
+        System.Assert.areEqual(System.Network.getLoginUrl(networkRecord.Id), logEntryEvent.NetworkLoginUrl__c);
+        System.Assert.areEqual(System.Network.getLogoutUrl(networkRecord.Id), logEntryEvent.NetworkLogoutUrl__c);
+        System.Assert.areEqual(System.Network.getSelfRegUrl(networkRecord.Id), logEntryEvent.NetworkSelfRegistrationUrl__c);
+        System.Assert.areEqual((String) networkRecord.get('UrlPathPrefix'), logEntryEvent.NetworkUrlPathPrefix__c);
     }
 
     @IsTest
@@ -43,9 +43,9 @@ private class LogEntryEventBuilder_Tests_Network {
         }
 
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryNetworkData', Value__c = String.valueOf(false)));
-        System.assertEquals(false, LoggerParameter.QUERY_NETWORK_DATA);
+        System.Assert.isFalse(LoggerParameter.QUERY_NETWORK_DATA);
         SObject networkRecord = getExperienceCloudNetwork();
-        System.assertNotEquals(null, networkRecord.Id);
+        System.Assert.isNotNull(networkRecord.Id);
         LogEntryEventBuilder.networkId = networkRecord.Id;
         User experienceSiteUser = setupExperienceSiteUser();
 
@@ -54,11 +54,11 @@ private class LogEntryEventBuilder_Tests_Network {
             logEntryEvent = new LogEntryEventBuilder(getUserSettings(), LoggingLevel.INFO, true, new Set<String>()).getLogEntryEvent();
         }
 
-        System.assertEquals(null, logEntryEvent.NetworkName__c);
-        System.assertEquals(null, logEntryEvent.NetworkLoginUrl__c);
-        System.assertEquals(null, logEntryEvent.NetworkLogoutUrl__c);
-        System.assertEquals(null, logEntryEvent.NetworkSelfRegistrationUrl__c);
-        System.assertEquals(null, logEntryEvent.NetworkUrlPathPrefix__c);
+        System.Assert.isNull(logEntryEvent.NetworkName__c);
+        System.Assert.isNull(logEntryEvent.NetworkLoginUrl__c);
+        System.Assert.isNull(logEntryEvent.NetworkLogoutUrl__c);
+        System.Assert.isNull(logEntryEvent.NetworkSelfRegistrationUrl__c);
+        System.Assert.isNull(logEntryEvent.NetworkUrlPathPrefix__c);
     }
 
     static SObject getExperienceCloudNetwork() {

--- a/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Network.cls
+++ b/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Network.cls
@@ -67,14 +67,14 @@ private class LogEntryEventBuilder_Tests_Network {
 
     static LoggerSettings__c getUserSettings() {
         LoggerSettings__c userSettings = (LoggerSettings__c) Schema.LoggerSettings__c.SObjectType.newSObject(null, true);
-        userSettings.SetupOwnerId = UserInfo.getUserId();
+        userSettings.SetupOwnerId = System.UserInfo.getUserId();
         return userSettings;
     }
 
     static User setupExperienceSiteUser() {
         UserRole userRole = new UserRole(DeveloperName = 'LoggerTestRole', Name = 'Logger Test Role');
         insert userRole;
-        User currentUser = new User(Id = UserInfo.getUserId(), UserRoleId = userRole.Id);
+        User currentUser = new User(Id = System.UserInfo.getUserId(), UserRoleId = userRole.Id);
         update currentUser;
         User experienceSiteUser;
         System.runAs(currentUser) {

--- a/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Security.cls
+++ b/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Security.cls
@@ -21,23 +21,31 @@ private class LogEntryEventBuilder_Tests_Security {
 
         LogEntryEventBuilder builder;
         System.runAs(standardUser) {
-            System.assertEquals(false, Schema.AccountBrand.SObjectType.getDescribe().isAccessible(), 'AccountBrand was accessible, and should not have been.');
-            System.assertEquals(
+            System.Assert.isFalse(Schema.AccountBrand.SObjectType.getDescribe().isAccessible(), 'AccountBrand was accessible, and should not have been.');
+            System.Assert.areEqual(
                 false,
                 Schema.AccountBrand.CompanyName.getDescribe().isAccessible(),
                 'AccountBrand Company Name was accessible, and should not have been.'
             );
-            System.assertEquals(false, Schema.AccountBrand.Email.getDescribe().isAccessible(), 'AccountBrand Email was accessible, and should not have been.');
-            System.assertEquals(false, Schema.AccountBrand.Name.getDescribe().isAccessible(), 'AccountBrand Name was accessible, and should not have been.');
-            System.assertEquals(false, Schema.AccountBrand.Phone.getDescribe().isAccessible(), 'AccountBrand Phone was accessible, and should not have been.');
+            System.Assert.isFalse(Schema.AccountBrand.Email.getDescribe().isAccessible(), 'AccountBrand Email was accessible, and should not have been.');
+            System.Assert.isFalse(Schema.AccountBrand.Name.getDescribe().isAccessible(), 'AccountBrand Name was accessible, and should not have been.');
+            System.Assert.isFalse(Schema.AccountBrand.Phone.getDescribe().isAccessible(), 'AccountBrand Phone was accessible, and should not have been.');
 
             LoggerSettings__c userSettings = getUserSettings();
             userSettings.IsRecordFieldStrippingEnabled__c = true;
             builder = new LogEntryEventBuilder(userSettings, LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAccountBrand);
         }
 
-        System.assertNotEquals(JSON.serializePretty(mockAccountBrand), builder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(JSON.serializePretty(strippedAccountBrand), builder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areNotEqual(
+            JSON.serializePretty(mockAccountBrand),
+            builder.getLogEntryEvent().RecordJson__c,
+            'Log entry event record JSON was incorrect.'
+        );
+        System.Assert.areEqual(
+            JSON.serializePretty(strippedAccountBrand),
+            builder.getLogEntryEvent().RecordJson__c,
+            'Log entry event record JSON was incorrect.'
+        );
     }
 
     @IsTest
@@ -60,23 +68,23 @@ private class LogEntryEventBuilder_Tests_Security {
 
         LogEntryEventBuilder builder;
         System.runAs(standardUser) {
-            System.assertEquals(false, Schema.AccountBrand.SObjectType.getDescribe().isAccessible(), 'AccountBrand was accessible, and should not have been.');
-            System.assertEquals(
+            System.Assert.isFalse(Schema.AccountBrand.SObjectType.getDescribe().isAccessible(), 'AccountBrand was accessible, and should not have been.');
+            System.Assert.areEqual(
                 false,
                 Schema.AccountBrand.CompanyName.getDescribe().isAccessible(),
                 'AccountBrand Company Name was accessible and should not have been.'
             );
-            System.assertEquals(false, Schema.AccountBrand.Email.getDescribe().isAccessible(), 'AccountBrand Email was accessible, and should not have been,');
-            System.assertEquals(false, Schema.AccountBrand.Name.getDescribe().isAccessible(), 'AccountBrand Name was accessible, and should not have been.');
-            System.assertEquals(false, Schema.AccountBrand.Phone.getDescribe().isAccessible(), 'AccountBrand Phone was accessible, and should not have been.');
+            System.Assert.isFalse(Schema.AccountBrand.Email.getDescribe().isAccessible(), 'AccountBrand Email was accessible, and should not have been,');
+            System.Assert.isFalse(Schema.AccountBrand.Name.getDescribe().isAccessible(), 'AccountBrand Name was accessible, and should not have been.');
+            System.Assert.isFalse(Schema.AccountBrand.Phone.getDescribe().isAccessible(), 'AccountBrand Phone was accessible, and should not have been.');
 
             LoggerSettings__c userSettings = getUserSettings();
             userSettings.IsRecordFieldStrippingEnabled__c = true;
             builder = new LogEntryEventBuilder(userSettings, LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAccountBrands);
         }
 
-        System.assertNotEquals(JSON.serializePretty(mockAccountBrands), builder.getLogEntryEvent().RecordJson__c, 'Record JSON is incorrect.');
-        System.assertEquals(JSON.serializePretty(strippedAccountBrands), builder.getLogEntryEvent().RecordJson__c, 'Record JSON is incorrect.');
+        System.Assert.areNotEqual(JSON.serializePretty(mockAccountBrands), builder.getLogEntryEvent().RecordJson__c, 'Record JSON is incorrect.');
+        System.Assert.areEqual(JSON.serializePretty(strippedAccountBrands), builder.getLogEntryEvent().RecordJson__c, 'Record JSON is incorrect.');
     }
 
     static LoggerSettings__c getUserSettings() {

--- a/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Security.cls
+++ b/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Security.cls
@@ -89,7 +89,7 @@ private class LogEntryEventBuilder_Tests_Security {
 
     static LoggerSettings__c getUserSettings() {
         LoggerSettings__c userSettings = (LoggerSettings__c) Schema.LoggerSettings__c.SObjectType.newSObject(null, true);
-        userSettings.SetupOwnerId = UserInfo.getUserId();
+        userSettings.SetupOwnerId = System.UserInfo.getUserId();
         return userSettings;
     }
 }

--- a/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Security.cls
+++ b/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Security.cls
@@ -33,7 +33,7 @@ private class LogEntryEventBuilder_Tests_Security {
 
             LoggerSettings__c userSettings = getUserSettings();
             userSettings.IsRecordFieldStrippingEnabled__c = true;
-            builder = new LogEntryEventBuilder(userSettings, LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAccountBrand);
+            builder = new LogEntryEventBuilder(userSettings, System.LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAccountBrand);
         }
 
         System.Assert.areNotEqual(
@@ -80,7 +80,7 @@ private class LogEntryEventBuilder_Tests_Security {
 
             LoggerSettings__c userSettings = getUserSettings();
             userSettings.IsRecordFieldStrippingEnabled__c = true;
-            builder = new LogEntryEventBuilder(userSettings, LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAccountBrands);
+            builder = new LogEntryEventBuilder(userSettings, System.LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAccountBrands);
         }
 
         System.Assert.areNotEqual(JSON.serializePretty(mockAccountBrands), builder.getLogEntryEvent().RecordJson__c, 'Record JSON is incorrect.');

--- a/nebula-logger/extra-tests/tests/LogEntryHandler_Tests_EmailMessage.cls
+++ b/nebula-logger/extra-tests/tests/LogEntryHandler_Tests_EmailMessage.cls
@@ -8,7 +8,7 @@
 private class LogEntryHandler_Tests_EmailMessage {
     @IsTest
     static void it_should_populate_related_record_name_field_on_log_entry_with_email_message_subject() {
-        System.assertEquals(
+        System.Assert.areEqual(
             false,
             Schema.EmailMessage.Subject.getDescribe().isNameField(),
             'This test assumes that EmailMessage does not use Subject as the object\'s display-name field'
@@ -27,7 +27,7 @@ private class LogEntryHandler_Tests_EmailMessage {
         insert logEntry;
 
         logEntry = [SELECT Id, RecordId__c, RecordName__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.assertEquals(emailMessage.Id, logEntry.RecordId__c);
-        System.assertEquals(emailMessage.Subject, logEntry.RecordName__c);
+        System.Assert.areEqual(emailMessage.Id, logEntry.RecordId__c);
+        System.Assert.areEqual(emailMessage.Subject, logEntry.RecordName__c);
     }
 }

--- a/nebula-logger/extra-tests/tests/LogEntryHandler_Tests_Flow.cls
+++ b/nebula-logger/extra-tests/tests/LogEntryHandler_Tests_Flow.cls
@@ -18,19 +18,19 @@ private class LogEntryHandler_Tests_Flow {
         insert logEntry;
 
         logEntry = getLogEntry();
-        System.assertEquals(null, logEntry.OriginLocation__c, 'Origin Location was not null.');
-        System.assertEquals('Flow', logEntry.OriginType__c, 'Origin Type was not equal to Flow.');
-        System.assertEquals(null, logEntry.FlowActiveVersionId__c, 'FlowActiveVersionId was not null.');
-        System.assertEquals(null, logEntry.FlowDescription__c, 'Flow Description was not null.');
-        System.assertEquals(null, logEntry.FlowDurableId__c, 'FlowDurableId was not null.');
-        System.assertEquals(null, logEntry.FlowLabel__c, 'Flow Label was not null.');
-        System.assertEquals(null, logEntry.FlowLastModifiedByName__c, 'FlowLastModifiedByName was not null.');
-        System.assertEquals(null, logEntry.FlowLastModifiedDate__c, 'FlowLastModifiedDate was not null.');
-        System.assertEquals(null, logEntry.FlowProcessType__c, 'FlowProcessType was not null.');
-        System.assertEquals(null, logEntry.FlowTriggerType__c, 'FlowTriggerType was not null.');
-        System.assertEquals(null, logEntry.FlowVersionApiVersionRuntime__c, 'FlowVersionApiVersionRuntime was not null.');
-        System.assertEquals(null, logEntry.FlowVersionNumber__c, 'FlowVersionNumber was not null.');
-        System.assertEquals(null, logEntry.FlowVersionRunInMode__c, 'FlowVersionRunInMode was not null.');
+        System.Assert.isNull(logEntry.OriginLocation__c, 'Origin Location was not null.');
+        System.Assert.areEqual('Flow', logEntry.OriginType__c, 'Origin Type was not equal to Flow.');
+        System.Assert.isNull(logEntry.FlowActiveVersionId__c, 'FlowActiveVersionId was not null.');
+        System.Assert.isNull(logEntry.FlowDescription__c, 'Flow Description was not null.');
+        System.Assert.isNull(logEntry.FlowDurableId__c, 'FlowDurableId was not null.');
+        System.Assert.isNull(logEntry.FlowLabel__c, 'Flow Label was not null.');
+        System.Assert.isNull(logEntry.FlowLastModifiedByName__c, 'FlowLastModifiedByName was not null.');
+        System.Assert.isNull(logEntry.FlowLastModifiedDate__c, 'FlowLastModifiedDate was not null.');
+        System.Assert.isNull(logEntry.FlowProcessType__c, 'FlowProcessType was not null.');
+        System.Assert.isNull(logEntry.FlowTriggerType__c, 'FlowTriggerType was not null.');
+        System.Assert.isNull(logEntry.FlowVersionApiVersionRuntime__c, 'FlowVersionApiVersionRuntime was not null.');
+        System.Assert.isNull(logEntry.FlowVersionNumber__c, 'FlowVersionNumber was not null.');
+        System.Assert.isNull(logEntry.FlowVersionRunInMode__c, 'FlowVersionRunInMode was not null.');
     }
 
     @IsTest
@@ -45,25 +45,25 @@ private class LogEntryHandler_Tests_Flow {
         insert logEntry;
 
         logEntry = getLogEntry();
-        System.assertEquals(EXAMPLE_FLOW_API_NAME, logEntry.OriginLocation__c, 'Origin Location was not null.');
-        System.assertEquals('Flow', logEntry.OriginType__c, 'OriginType was not flow.');
-        System.assertEquals(flowDefinitionView.ActiveVersionId, logEntry.FlowActiveVersionId__c, 'FlowActiveVersionId was incorrect.');
-        System.assertEquals(flowDefinitionView.Description, logEntry.FlowDescription__c, 'FlowDescription was incorrect.');
-        System.assertEquals(flowDefinitionView.DurableId, logEntry.FlowDurableId__c, 'FlowDurableId was incorrect.');
-        System.assertEquals(flowDefinitionView.Label, logEntry.FlowLabel__c, 'FlowLabel was incorrect');
-        System.assertEquals(flowDefinitionView.LastModifiedBy, logEntry.FlowLastModifiedByName__c, 'FlowLastModifiedByName was incorrect.');
-        System.assertEquals(flowDefinitionView.LastModifiedDate, logEntry.FlowLastModifiedDate__c, 'FlowLastModifiedDate was incorrect.');
-        System.assertEquals(flowDefinitionView.ProcessType, logEntry.FlowProcessType__c, 'FlowProcessType was incorrect.');
-        System.assertEquals(flowDefinitionView.TriggerType, logEntry.FlowTriggerType__c, 'FlowTriggerType was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(EXAMPLE_FLOW_API_NAME, logEntry.OriginLocation__c, 'Origin Location was not null.');
+        System.Assert.areEqual('Flow', logEntry.OriginType__c, 'OriginType was not flow.');
+        System.Assert.areEqual(flowDefinitionView.ActiveVersionId, logEntry.FlowActiveVersionId__c, 'FlowActiveVersionId was incorrect.');
+        System.Assert.areEqual(flowDefinitionView.Description, logEntry.FlowDescription__c, 'FlowDescription was incorrect.');
+        System.Assert.areEqual(flowDefinitionView.DurableId, logEntry.FlowDurableId__c, 'FlowDurableId was incorrect.');
+        System.Assert.areEqual(flowDefinitionView.Label, logEntry.FlowLabel__c, 'FlowLabel was incorrect');
+        System.Assert.areEqual(flowDefinitionView.LastModifiedBy, logEntry.FlowLastModifiedByName__c, 'FlowLastModifiedByName was incorrect.');
+        System.Assert.areEqual(flowDefinitionView.LastModifiedDate, logEntry.FlowLastModifiedDate__c, 'FlowLastModifiedDate was incorrect.');
+        System.Assert.areEqual(flowDefinitionView.ProcessType, logEntry.FlowProcessType__c, 'FlowProcessType was incorrect.');
+        System.Assert.areEqual(flowDefinitionView.TriggerType, logEntry.FlowTriggerType__c, 'FlowTriggerType was incorrect.');
+        System.Assert.areEqual(
             'v' +
             flowVersion.ApiVersionRuntime +
             '.0',
             logEntry.FlowVersionApiVersionRuntime__c,
             'FlowVersionApiVersionRuntime was incorrect.'
         );
-        System.assertEquals(flowVersion.RunInMode, logEntry.FlowVersionRunInMode__c, 'FlowVersionRunInMode was incorrect.');
-        System.assertEquals(flowVersion.VersionNumber, logEntry.FlowVersionNumber__c, 'FlowVersionNumber was incorrect.');
+        System.Assert.areEqual(flowVersion.RunInMode, logEntry.FlowVersionRunInMode__c, 'FlowVersionRunInMode was incorrect.');
+        System.Assert.areEqual(flowVersion.VersionNumber, logEntry.FlowVersionNumber__c, 'FlowVersionNumber was incorrect.');
     }
 
     private static LogEntry__c getLogEntry() {

--- a/nebula-logger/extra-tests/tests/LogManagementDataSelector_Tests_Flow.cls
+++ b/nebula-logger/extra-tests/tests/LogManagementDataSelector_Tests_Flow.cls
@@ -19,19 +19,19 @@ private class LogManagementDataSelector_Tests_Flow {
 
         List<FlowDefinitionView> returnedResults = LogManagementDataSelector.getInstance().getFlowDefinitionViewsByFlowApiName(targetFlowApiNames);
 
-        System.assertEquals(expectedResults, returnedResults);
+        System.Assert.areEqual(expectedResults, returnedResults);
     }
 
     @IsTest
     static void it_does_not_query_flow_definition_views_when_disabled_via_logger_parameter() {
         List<String> targetFlowApiNames = new List<String>{ TEST_FLOW_NAME };
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryFlowDefinitionViewData', Value__c = String.valueOf(false)));
-        System.assertEquals(false, LoggerParameter.QUERY_FLOW_DEFINITION_VIEW_DATA);
+        System.Assert.isFalse(LoggerParameter.QUERY_FLOW_DEFINITION_VIEW_DATA);
         Integer originalQueryCount = System.Limits.getQueries();
 
         List<FlowDefinitionView> returnedResults = LogManagementDataSelector.getInstance().getFlowDefinitionViewsByFlowApiName(targetFlowApiNames);
 
-        System.assertEquals(originalQueryCount, System.Limits.getQueries());
-        System.assertEquals(0, returnedResults.size());
+        System.Assert.areEqual(originalQueryCount, System.Limits.getQueries());
+        System.Assert.areEqual(0, returnedResults.size());
     }
 }

--- a/nebula-logger/extra-tests/tests/LogMassDeleteExtension_Tests_Security.cls
+++ b/nebula-logger/extra-tests/tests/LogMassDeleteExtension_Tests_Security.cls
@@ -39,13 +39,13 @@ private class LogMassDeleteExtension_Tests_Security {
         System.Test.setCurrentPage(pageReference);
         User standardUser = LoggerMockDataCreator.createUser(STANDARD_USER_PROFILE.Id);
         System.runAs(standardUser) {
-            System.assertEquals(false, Schema.Log__c.SObjectType.getDescribe().isDeletable());
+            System.Assert.isFalse(Schema.Log__c.SObjectType.getDescribe().isDeletable());
 
             new LogMassDeleteExtension(controller);
 
             String deleteAccessError = 'You do not have access to delete logs records';
-            System.assertEquals(true, ApexPages.hasMessages(ApexPages.SEVERITY.ERROR));
-            System.assertEquals(deleteAccessError, ApexPages.getMessages().get(0).getSummary());
+            System.Assert.isTrue(ApexPages.hasMessages(ApexPages.SEVERITY.ERROR));
+            System.Assert.areEqual(deleteAccessError, ApexPages.getMessages().get(0).getSummary());
         }
     }
 }

--- a/nebula-logger/extra-tests/tests/LoggerCache_Tests_PlatformCache.cls
+++ b/nebula-logger/extra-tests/tests/LoggerCache_Tests_PlatformCache.cls
@@ -17,34 +17,34 @@ private class LoggerCache_Tests_PlatformCache {
     static void it_adds_new_key_to_organization_and_transaction_cache() {
         String mockKey = 'SomeKey';
         User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
-        System.assertEquals(false, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
 
         LoggerCache.getOrganizationCache().put(mockKey, mockValue);
 
-        System.assertEquals(true, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
-        System.assertEquals(true, Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
-        System.assertEquals(mockValue, Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
+        System.Assert.isTrue(Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
+        System.Assert.areEqual(mockValue, Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
     static void it_adds_new_key_with_null_value_to_organization_and_transaction_cache() {
         String mockKey = 'SomeKey';
         User mockValue = null;
-        System.assertEquals(false, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
 
         LoggerCache.getOrganizationCache().put(mockKey, mockValue);
 
-        System.assertEquals(true, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
-        System.assertEquals(true, Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
-        System.assertEquals(LoggerCache.PLATFORM_CACHE_NULL_VALUE, Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
+        System.Assert.isTrue(Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
+        System.Assert.areEqual(LoggerCache.PLATFORM_CACHE_NULL_VALUE, Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
@@ -52,83 +52,83 @@ private class LoggerCache_Tests_PlatformCache {
         String mockKey = 'SomeKey';
         User oldMockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
         LoggerCache.getOrganizationCache().put(mockKey, oldMockValue);
-        System.assertEquals(true, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(oldMockValue, LoggerCache.getOrganizationCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(oldMockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(oldMockValue, LoggerCache.getOrganizationCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(oldMockValue, LoggerCache.getTransactionCache().get(mockKey));
         Account newMockValue = new Account(Name = 'Some fake account');
 
         LoggerCache.getOrganizationCache().put(mockKey, newMockValue);
 
-        System.assertEquals(true, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(newMockValue, LoggerCache.getOrganizationCache().get(mockKey));
-        System.assertEquals(true, Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
-        System.assertEquals(newMockValue, Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(newMockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(newMockValue, LoggerCache.getOrganizationCache().get(mockKey));
+        System.Assert.isTrue(Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
+        System.Assert.areEqual(newMockValue, Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(newMockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
     static void it_removes_value_for_existing_key_in_organization_and_transaction_cache() {
         String mockKey = 'SomeKey';
         User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
-        System.assertEquals(false, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
         LoggerCache.getOrganizationCache().put(mockKey, mockValue);
-        System.assertEquals(true, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
-        System.assertEquals(true, Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
-        System.assertEquals(mockValue, Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getOrganizationCache().get(mockKey));
+        System.Assert.isTrue(Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
+        System.Assert.areEqual(mockValue, Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
 
         LoggerCache.getOrganizationCache().remove(mockKey);
 
-        System.assertEquals(false, LoggerCache.getOrganizationCache().contains(mockKey));
-        System.assertEquals(false, Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getOrganizationCache().contains(mockKey));
+        System.Assert.isFalse(Cache.Org.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
     }
 
     @IsTest
     static void it_adds_new_key_to_session_and_transaction_cache() {
         String mockKey = 'SomeKey';
         User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
-        System.assertEquals(false, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
 
         LoggerCache.getSessionCache().put(mockKey, mockValue);
 
-        System.assertEquals(true, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getSessionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getSessionCache().get(mockKey));
         // Depending on how you start Apex tests, you may or may not have an active session
         // during the test execution, so session cache may or may not be available (╯°□°)╯︵ ┻━┻
         if (Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).isAvailable() == true) {
-            System.assertEquals(true, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
-            System.assertEquals(mockValue, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
+            System.Assert.isTrue(Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
+            System.Assert.areEqual(mockValue, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
         }
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
     static void it_adds_new_key_with_null_value_to_session_and_transaction_cache() {
         String mockKey = 'SomeKey';
         User mockValue = null;
-        System.assertEquals(false, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
 
         LoggerCache.getSessionCache().put(mockKey, mockValue);
 
-        System.assertEquals(true, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getSessionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getSessionCache().get(mockKey));
         // Depending on how you start Apex tests, you may or may not have an active session
         // during the test execution, so session cache may or may not be available (╯°□°)╯︵ ┻━┻
         if (Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).isAvailable() == true) {
-            System.assertEquals(true, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
-            System.assertEquals(LoggerCache.PLATFORM_CACHE_NULL_VALUE, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
+            System.Assert.isTrue(Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
+            System.Assert.areEqual(LoggerCache.PLATFORM_CACHE_NULL_VALUE, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
         }
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
@@ -136,48 +136,48 @@ private class LoggerCache_Tests_PlatformCache {
         String mockKey = 'SomeKey';
         User oldMockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
         LoggerCache.getSessionCache().put(mockKey, oldMockValue);
-        System.assertEquals(true, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(oldMockValue, LoggerCache.getSessionCache().get(mockKey));
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(oldMockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(oldMockValue, LoggerCache.getSessionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(oldMockValue, LoggerCache.getTransactionCache().get(mockKey));
         Account newMockValue = new Account(Name = 'Some fake account');
 
         LoggerCache.getSessionCache().put(mockKey, newMockValue);
 
-        System.assertEquals(true, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(newMockValue, LoggerCache.getSessionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(newMockValue, LoggerCache.getSessionCache().get(mockKey));
         // Depending on how you start Apex tests, you may or may not have an active session
         // during the test execution, so session cache may or may not be available (╯°□°)╯︵ ┻━┻
         if (Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).isAvailable() == true) {
-            System.assertEquals(true, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
-            System.assertEquals(newMockValue, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
+            System.Assert.isTrue(Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
+            System.Assert.areEqual(newMockValue, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
         }
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(newMockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(newMockValue, LoggerCache.getTransactionCache().get(mockKey));
     }
 
     @IsTest
     static void it_removes_value_for_existing_key_in_session_and_transaction_cache() {
         String mockKey = 'SomeKey';
         User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
-        System.assertEquals(false, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
         LoggerCache.getSessionCache().put(mockKey, mockValue);
-        System.assertEquals(true, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getSessionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getSessionCache().get(mockKey));
         // Depending on how you start Apex tests, you may or may not have an active session
         // during the test execution, so session cache may or may not be available (╯°□°)╯︵ ┻━┻
         if (Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).isAvailable() == true) {
-            System.assertEquals(true, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
-            System.assertEquals(mockValue, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
+            System.Assert.isTrue(Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
+            System.Assert.areEqual(mockValue, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
         }
-        System.assertEquals(true, LoggerCache.getTransactionCache().contains(mockKey));
-        System.assertEquals(mockValue, LoggerCache.getTransactionCache().get(mockKey));
+        System.Assert.isTrue(LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.areEqual(mockValue, LoggerCache.getTransactionCache().get(mockKey));
 
         LoggerCache.getSessionCache().remove(mockKey);
 
-        System.assertEquals(false, LoggerCache.getSessionCache().contains(mockKey));
-        System.assertEquals(false, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
-        System.assertEquals(false, LoggerCache.getTransactionCache().contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getSessionCache().contains(mockKey));
+        System.Assert.isFalse(Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
+        System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
     }
 }

--- a/nebula-logger/extra-tests/tests/LoggerCache_Tests_PlatformCache.cls
+++ b/nebula-logger/extra-tests/tests/LoggerCache_Tests_PlatformCache.cls
@@ -16,7 +16,7 @@ private class LoggerCache_Tests_PlatformCache {
     @IsTest
     static void it_adds_new_key_to_organization_and_transaction_cache() {
         String mockKey = 'SomeKey';
-        User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User mockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         System.Assert.isFalse(LoggerCache.getOrganizationCache().contains(mockKey));
         System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
 
@@ -50,7 +50,7 @@ private class LoggerCache_Tests_PlatformCache {
     @IsTest
     static void it_updates_value_for_existing_key_in_organization_and_transaction_cache() {
         String mockKey = 'SomeKey';
-        User oldMockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User oldMockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         LoggerCache.getOrganizationCache().put(mockKey, oldMockValue);
         System.Assert.isTrue(LoggerCache.getOrganizationCache().contains(mockKey));
         System.Assert.areEqual(oldMockValue, LoggerCache.getOrganizationCache().get(mockKey));
@@ -71,7 +71,7 @@ private class LoggerCache_Tests_PlatformCache {
     @IsTest
     static void it_removes_value_for_existing_key_in_organization_and_transaction_cache() {
         String mockKey = 'SomeKey';
-        User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User mockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         System.Assert.isFalse(LoggerCache.getOrganizationCache().contains(mockKey));
         System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
         LoggerCache.getOrganizationCache().put(mockKey, mockValue);
@@ -92,7 +92,7 @@ private class LoggerCache_Tests_PlatformCache {
     @IsTest
     static void it_adds_new_key_to_session_and_transaction_cache() {
         String mockKey = 'SomeKey';
-        User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User mockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         System.Assert.isFalse(LoggerCache.getSessionCache().contains(mockKey));
         System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
 
@@ -134,7 +134,7 @@ private class LoggerCache_Tests_PlatformCache {
     @IsTest
     static void it_updates_value_for_existing_key_in_session_and_transaction_cache() {
         String mockKey = 'SomeKey';
-        User oldMockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User oldMockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         LoggerCache.getSessionCache().put(mockKey, oldMockValue);
         System.Assert.isTrue(LoggerCache.getSessionCache().contains(mockKey));
         System.Assert.areEqual(oldMockValue, LoggerCache.getSessionCache().get(mockKey));
@@ -159,7 +159,7 @@ private class LoggerCache_Tests_PlatformCache {
     @IsTest
     static void it_removes_value_for_existing_key_in_session_and_transaction_cache() {
         String mockKey = 'SomeKey';
-        User mockValue = new User(Id = UserInfo.getUserId(), ProfileId = UserInfo.getProfileId());
+        User mockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
         System.Assert.isFalse(LoggerCache.getSessionCache().contains(mockKey));
         System.Assert.isFalse(LoggerCache.getTransactionCache().contains(mockKey));
         LoggerCache.getSessionCache().put(mockKey, mockValue);

--- a/nebula-logger/extra-tests/tests/LoggerEngineDataSelector_Tests_Network.cls
+++ b/nebula-logger/extra-tests/tests/LoggerEngineDataSelector_Tests_Network.cls
@@ -18,15 +18,15 @@ private class LoggerEngineDataSelector_Tests_Network {
         }
 
         Id expectedNetworkId = (Id) getExperienceCloudNetwork().get('Id');
-        System.assertEquals(1, System.Limits.getQueries());
+        System.Assert.areEqual(1, System.Limits.getQueries());
         Integer expectedQueryCount = System.Limits.getQueries() + 1;
 
-        LoggerSObjectProxy.Network returnedProxyNetwork = LoggerEngineDataSelector.getInstance().getCachedNetworkProxy(expectedNetworkId);
+        LoggerSObjectProxy.Network returnedNetworkProxy = LoggerEngineDataSelector.getInstance().getCachedNetworkProxy(expectedNetworkId);
 
-        System.assertEquals(expectedQueryCount, System.Limits.getQueries());
+        System.Assert.areEqual(expectedQueryCount, System.Limits.getQueries());
         LoggerEngineDataSelector.getInstance().getCachedNetworkProxy(expectedNetworkId);
-        System.assertEquals(expectedQueryCount, System.Limits.getQueries(), 'Query results should have been cached');
-        System.assertEquals(expectedNetworkId, returnedProxyNetwork?.Id);
+        System.Assert.areEqual(expectedQueryCount, System.Limits.getQueries(), 'Query results should have been cached');
+        System.Assert.areEqual(expectedNetworkId, returnedNetworkProxy?.Id);
     }
 
     static SObject getExperienceCloudNetwork() {

--- a/nebula-logger/extra-tests/tests/LoggerSObjectHandler_Tests_Flow.cls
+++ b/nebula-logger/extra-tests/tests/LoggerSObjectHandler_Tests_Flow.cls
@@ -27,12 +27,12 @@ private class LoggerSObjectHandler_Tests_Flow {
 
         mockHandler.execute();
 
-        System.assertEquals(1, mockHandler.getPluginConfigurations().size(), mockHandler.getPluginConfigurations());
-        System.assertEquals(1, mockHandler.getExecutedFlowPlugins().size(), mockHandler.getExecutedFlowPlugins());
+        System.Assert.areEqual(1, mockHandler.getPluginConfigurations().size(), mockHandler.getPluginConfigurations().toString());
+        System.Assert.areEqual(1, mockHandler.getExecutedFlowPlugins().size(), mockHandler.getExecutedFlowPlugins().toString());
         Flow.Interview executedFlowPlugin = mockHandler.getExecutedFlowPlugins().get(0);
-        System.assertEquals(mockPluginConfiguration, executedFlowPlugin.getVariableValue('pluginConfiguration'));
-        System.assertEquals(mockHandler.input, executedFlowPlugin.getVariableValue('pluginInput'));
-        System.assertEquals(MOCK_FLOW_OUTPUT_VARIABLE_VALUE, executedFlowPlugin.getVariableValue('someExampleVariable'));
+        System.Assert.areEqual(mockPluginConfiguration, executedFlowPlugin.getVariableValue('pluginConfiguration'));
+        System.Assert.areEqual(mockHandler.input, executedFlowPlugin.getVariableValue('pluginInput'));
+        System.Assert.areEqual(MOCK_FLOW_OUTPUT_VARIABLE_VALUE, executedFlowPlugin.getVariableValue('someExampleVariable'));
     }
 
     private class MockLogHandler extends LoggerSObjectHandler {

--- a/nebula-logger/extra-tests/tests/LoggerSettingsController_Tests_Security.cls
+++ b/nebula-logger/extra-tests/tests/LoggerSettingsController_Tests_Security.cls
@@ -24,8 +24,8 @@ private class LoggerSettingsController_Tests_Security {
         insert new List<SObject>{ setupEntityAccess, permissionSetAssignment };
 
         System.runAs(standardUser) {
-            System.assertEquals(true, FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME), permissionSetAssignment);
-            System.assertEquals(true, LoggerSettingsController.canUserModifyLoggerSettings());
+            System.Assert.isTrue(FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME), JSON.serializePretty(permissionSetAssignment));
+            System.Assert.isTrue(LoggerSettingsController.canUserModifyLoggerSettings());
         }
     }
 
@@ -36,8 +36,8 @@ private class LoggerSettingsController_Tests_Security {
         LoggerTestConfigurator.assignAdminPermissionSet(standardUser.Id);
 
         System.runAs(standardUser) {
-            System.assertEquals(true, FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
-            System.assertEquals(true, LoggerSettingsController.canUserModifyLoggerSettings());
+            System.Assert.isTrue(FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
+            System.Assert.isTrue(LoggerSettingsController.canUserModifyLoggerSettings());
         }
     }
 
@@ -48,8 +48,8 @@ private class LoggerSettingsController_Tests_Security {
         LoggerTestConfigurator.assignLogViewerPermissionSet(standardUser.Id);
 
         System.runAs(standardUser) {
-            System.assertEquals(false, FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
-            System.assertEquals(false, LoggerSettingsController.canUserModifyLoggerSettings());
+            System.Assert.isFalse(FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
+            System.Assert.isFalse(LoggerSettingsController.canUserModifyLoggerSettings());
         }
     }
 
@@ -60,8 +60,8 @@ private class LoggerSettingsController_Tests_Security {
         LoggerTestConfigurator.assignEndUserPermissionSet(standardUser.Id);
 
         System.runAs(standardUser) {
-            System.assertEquals(false, FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
-            System.assertEquals(false, LoggerSettingsController.canUserModifyLoggerSettings());
+            System.Assert.isFalse(FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
+            System.Assert.isFalse(LoggerSettingsController.canUserModifyLoggerSettings());
         }
     }
 
@@ -72,8 +72,8 @@ private class LoggerSettingsController_Tests_Security {
         LoggerTestConfigurator.assignLogCreatorPermissionSet(standardUser.Id);
 
         System.runAs(standardUser) {
-            System.assertEquals(false, FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
-            System.assertEquals(false, LoggerSettingsController.canUserModifyLoggerSettings());
+            System.Assert.isFalse(FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
+            System.Assert.isFalse(LoggerSettingsController.canUserModifyLoggerSettings());
         }
     }
 
@@ -81,7 +81,7 @@ private class LoggerSettingsController_Tests_Security {
     static void it_should_not_permit_user_to_modify_logger_settings_when_custom_permission_is_not_assigned() {
         User standardUser = LoggerMockDataCreator.createUser(STANDARD_USER_PROFILE.Id);
         System.runAs(standardUser) {
-            System.assertEquals(false, LoggerSettingsController.canUserModifyLoggerSettings());
+            System.Assert.isFalse(LoggerSettingsController.canUserModifyLoggerSettings());
         }
     }
 }

--- a/nebula-logger/extra-tests/tests/Logger_Tests_InboundEmailHandler.cls
+++ b/nebula-logger/extra-tests/tests/Logger_Tests_InboundEmailHandler.cls
@@ -17,18 +17,18 @@ private class Logger_Tests_InboundEmailHandler {
         System.Test.startTest();
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
         String transactionId = Logger.getTransactionId();
-        System.assertNotEquals(1, Logger.saveLogCallCount, 'No logging should have occurred yet');
+        System.Assert.areNotEqual(1, Logger.saveLogCallCount, 'No logging should have occurred yet');
 
         Messaging.InboundEmailResult result = emailHandler.handleInboundEmail(email, envelope);
 
-        System.assertNotEquals(0, Logger.saveLogCallCount, 'ExampleInboundEmailHandler class should have logged & saved some logging data');
+        System.Assert.areNotEqual(0, Logger.saveLogCallCount, 'ExampleInboundEmailHandler class should have logged & saved some logging data');
         System.Test.stopTest();
-        System.assertEquals(true, result.success, 'InboundEmailResult returned a failure message');
+        System.Assert.isTrue(result.success, 'InboundEmailResult returned a failure message');
         List<Log__c> logs = [SELECT Id, TransactionId__c FROM Log__c];
-        System.assertEquals(1, logs.size(), 'Logs size did not match expected value of 1.');
-        System.assertEquals(transactionId, logs.get(0).TransactionId__c, 'Transaction Id does match expected value');
+        System.Assert.areEqual(1, logs.size(), 'Logs size did not match expected value of 1.');
+        System.Assert.areEqual(transactionId, logs.get(0).TransactionId__c, 'Transaction Id does match expected value');
         List<LogEntry__c> logEntries = [SELECT Id, Message__c FROM LogEntry__c];
-        System.assertEquals(2, logEntries.size(), 'Log entries size did not match expected value of 2 ' + JSON.serializePretty(logEntries));
-        System.assertEquals(ExampleInboundEmailHandler.logEntryMessage, logEntries.get(0).Message__c, 'Log entries message did not match expected value');
+        System.Assert.areEqual(2, logEntries.size(), 'Log entries size did not match expected value of 2 ' + JSON.serializePretty(logEntries));
+        System.Assert.areEqual(ExampleInboundEmailHandler.logEntryMessage, logEntries.get(0).Message__c, 'Log entries message did not match expected value');
     }
 }

--- a/nebula-logger/extra-tests/tests/Logger_Tests_MergeResult.cls
+++ b/nebula-logger/extra-tests/tests/Logger_Tests_MergeResult.cls
@@ -22,7 +22,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addErrorEntryForLogMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -59,7 +59,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addErrorEntryForLogMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -91,7 +91,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addErrorEntryForStringMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -128,7 +128,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addErrorEntryForStringMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.ERROR;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -165,7 +165,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addWarnEntryForLogMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -202,7 +202,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addWarnEntryForLogMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -234,7 +234,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addWarnEntryForStringMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -271,7 +271,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addWarnEntryForStringMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.WARN;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -308,7 +308,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addAnInfoEntryForLogMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -345,7 +345,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addInfoEntryForLogMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -377,7 +377,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addInfoEntryForStringMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -414,7 +414,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addAnInfoEntryForStringMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.INFO;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Log entry buffer size was incorrect.');
 
@@ -451,7 +451,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addDebugEntryForLogMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -488,7 +488,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addDebugEntryForLogMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -520,7 +520,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addDebugEntryForStringMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -557,7 +557,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addDebugEntryForStringMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.DEBUG;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.DEBUG;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -594,7 +594,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addFineEntryForLogMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -631,7 +631,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addFineEntryForLogMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -663,7 +663,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addFineEntryForStringMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -700,7 +700,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addFineEntryForStringMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINE;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINE;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -737,7 +737,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addFinerEntryForLogMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -774,7 +774,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addFinerEntryForLogMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -806,7 +806,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addFinerEntryForStringMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -843,7 +843,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addFinerEntryForStringMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINER;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINER;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -880,7 +880,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addFinestEntryForLogMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -917,7 +917,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addFinestEntryForLogMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -949,7 +949,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addFinestEntryForStringMessageWithMergeResult() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
@@ -986,7 +986,7 @@ private class Logger_Tests_MergeResult {
 
     @IsTest
     static void addFinestEntryForStringMessageWithMergeResultList() {
-        LoggingLevel loggingLevel = LoggingLevel.FINEST;
+        System.LoggingLevel loggingLevel = System.LoggingLevel.FINEST;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
         System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 

--- a/nebula-logger/extra-tests/tests/Logger_Tests_MergeResult.cls
+++ b/nebula-logger/extra-tests/tests/Logger_Tests_MergeResult.cls
@@ -24,7 +24,7 @@ private class Logger_Tests_MergeResult {
     static void addErrorEntryForLogMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -34,34 +34,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Logging level name was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Logging level name was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry record JSON was incorrect.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry tags was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry tags was incorrect.');
     }
 
     @IsTest
     static void addErrorEntryForLogMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -71,29 +71,29 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Logging level was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Logging level was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry record JSON was incorrect.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags was incorrect.');
     }
 
     @IsTest
     static void addErrorEntryForStringMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -103,34 +103,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was incorrect.');
     }
 
     @IsTest
     static void addErrorEntryForStringMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.ERROR;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -140,34 +140,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             'List',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was incorrect.');
     }
 
     @IsTest
     static void addWarnEntryForLogMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -177,34 +177,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field not null.');
     }
 
     @IsTest
     static void addWarnEntryForLogMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -214,29 +214,29 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addWarnEntryForStringMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -246,34 +246,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null');
     }
 
     @IsTest
     static void addWarnEntryForStringMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.WARN;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -283,34 +283,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event recrd JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event recrd JSON was incorrect.');
+        System.Assert.areEqual(
             'List',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event databse result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result json was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addAnInfoEntryForLogMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -320,34 +320,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was not null.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was not null.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addInfoEntryForLogMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -357,29 +357,29 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null');
     }
 
     @IsTest
     static void addInfoEntryForStringMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -389,34 +389,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null');
     }
 
     @IsTest
     static void addAnInfoEntryForStringMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.INFO;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Log entry buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Log entry buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -426,34 +426,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry record JSON was incorrect.');
+        System.Assert.areEqual(
             'List',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addDebugEntryForLogMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -463,34 +463,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addDebugEntryForLogMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -500,29 +500,29 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addDebugEntryForStringMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -532,34 +532,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addDebugEntryForStringMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.DEBUG;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -569,34 +569,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             'List',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addFineEntryForLogMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -606,34 +606,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addFineEntryForLogMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -643,29 +643,29 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addFineEntryForStringMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -675,34 +675,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log event logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log event logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was incorrect.');
     }
 
     @IsTest
     static void addFineEntryForStringMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINE;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -712,34 +712,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             'List',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addFinerEntryForLogMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -749,34 +749,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addFinerEntryForLogMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -786,29 +786,29 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addFinerEntryForStringMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -818,34 +818,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addFinerEntryForStringMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINER;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -855,34 +855,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             'List',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addFinestEntryForLogMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -892,34 +892,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addFinestEntryForLogMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -929,29 +929,29 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getLogMessage().getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addFinestEntryForStringMessageWithMergeResult() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         Database.MergeResult mergeResult = LoggerMockDataCreator.createDatabaseMergeResult(true);
 
@@ -961,34 +961,34 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.areEqual(mergeResult.getId(), entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             'Single',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResult),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 
     @IsTest
     static void addFinestEntryForStringMessageWithMergeResultList() {
         LoggingLevel loggingLevel = LoggingLevel.FINEST;
         Logger.getUserSettings().LoggingLevel__c = loggingLevel.name();
-        System.assertEquals(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
 
         List<Database.MergeResult> mergeResults = getMergeResultList();
 
@@ -998,26 +998,26 @@ private class Logger_Tests_MergeResult {
 
         System.Test.stopTest();
 
-        System.assertEquals(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
-        System.assertEquals(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
-        System.assertEquals(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
-        System.assertEquals(
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Logger buffer size was incorrect.');
+        System.Assert.areEqual(loggingLevel.name(), entryBuilder.getLogEntryEvent().LoggingLevel__c, 'Log entry event logging level was incorrect.');
+        System.Assert.areEqual(getMessage(), entryBuilder.getLogEntryEvent().Message__c, 'Log entry event message was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordId__c, 'Log entry event record id was incorrect.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().RecordJson__c, 'Log entry event record JSON was incorrect.');
+        System.Assert.areEqual(
             'List',
             entryBuilder.getLogEntryEvent().DatabaseResultCollectionType__c,
             'Log entry event database result collection type was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             JSON.serializePretty(mergeResults),
             entryBuilder.getLogEntryEvent().DatabaseResultJson__c,
             'Log entry event database result JSON was incorrect.'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             Database.MergeResult.class.getName(),
             entryBuilder.getLogEntryEvent().DatabaseResultType__c,
             'Log entry event database result type was incorrect.'
         );
-        System.assertEquals(null, entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
+        System.Assert.isNull(entryBuilder.getLogEntryEvent().Tags__c, 'Log entry event tags field was not null.');
     }
 }

--- a/nebula-logger/extra-tests/tests/Logger_Tests_Network.cls
+++ b/nebula-logger/extra-tests/tests/Logger_Tests_Network.cls
@@ -24,7 +24,7 @@ private class Logger_Tests_Network {
         }
 
         Profile loggerSiteProfile = matchingProfiles.get(0);
-        System.assertEquals('Guest User License', loggerSiteProfile.UserLicense.Name, 'User license did not match Guest User License.');
+        System.Assert.areEqual('Guest User License', loggerSiteProfile.UserLicense.Name, 'User license did not match Guest User License.');
 
         // Even if Experience Cloud is enabled, the expected test site might not exist, so exit early if the guest user cannot be found
         List<User> guestUsers = [SELECT Id FROM User WHERE Profile.Name = :EXPERIENCE_CLOUD_GUEST_PROFILE_NAME AND Profile.UserType = :GUEST_USER_TYPE];
@@ -58,10 +58,10 @@ private class Logger_Tests_Network {
         try {
             log.OwnerId = guestUser.Id;
             update log;
-            System.assert(false, 'Expected exception, this exception should not occur');
+            System.Assert.fail('Expected exception, this exception should not occur');
         } catch (Exception ex) {
             String expectedExceptionMessage = 'FIELD_INTEGRITY_EXCEPTION, field integrity exception (Guest users cannot be record owners.)';
-            System.assert(ex.getMessage().contains(expectedExceptionMessage), 'Exception did not contain expected message.');
+            System.Assert.isTrue(ex.getMessage().contains(expectedExceptionMessage), 'Exception did not contain expected message.');
         }
         System.Test.stopTest();
     }
@@ -97,10 +97,10 @@ private class Logger_Tests_Network {
             SELECT Id, Log__r.LoggedBy__c, Log__r.OwnerId, Log__r.UserLicenseDefinitionKey__c, Log__r.UserType__c, Message__c
             FROM LogEntry__c
         ];
-        System.assertEquals(guestUser.Id, logEntry.Log__r.LoggedBy__c, 'LoggedBy was set to the wrong user ID');
-        System.assertNotEquals(guestUser.Id, logEntry.Log__r.OwnerId, 'Log owner ID was incorrect');
-        System.assertEquals(GUEST_USER_TYPE, logEntry.Log__r.UserType__c, 'UserType was incorrect');
-        System.assertEquals('PID_Guest_User', logEntry.Log__r.UserLicenseDefinitionKey__c, 'UserLicenseDefinitionKey was incorrect');
-        System.assertEquals(message, logEntry.Message__c, 'Log Entry message was incorrect');
+        System.Assert.areEqual(guestUser.Id, logEntry.Log__r.LoggedBy__c, 'LoggedBy was set to the wrong user ID');
+        System.Assert.areNotEqual(guestUser.Id, logEntry.Log__r.OwnerId, 'Log owner ID was incorrect');
+        System.Assert.areEqual(GUEST_USER_TYPE, logEntry.Log__r.UserType__c, 'UserType was incorrect');
+        System.Assert.areEqual('PID_Guest_User', logEntry.Log__r.UserLicenseDefinitionKey__c, 'UserLicenseDefinitionKey was incorrect');
+        System.Assert.areEqual(message, logEntry.Message__c, 'Log Entry message was incorrect');
     }
 }

--- a/nebula-logger/extra-tests/tests/Logger_Tests_Network.cls
+++ b/nebula-logger/extra-tests/tests/Logger_Tests_Network.cls
@@ -59,9 +59,9 @@ private class Logger_Tests_Network {
             log.OwnerId = guestUser.Id;
             update log;
             System.Assert.fail('Expected exception, this exception should not occur');
-        } catch (Exception ex) {
+        } catch (System.Exception ex) {
             String expectedExceptionMessage = 'FIELD_INTEGRITY_EXCEPTION, field integrity exception (Guest users cannot be record owners.)';
-            System.Assert.isTrue(ex.getMessage().contains(expectedExceptionMessage), 'Exception did not contain expected message.');
+            System.Assert.isTrue(ex.getMessage().contains(expectedExceptionMessage), 'System.Exception did not contain expected message.');
         }
         System.Test.stopTest();
     }

--- a/nebula-logger/managed-package/core/main/configuration/classes/LoggerInstallHandler_Tests.cls
+++ b/nebula-logger/managed-package/core/main/configuration/classes/LoggerInstallHandler_Tests.cls
@@ -43,8 +43,8 @@ private class LoggerInstallHandler_Tests {
 
         List<LoggerSettings__c> mockSettings = new List<LoggerSettings__c>{
             LoggerSettings__c.getOrgDefaults(),
-            LoggerSettings__c.getInstance(UserInfo.getProfileId()),
-            LoggerSettings__c.getInstance(UserInfo.getUserId())
+            LoggerSettings__c.getInstance(System.UserInfo.getProfileId()),
+            LoggerSettings__c.getInstance(System.UserInfo.getUserId())
         };
         for (LoggerSettings__c setting : mockSettings) {
             setting.DefaultSaveMethod__c = null;

--- a/nebula-logger/managed-package/core/main/configuration/classes/LoggerInstallHandler_Tests.cls
+++ b/nebula-logger/managed-package/core/main/configuration/classes/LoggerInstallHandler_Tests.cls
@@ -10,7 +10,7 @@ private class LoggerInstallHandler_Tests {
     static void it_should_initialize_logger_settings_when_installed() {
         // Quick sanity check to make sure there are no existing records
         List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
-        System.assertEquals(0, existingSettings.size());
+        System.Assert.areEqual(0, existingSettings.size());
 
         // Currently, there's no logic in LoggerInstallerHandler that checks for a specific version number or upgrades...
         // so null/false are fine for this test right now
@@ -25,11 +25,11 @@ private class LoggerInstallHandler_Tests {
 
         // Verify that we now have 1 record...
         List<LoggerSettings__c> loggerSettings = [SELECT Id FROM LoggerSettings__c];
-        System.assertEquals(1, loggerSettings.size());
+        System.Assert.areEqual(1, loggerSettings.size());
 
         // ..and verify that it's the org defaults
         LoggerSettings__c orgDefaults = LoggerSettings__c.getOrgDefaults();
-        System.assertEquals(orgDefaults.Id, loggerSettings.get(0).Id);
+        System.Assert.areEqual(orgDefaults.Id, loggerSettings.get(0).Id);
     }
 
     @IsTest
@@ -39,7 +39,7 @@ private class LoggerInstallHandler_Tests {
 
         // Quick sanity check to make sure there are no existing records
         List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
-        System.assertEquals(0, existingSettings.size());
+        System.Assert.areEqual(0, existingSettings.size());
 
         List<LoggerSettings__c> mockSettings = new List<LoggerSettings__c>{
             LoggerSettings__c.getOrgDefaults(),
@@ -66,14 +66,14 @@ private class LoggerInstallHandler_Tests {
         System.Test.stopTest();
 
         for (LoggerSettings__c setting : mockSettings) {
-            System.assertNotEquals(null, setting.DefaultSaveMethod__c);
+            System.Assert.isNotNull(setting.DefaultSaveMethod__c);
         }
 
         // Verify that all records have been updated with a default save method
         List<LoggerSettings__c> loggerSettings = [SELECT Id, DefaultSaveMethod__c FROM LoggerSettings__c];
-        System.assertEquals(3, loggerSettings.size());
+        System.Assert.areEqual(3, loggerSettings.size());
         for (LoggerSettings__c setting : loggerSettings) {
-            System.assertNotEquals(null, setting.DefaultSaveMethod__c);
+            System.Assert.isNotNull(setting.DefaultSaveMethod__c);
         }
     }
 }

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogBatchApexErrorEventHandler_Tests.cls
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogBatchApexErrorEventHandler_Tests.cls
@@ -39,7 +39,7 @@ private class LogBatchApexErrorEventHandler_Tests implements Database.Batchable<
             System.Test.startTest();
             Database.executeBatch(new LogBatchApexErrorEventHandler_Tests(phase));
             System.Test.stopTest();
-        } catch (Exception ex) {
+        } catch (System.Exception ex) {
             // via https://salesforce.stackexchange.com/questions/263419/testing-batchapexerrorevent-trigger
         }
         // at this point, we're still two async-levels deep into Platform Event-land; we need to call "deliver()" twice
@@ -90,7 +90,7 @@ private class LogBatchApexErrorEventHandler_Tests implements Database.Batchable<
 
     private void throwOnLocationMatch(Phase phase) {
         if (this.throwLocation == phase) {
-            throw new IllegalArgumentException(this.throwLocation.name());
+            throw new System.IllegalArgumentException(this.throwLocation.name());
         }
     }
 

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogBatchApexErrorEventHandler_Tests.cls
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogBatchApexErrorEventHandler_Tests.cls
@@ -51,10 +51,10 @@ private class LogBatchApexErrorEventHandler_Tests implements Database.Batchable<
 
     private static void assertLogWasCreatedForPhase(Phase phase) {
         Log__c log = getLog();
-        System.assertNotEquals(null, log, 'Log should have been created!');
-        System.assertEquals(2, log.LogEntries__r.size(), 'Two log entries should have been created');
-        System.assertEquals('Batch job terminated unexpectedly', log.LogEntries__r[0].Message__c);
-        System.assertEquals(
+        System.Assert.isNotNull(log, 'Log should have been created!');
+        System.Assert.areEqual(2, log.LogEntries__r.size(), 'Two log entries should have been created');
+        System.Assert.areEqual('Batch job terminated unexpectedly', log.LogEntries__r[0].Message__c);
+        System.Assert.areEqual(
             String.format(
                     LogBatchApexErrorEventHandler.LOG_MESSAGE,
                     new List<String>{ 'someId', 'System.IllegalArgumentException', phase.name(), phase.name(), 'stacktrace' }

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFinalizer_Tests.cls
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFinalizer_Tests.cls
@@ -22,7 +22,7 @@ private class LogFinalizer_Tests {
             System.Test.startTest();
             System.enqueueJob(new ExampleFailedQueueable());
             System.Test.stopTest();
-        } catch (Exception ex) {
+        } catch (System.Exception ex) {
             System.Assert.areEqual(EXPECTED_ERROR_MESSAGE, ex.getMessage());
         }
         System.Test.getEventBus().deliver();
@@ -49,7 +49,7 @@ private class LogFinalizer_Tests {
 
     private virtual class ExampleFailedQueueable extends ExampleQueueable {
         protected override void innerExecute() {
-            throw new IllegalArgumentException(EXPECTED_ERROR_MESSAGE);
+            throw new System.IllegalArgumentException(EXPECTED_ERROR_MESSAGE);
         }
     }
 }

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFinalizer_Tests.cls
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFinalizer_Tests.cls
@@ -13,7 +13,7 @@ private class LogFinalizer_Tests {
         System.Test.stopTest();
         System.Test.getEventBus().deliver();
 
-        System.assertEquals(0, [SELECT COUNT() FROM Log__c], 'Should not log if no errors');
+        System.Assert.areEqual(0, [SELECT COUNT() FROM Log__c], 'Should not log if no errors');
     }
 
     @IsTest
@@ -23,17 +23,17 @@ private class LogFinalizer_Tests {
             System.enqueueJob(new ExampleFailedQueueable());
             System.Test.stopTest();
         } catch (Exception ex) {
-            System.assertEquals(EXPECTED_ERROR_MESSAGE, ex.getMessage());
+            System.Assert.areEqual(EXPECTED_ERROR_MESSAGE, ex.getMessage());
         }
         System.Test.getEventBus().deliver();
 
         List<LogEntry__c> logEntries = [SELECT Message__c, ExceptionMessage__c FROM LogEntry__c];
-        System.assertEquals(2, logEntries.size(), 'Should log for errors');
+        System.Assert.areEqual(2, logEntries.size(), 'Should log for errors');
         LogEntry__c firstEntry = logEntries.get(0);
-        System.assertEquals('There was an error during this queueable job', firstEntry.Message__c);
+        System.Assert.areEqual('There was an error during this queueable job', firstEntry.Message__c);
         LogEntry__c secondEntry = logEntries.get(1);
-        System.assertEquals('Error details', secondEntry.Message__c);
-        System.assertEquals(EXPECTED_ERROR_MESSAGE, secondEntry.ExceptionMessage__c);
+        System.Assert.areEqual('Error details', secondEntry.Message__c);
+        System.Assert.areEqual(EXPECTED_ERROR_MESSAGE, secondEntry.ExceptionMessage__c);
     }
 
     private virtual class ExampleQueueable implements System.Queueable {

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFlowExecutionErrorEventHandler_Tests.cls
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFlowExecutionErrorEventHandler_Tests.cls
@@ -24,7 +24,7 @@ private class LogFlowExecutionErrorEventHandler_Tests {
         flowExecutionErrorEvent.ElementApiName = 'test_exception_element';
         flowExecutionErrorEvent.FlowApiName = 'Testing_FlowExecutionErrorEvent';
         flowExecutionErrorEvent.FlowVersionNumber = 1;
-        flowExecutionErrorEvent.Username = UserInfo.getUserName();
+        flowExecutionErrorEvent.Username = System.UserInfo.getUserName();
 
         System.runAs(new User(Id = [SELECT Id FROM User WHERE Alias = 'autoproc'].Id)) {
             System.Test.startTest();
@@ -89,7 +89,7 @@ private class LogFlowExecutionErrorEventHandler_Tests {
                 UserRole.Name,
                 UserType
             FROM User
-            WHERE Id = :UserInfo.getUserId()
+            WHERE Id = :System.UserInfo.getUserId()
         ];
         Log__c log = entry.Log__r;
         System.Assert.areEqual(currentUser.Id, log.LoggedBy__c, 'Should not use autoproc user Id');
@@ -107,8 +107,8 @@ private class LogFlowExecutionErrorEventHandler_Tests {
         System.Assert.isNull(log.SessionSecurityLevel__c, 'SessionSecurityLevel__c should have been cleared');
         System.Assert.isNull(log.SessionType__c, 'SessionType__c should have been cleared');
         System.Assert.isNull(log.SourceIp__c, 'SourceIp__c should have been cleared');
-        System.Assert.areEqual(UserInfo.getTimeZone().getId(), log.TimeZoneId__c, 'Timezone Id should be set correctly');
-        System.Assert.areEqual(UserInfo.getTimeZone().getDisplayName(), log.TimeZoneName__c, 'Timezone name should be set correctly');
+        System.Assert.areEqual(System.UserInfo.getTimeZone().getId(), log.TimeZoneId__c, 'Timezone Id should be set correctly');
+        System.Assert.areEqual(System.UserInfo.getTimeZone().getDisplayName(), log.TimeZoneName__c, 'Timezone name should be set correctly');
     }
 
     static void setLoggerParamEnabled(Boolean value) {

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFlowExecutionErrorEventHandler_Tests.cls
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFlowExecutionErrorEventHandler_Tests.cls
@@ -13,7 +13,7 @@ private class LogFlowExecutionErrorEventHandler_Tests {
         LogFlowExecutionErrorEventHandler.logErrors(new List<FlowExecutionErrorEvent>{ new FlowExecutionErrorEvent() });
         System.Test.stopTest();
 
-        System.assertEquals(0, [SELECT COUNT() FROM Log__c]);
+        System.Assert.areEqual(0, [SELECT COUNT() FROM Log__c]);
     }
 
     @IsTest
@@ -61,8 +61,8 @@ private class LogFlowExecutionErrorEventHandler_Tests {
             FROM LogEntry__c
         ];
         // LogEntry__c related asserts
-        System.assertEquals(System.LoggingLevel.ERROR.name(), entry.LoggingLevel__c, 'Logging level should be set correctly');
-        System.assertEquals(
+        System.Assert.areEqual(System.LoggingLevel.ERROR.name(), entry.LoggingLevel__c, 'Logging level should be set correctly');
+        System.Assert.areEqual(
             String.format(
                 LogFlowExecutionErrorEventHandler.LOG_STRING,
                 new List<String>{ flowExecutionErrorEvent.ElementApiName, flowExecutionErrorEvent.FlowVersionNumber.format() }
@@ -70,10 +70,10 @@ private class LogFlowExecutionErrorEventHandler_Tests {
             entry.Message__c,
             'Log message should be formatted correctly'
         );
-        System.assertEquals('Flow.' + flowExecutionErrorEvent.FlowApiName, entry.Origin__c, 'Origin__c should be set correctly');
-        System.assertEquals(flowExecutionErrorEvent.FlowApiName, entry.OriginLocation__c, 'OriginLocation__c should be set correctly');
-        System.assertEquals('Flow', entry.OriginType__c, 'OriginType__c should be set to Flow');
-        System.assertEquals(flowExecutionErrorEvent.EventDate, entry.Timestamp__c, 'Should take timestamp from flow error event');
+        System.Assert.areEqual('Flow.' + flowExecutionErrorEvent.FlowApiName, entry.Origin__c, 'Origin__c should be set correctly');
+        System.Assert.areEqual(flowExecutionErrorEvent.FlowApiName, entry.OriginLocation__c, 'OriginLocation__c should be set correctly');
+        System.Assert.areEqual('Flow', entry.OriginType__c, 'OriginType__c should be set to Flow');
+        System.Assert.areEqual(flowExecutionErrorEvent.EventDate, entry.Timestamp__c, 'Should take timestamp from flow error event');
 
         // Log__c related asserts
         User currentUser = [
@@ -92,23 +92,23 @@ private class LogFlowExecutionErrorEventHandler_Tests {
             WHERE Id = :UserInfo.getUserId()
         ];
         Log__c log = entry.Log__r;
-        System.assertEquals(currentUser.Id, log.LoggedBy__c, 'Should not use autoproc user Id');
-        System.assertEquals(currentUser.Username, log.LoggedByUsername__c, 'Username should match');
-        System.assertEquals(currentUser.ProfileId, log.ProfileId__c, 'Should not use autoproc user ProfileId');
-        System.assertEquals(currentUser.Profile.Name, log.ProfileName__c, 'Should not use autoproc user Profile name');
-        System.assertEquals(null, log.LoginApplication__c, 'LoginApplication__c should have been cleared');
-        System.assertEquals(null, log.LoginBrowser__c, 'LoginBrowser__c should have been cleared');
-        System.assertEquals(null, log.LoginHistoryId__c, 'LoginHistoryId__c should have been cleared');
-        System.assertEquals(null, log.LoginPlatform__c, 'LoginPlatform__c should have been cleared');
-        System.assertEquals(null, log.LoginType__c, 'LoginType__c should have been cleared');
-        System.assertEquals(null, log.LogoutUrl__c, 'LogoutUrl__c should have been cleared');
-        System.assertEquals(null, log.NetworkId__c, 'NetworkId__c should have been cleared');
-        System.assertEquals(null, log.SessionId__c, 'SessionId__c Should have been cleared');
-        System.assertEquals(null, log.SessionSecurityLevel__c, 'SessionSecurityLevel__c should have been cleared');
-        System.assertEquals(null, log.SessionType__c, 'SessionType__c should have been cleared');
-        System.assertEquals(null, log.SourceIp__c, 'SourceIp__c should have been cleared');
-        System.assertEquals(UserInfo.getTimeZone().getId(), log.TimeZoneId__c, 'Timezone Id should be set correctly');
-        System.assertEquals(UserInfo.getTimeZone().getDisplayName(), log.TimeZoneName__c, 'Timezone name should be set correctly');
+        System.Assert.areEqual(currentUser.Id, log.LoggedBy__c, 'Should not use autoproc user Id');
+        System.Assert.areEqual(currentUser.Username, log.LoggedByUsername__c, 'Username should match');
+        System.Assert.areEqual(currentUser.ProfileId, log.ProfileId__c, 'Should not use autoproc user ProfileId');
+        System.Assert.areEqual(currentUser.Profile.Name, log.ProfileName__c, 'Should not use autoproc user Profile name');
+        System.Assert.isNull(log.LoginApplication__c, 'LoginApplication__c should have been cleared');
+        System.Assert.isNull(log.LoginBrowser__c, 'LoginBrowser__c should have been cleared');
+        System.Assert.isNull(log.LoginHistoryId__c, 'LoginHistoryId__c should have been cleared');
+        System.Assert.isNull(log.LoginPlatform__c, 'LoginPlatform__c should have been cleared');
+        System.Assert.isNull(log.LoginType__c, 'LoginType__c should have been cleared');
+        System.Assert.isNull(log.LogoutUrl__c, 'LogoutUrl__c should have been cleared');
+        System.Assert.isNull(log.NetworkId__c, 'NetworkId__c should have been cleared');
+        System.Assert.isNull(log.SessionId__c, 'SessionId__c Should have been cleared');
+        System.Assert.isNull(log.SessionSecurityLevel__c, 'SessionSecurityLevel__c should have been cleared');
+        System.Assert.isNull(log.SessionType__c, 'SessionType__c should have been cleared');
+        System.Assert.isNull(log.SourceIp__c, 'SourceIp__c should have been cleared');
+        System.Assert.areEqual(UserInfo.getTimeZone().getId(), log.TimeZoneId__c, 'Timezone Id should be set correctly');
+        System.Assert.areEqual(UserInfo.getTimeZone().getDisplayName(), log.TimeZoneName__c, 'Timezone name should be set correctly');
     }
 
     static void setLoggerParamEnabled(Boolean value) {

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveBuilder.cls
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveBuilder.cls
@@ -49,9 +49,9 @@ public without sharing class LogEntryArchiveBuilder {
     private void convertLogEntryEventToLogEntryArchive() {
         this.logEntryArchive = new LogEntryArchive__b(
             ApiVersion__c = this.logEntryEvent.ApiVersion__c,
-            ArchivedById__c = UserInfo.getUserId(),
+            ArchivedById__c = System.UserInfo.getUserId(),
             ArchivedDate__c = System.now(),
-            ArchivedByUsername__c = UserInfo.getUsername(),
+            ArchivedByUsername__c = System.UserInfo.getUsername(),
             ComponentType__c = this.logEntryEvent.ComponentType__c,
             DatabaseResultCollectionSize__c = this.logEntryEvent.DatabaseResultCollectionSize__c,
             DatabaseResultCollectionType__c = this.logEntryEvent.DatabaseResultCollectionType__c,
@@ -178,9 +178,9 @@ public without sharing class LogEntryArchiveBuilder {
             ApiReleaseNumber__c = this.logEntry.Log__r.ApiReleaseNumber__c,
             ApiReleaseVersion__c = this.logEntry.Log__r.ApiReleaseVersion__c,
             ApiVersion__c = this.logEntry.Log__r.ApiVersion__c,
-            ArchivedById__c = UserInfo.getUserId(),
+            ArchivedById__c = System.UserInfo.getUserId(),
             ArchivedDate__c = System.now(),
-            ArchivedByUsername__c = UserInfo.getUsername(),
+            ArchivedByUsername__c = System.UserInfo.getUsername(),
             ClosedById__c = this.logEntry.Log__r.ClosedBy__c,
             ClosedByUsername__c = this.logEntry.Log__r.ClosedBy__r.Username,
             ClosedDate__c = this.logEntry.Log__r.ClosedDate__c,

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveBuilder_Tests.cls
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveBuilder_Tests.cls
@@ -13,7 +13,7 @@ private class LogEntryArchiveBuilder_Tests {
             .populateAllFields()
             .getRecord();
         mockEvent = (LogEntryEvent__e) LoggerMockDataCreator.setReadOnlyField(mockEvent, Schema.LogEntryEvent__e.EventUuid, 'abc-xyz-some-value');
-        mockEvent.LoggingLevel__c = LoggingLevel.INFO.name();
+        mockEvent.LoggingLevel__c = System.LoggingLevel.INFO.name();
         mockEvent.Timestamp__c = timestamp;
         mockEvent.TimestampString__c = String.valueOf(timestamp.getTime());
 
@@ -55,7 +55,7 @@ private class LogEntryArchiveBuilder_Tests {
     static void it_should_write_all_fields_over_from_log_entry() {
         LogEntry__c mockLogEntry = (LogEntry__c) LoggerMockDataCreator.createDataBuilder(Schema.LogEntry__c.SObjectType).populateAllFields().getRecord();
         mockLogEntry.Log__r = (Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateAllFields().getRecord();
-        mockLogEntry.LoggingLevel__c = LoggingLevel.INFO.name();
+        mockLogEntry.LoggingLevel__c = System.LoggingLevel.INFO.name();
 
         LogEntryArchive__b logEntryArchive = new LogEntryArchiveBuilder(mockLogEntry).getLogEntryArchive();
 

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveBuilder_Tests.cls
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveBuilder_Tests.cls
@@ -19,7 +19,7 @@ private class LogEntryArchiveBuilder_Tests {
 
         LogEntryArchive__b logEntryArchive = new LogEntryArchiveBuilder(mockEvent).getLogEntryArchive();
 
-        System.assertNotEquals(null, logEntryArchive);
+        System.Assert.isNotNull(logEntryArchive);
         assertAllFieldsMatch(timestamp, mockEvent, logEntryArchive);
     }
 
@@ -35,7 +35,7 @@ private class LogEntryArchiveBuilder_Tests {
 
         LogEntryArchive__b secondLogEntryArchive = archiveBuilder.getLogEntryArchive();
 
-        System.assertEquals(originalLogEntryArchive, secondLogEntryArchive);
+        System.Assert.areEqual(originalLogEntryArchive, secondLogEntryArchive);
     }
 
     @IsTest
@@ -47,8 +47,8 @@ private class LogEntryArchiveBuilder_Tests {
         mockEvent.Message__c = 'Z'.repeat(Schema.LogEntryArchive__b.Message__c.getDescribe().getLength() + 1);
         LogEntryArchive__b logEntryArchive = new LogEntryArchiveBuilder(mockEvent).getLogEntryArchive();
 
-        System.assertNotEquals(mockEvent.Message__c, logEntryArchive.Message__c);
-        System.assertEquals(mockEvent.Message__c.left(Schema.LogEntryArchive__b.Message__c.getDescribe().getLength()), logEntryArchive.Message__c);
+        System.Assert.areNotEqual(mockEvent.Message__c, logEntryArchive.Message__c);
+        System.Assert.areEqual(mockEvent.Message__c.left(Schema.LogEntryArchive__b.Message__c.getDescribe().getLength()), logEntryArchive.Message__c);
     }
 
     @IsTest
@@ -59,7 +59,7 @@ private class LogEntryArchiveBuilder_Tests {
 
         LogEntryArchive__b logEntryArchive = new LogEntryArchiveBuilder(mockLogEntry).getLogEntryArchive();
 
-        System.assertNotEquals(null, logEntryArchive);
+        System.Assert.isNotNull(logEntryArchive);
         assertAllFieldsMatch(mockLogEntry, logEntryArchive);
     }
 
@@ -73,8 +73,8 @@ private class LogEntryArchiveBuilder_Tests {
 
         LogEntryArchive__b secondLogEntryArchive = archiveBuilder.getLogEntryArchive();
 
-        System.assertEquals(originalLogEntryArchive, secondLogEntryArchive);
-        System.assertEquals(originalLogEntryArchive.Message__c, secondLogEntryArchive.Message__c);
+        System.Assert.areEqual(originalLogEntryArchive, secondLogEntryArchive);
+        System.Assert.areEqual(originalLogEntryArchive.Message__c, secondLogEntryArchive.Message__c);
     }
 
     @IsTest
@@ -83,354 +83,378 @@ private class LogEntryArchiveBuilder_Tests {
         mockLogEntry.Message__c = 'Z'.repeat(Schema.LogEntryArchive__b.Message__c.getDescribe().getLength() + 1);
         LogEntryArchive__b logEntryArchive = new LogEntryArchiveBuilder(mockLogEntry).getLogEntryArchive();
 
-        System.assertNotEquals(mockLogEntry.Message__c, logEntryArchive.Message__c);
-        System.assertEquals(mockLogEntry.Message__c.left(Schema.LogEntryArchive__b.Message__c.getDescribe().getLength()), logEntryArchive.Message__c);
+        System.Assert.areNotEqual(mockLogEntry.Message__c, logEntryArchive.Message__c);
+        System.Assert.areEqual(mockLogEntry.Message__c.left(Schema.LogEntryArchive__b.Message__c.getDescribe().getLength()), logEntryArchive.Message__c);
     }
 
     @SuppressWarnings('PMD.NcssMethodCount')
     private static void assertAllFieldsMatch(Datetime timestamp, LogEntryEvent__e mockEvent, LogEntryArchive__b logEntryArchive) {
-        System.assertEquals(mockEvent.ApiVersion__c, logEntryArchive.ApiVersion__c, 'logEntryArchive.ApiVersion__c was not properly set');
-        System.assertEquals(UserInfo.getUserId(), logEntryArchive.ArchivedById__c, 'logEntryArchive.ArchivedById__c was not properly set');
-        System.assertNotEquals(null, logEntryArchive.ArchivedDate__c, 'logEntryArchive.ArchivedDate__c was not properly set');
-        System.assertEquals(System.today(), logEntryArchive.ArchivedDate__c.date(), 'logEntryArchive.ArchivedDate__c was not properly set');
-        System.assertEquals(UserInfo.getUsername(), logEntryArchive.ArchivedByUsername__c, 'logEntryArchive.ArchivedByUsername__c was not properly set');
-        System.assertEquals(mockEvent.ComponentType__c, logEntryArchive.ComponentType__c, 'logEntryArchive.ComponentType__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.ApiVersion__c, logEntryArchive.ApiVersion__c, 'logEntryArchive.ApiVersion__c was not properly set');
+        System.Assert.areEqual(UserInfo.getUserId(), logEntryArchive.ArchivedById__c, 'logEntryArchive.ArchivedById__c was not properly set');
+        System.Assert.isNotNull(logEntryArchive.ArchivedDate__c, 'logEntryArchive.ArchivedDate__c was not properly set');
+        System.Assert.areEqual(System.today(), logEntryArchive.ArchivedDate__c.date(), 'logEntryArchive.ArchivedDate__c was not properly set');
+        System.Assert.areEqual(UserInfo.getUsername(), logEntryArchive.ArchivedByUsername__c, 'logEntryArchive.ArchivedByUsername__c was not properly set');
+        System.Assert.areEqual(mockEvent.ComponentType__c, logEntryArchive.ComponentType__c, 'logEntryArchive.ComponentType__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.DatabaseResultCollectionSize__c,
             logEntryArchive.DatabaseResultCollectionSize__c,
             'logEntryArchive.DatabaseResultCollectionSize__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.DatabaseResultCollectionType__c,
             logEntryArchive.DatabaseResultCollectionType__c,
             'logEntryArchive.DatabaseResultCollectionType__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.DatabaseResultJson__c,
             logEntryArchive.DatabaseResultJson__c,
             'logEntryArchive.DatabaseResultJson__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.DatabaseResultType__c,
             logEntryArchive.DatabaseResultType__c,
             'logEntryArchive.DatabaseResultType__c was not properly set'
         );
-        System.assertEquals(mockEvent.EpochTimestamp__c, logEntryArchive.EpochTimestamp__c, 'logEntryArchive.EpochTimestamp__c was not properly set');
-        System.assertEquals(mockEvent.EventUuid, logEntryArchive.EventUuid__c, 'logEntryArchive.EventUuid__c was not properly set');
-        System.assertEquals(mockEvent.ExceptionMessage__c, logEntryArchive.ExceptionMessage__c, 'logEntryArchive.ExceptionMessage__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.EpochTimestamp__c, logEntryArchive.EpochTimestamp__c, 'logEntryArchive.EpochTimestamp__c was not properly set');
+        System.Assert.areEqual(mockEvent.EventUuid, logEntryArchive.EventUuid__c, 'logEntryArchive.EventUuid__c was not properly set');
+        System.Assert.areEqual(mockEvent.ExceptionMessage__c, logEntryArchive.ExceptionMessage__c, 'logEntryArchive.ExceptionMessage__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.ExceptionStackTrace__c,
             logEntryArchive.ExceptionStackTrace__c,
             'logEntryArchive.ExceptionStackTrace__c was not properly set'
         );
-        System.assertEquals(mockEvent.ExceptionType__c, logEntryArchive.ExceptionType__c, 'logEntryArchive.ExceptionType__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.ExceptionType__c, logEntryArchive.ExceptionType__c, 'logEntryArchive.ExceptionType__c was not properly set');
+        System.Assert.areEqual(
             String.valueOf(mockEvent.HttpRequestBody__c),
             logEntryArchive.HttpRequestBody__c,
             'logEntryArchive.HttpRequestBody__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             String.valueOf(mockEvent.HttpRequestCompressed__c),
             logEntryArchive.HttpRequestCompressed__c,
             'logEntryArchive.HttpRequestCompressed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.HttpRequestEndpoint__c,
             logEntryArchive.HttpRequestEndpoint__c,
             'logEntryArchive.HttpRequestEndpoint__c was not properly set'
         );
-        System.assertEquals(mockEvent.HttpRequestMethod__c, logEntryArchive.HttpRequestMethod__c, 'logEntryArchive.HttpRequestMethod__c was not properly set');
-        System.assertEquals(mockEvent.HttpResponseBody__c, logEntryArchive.HttpResponseBody__c, 'logEntryArchive.HttpResponseBody__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(
+            mockEvent.HttpRequestMethod__c,
+            logEntryArchive.HttpRequestMethod__c,
+            'logEntryArchive.HttpRequestMethod__c was not properly set'
+        );
+        System.Assert.areEqual(mockEvent.HttpResponseBody__c, logEntryArchive.HttpResponseBody__c, 'logEntryArchive.HttpResponseBody__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.HttpResponseHeaderKeys__c,
             logEntryArchive.HttpResponseHeaderKeys__c,
             'logEntryArchive.HttpResponseHeaderKeys__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.HttpResponseStatus__c,
             logEntryArchive.HttpResponseStatus__c,
             'logEntryArchive.HttpResponseStatus__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.HttpResponseStatusCode__c,
             logEntryArchive.HttpResponseStatusCode__c,
             'logEntryArchive.HttpResponseStatusCode__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsAggregateQueriesMax__c,
             logEntryArchive.LimitsAggregateQueriesMax__c,
             'logEntryArchive.LimitsAggregateQueriesMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsAggregateQueriesUsed__c,
             logEntryArchive.LimitsAggregateQueriesUsed__c,
             'logEntryArchive.LimitsAggregateQueriesUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsAsyncCallsMax__c,
             logEntryArchive.LimitsAsyncCallsMax__c,
             'logEntryArchive.LimitsAsyncCallsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsAsyncCallsUsed__c,
             logEntryArchive.LimitsAsyncCallsUsed__c,
             'logEntryArchive.LimitsAsyncCallsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsCalloutsUsed__c,
             logEntryArchive.LimitsCalloutsUsed__c,
             'logEntryArchive.LimitsCalloutsUsed__c was not properly set'
         );
-        System.assertEquals(mockEvent.LimitsCpuTimeMax__c, logEntryArchive.LimitsCpuTimeMax__c, 'logEntryArchive.LimitsCpuTimeMax__c was not properly set');
-        System.assertEquals(mockEvent.LimitsCpuTimeUsed__c, logEntryArchive.LimitsCpuTimeUsed__c, 'logEntryArchive.LimitsCpuTimeUsed__c was not properly set');
-        System.assertEquals(mockEvent.LimitsDmlRowsMax__c, logEntryArchive.LimitsDmlRowsMax__c, 'logEntryArchive.LimitsDmlRowsMax__c was not properly set');
-        System.assertEquals(mockEvent.LimitsDmlRowsUsed__c, logEntryArchive.LimitsDmlRowsUsed__c, 'logEntryArchive.LimitsDmlRowsUsed__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.LimitsCpuTimeMax__c, logEntryArchive.LimitsCpuTimeMax__c, 'logEntryArchive.LimitsCpuTimeMax__c was not properly set');
+        System.Assert.areEqual(
+            mockEvent.LimitsCpuTimeUsed__c,
+            logEntryArchive.LimitsCpuTimeUsed__c,
+            'logEntryArchive.LimitsCpuTimeUsed__c was not properly set'
+        );
+        System.Assert.areEqual(mockEvent.LimitsDmlRowsMax__c, logEntryArchive.LimitsDmlRowsMax__c, 'logEntryArchive.LimitsDmlRowsMax__c was not properly set');
+        System.Assert.areEqual(
+            mockEvent.LimitsDmlRowsUsed__c,
+            logEntryArchive.LimitsDmlRowsUsed__c,
+            'logEntryArchive.LimitsDmlRowsUsed__c was not properly set'
+        );
+        System.Assert.areEqual(
             mockEvent.LimitsDmlStatementsMax__c,
             logEntryArchive.LimitsDmlStatementsMax__c,
             'logEntryArchive.LimitsDmlStatementsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsDmlStatementsUsed__c,
             logEntryArchive.LimitsDmlStatementsUsed__c,
             'logEntryArchive.LimitsDmlStatementsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsEmailInvocationsMax__c,
             logEntryArchive.LimitsEmailInvocationsMax__c,
             'logEntryArchive.LimitsEmailInvocationsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsEmailInvocationsUsed__c,
             logEntryArchive.LimitsEmailInvocationsUsed__c,
             'logEntryArchive.LimitsEmailInvocationsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsFutureCallsMax__c,
             logEntryArchive.LimitsFutureCallsMax__c,
             'logEntryArchive.LimitsFutureCallsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsFutureCallsUsed__c,
             logEntryArchive.LimitsFutureCallsUsed__c,
             'logEntryArchive.LimitsFutureCallsUsed__c was not properly set'
         );
-        System.assertEquals(mockEvent.LimitsHeapSizeMax__c, logEntryArchive.LimitsHeapSizeMax__c, 'logEntryArchive.LimitsHeapSizeMax__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(
+            mockEvent.LimitsHeapSizeMax__c,
+            logEntryArchive.LimitsHeapSizeMax__c,
+            'logEntryArchive.LimitsHeapSizeMax__c was not properly set'
+        );
+        System.Assert.areEqual(
             mockEvent.LimitsHeapSizeUsed__c,
             logEntryArchive.LimitsHeapSizeUsed__c,
             'logEntryArchive.LimitsHeapSizeUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsPublishImmediateDmlStatementsMax__c,
             logEntryArchive.LimitsPublishImmediateDmlStatementsMax__c,
             'logEntryArchive.LimitsPublishImmediateDmlStatementsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsPublishImmediateDmlStatementsUsed__c,
             logEntryArchive.LimitsPublishImmediateDmlStatementsUsed__c,
             'logEntryArchive.LimitsPublishImmediateDmlStatementsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsMobilePushApexCallsMax__c,
             logEntryArchive.LimitsMobilePushApexCallsMax__c,
             'logEntryArchive.LimitsMobilePushApexCallsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsMobilePushApexCallsUsed__c,
             logEntryArchive.LimitsMobilePushApexCallsUsed__c,
             'logEntryArchive.LimitsMobilePushApexCallsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsQueueableJobsMax__c,
             logEntryArchive.LimitsQueueableJobsMax__c,
             'logEntryArchive.LimitsQueueableJobsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsQueueableJobsUsed__c,
             logEntryArchive.LimitsQueueableJobsUsed__c,
             'logEntryArchive.LimitsQueueableJobsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsSoqlQueriesMax__c,
             logEntryArchive.LimitsSoqlQueriesMax__c,
             'logEntryArchive.LimitsSoqlQueriesMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsSoqlQueriesUsed__c,
             logEntryArchive.LimitsSoqlQueriesUsed__c,
             'logEntryArchive.LimitsSoqlQueriesUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsSoqlQueryLocatorRowsMax__c,
             logEntryArchive.LimitsSoqlQueryLocatorRowsMax__c,
             'logEntryArchive.LimitsSoqlQueryLocatorRowsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsSoqlQueryLocatorRowsUsed__c,
             logEntryArchive.LimitsSoqlQueryLocatorRowsUsed__c,
             'logEntryArchive.LimitsSoqlQueryLocatorRowsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsSoqlQueryRowsMax__c,
             logEntryArchive.LimitsSoqlQueryRowsMax__c,
             'logEntryArchive.LimitsSoqlQueryRowsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsSoqlQueryRowsUsed__c,
             logEntryArchive.LimitsSoqlQueryRowsUsed__c,
             'logEntryArchive.LimitsSoqlQueryRowsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsSoslSearchesMax__c,
             logEntryArchive.LimitsSoslSearchesMax__c,
             'logEntryArchive.LimitsSoslSearchesMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LimitsSoslSearchesUsed__c,
             logEntryArchive.LimitsSoslSearchesUsed__c,
             'logEntryArchive.LimitsSoslSearchesUsed__c was not properly set'
         );
-        System.assertEquals(mockEvent.Locale__c, logEntryArchive.Locale__c, 'logEntryArchive.Locale__c was not properly set');
-        // System.assertEquals(String.isNotBlank(mockEvent.LoggedById__c) ? mockEvent.LoggedById__c : 'Anonymous', logEntryArchive.LoggedBy__c);
-        System.assertEquals(mockEvent.LoggedById__c, logEntryArchive.LoggedById__c, 'logEntryArchive.LoggedById__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.Locale__c, logEntryArchive.Locale__c, 'logEntryArchive.Locale__c was not properly set');
+        // System.Assert.areEqual(String.isNotBlank(mockEvent.LoggedById__c) ? mockEvent.LoggedById__c : 'Anonymous', logEntryArchive.LoggedBy__c);
+        System.Assert.areEqual(mockEvent.LoggedById__c, logEntryArchive.LoggedById__c, 'logEntryArchive.LoggedById__c was not properly set');
+        System.Assert.areEqual(
             String.isNotBlank(mockEvent.LoggedByUsername__c) ? mockEvent.LoggedByUsername__c : 'Anonymous',
             logEntryArchive.LoggedByUsername__c,
             'logEntryArchive.LoggedByUsername__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.LoggerVersionNumber__c,
             logEntryArchive.LoggerVersionNumber__c,
             'logEntryArchive.LoggerVersionNumber__c was not properly set'
         );
-        System.assertEquals(mockEvent.LoggingLevel__c, logEntryArchive.LoggingLevel__c, 'logEntryArchive.LoggingLevel__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.LoggingLevel__c, logEntryArchive.LoggingLevel__c, 'logEntryArchive.LoggingLevel__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.LoggingLevelOrdinal__c,
             logEntryArchive.LoggingLevelOrdinal__c,
             'logEntryArchive.LoggingLevelOrdinal__c was not properly set'
         );
-        System.assertEquals(mockEvent.LoginApplication__c, logEntryArchive.LoginApplication__c, 'logEntryArchive.LoginApplication__c was not properly set');
-        System.assertEquals(mockEvent.LoginBrowser__c, logEntryArchive.LoginBrowser__c, 'logEntryArchive.LoginBrowser__c was not properly set');
-        System.assertEquals(mockEvent.LoginHistoryId__c, logEntryArchive.LoginHistoryId__c, 'logEntryArchive.LoginHistoryId__c was not properly set');
-        System.assertEquals(mockEvent.LoginPlatform__c, logEntryArchive.LoginPlatform__c, 'logEntryArchive.LoginPlatform__c was not properly set');
-        System.assertEquals(mockEvent.LoginType__c, logEntryArchive.LoginType__c, 'logEntryArchive.LoginType__c was not properly set');
-        System.assertEquals(mockEvent.LogoutUrl__c, logEntryArchive.LogoutUrl__c, 'logEntryArchive.LogoutUrl__c was not properly set');
-        System.assertEquals(mockEvent.Message__c, logEntryArchive.Message__c, 'logEntryArchive.Message__c was not properly set');
-        System.assertEquals(mockEvent.NetworkId__c, logEntryArchive.NetworkId__c, 'logEntryArchive.NetworkId__c was not properly set');
-        System.assertEquals(mockEvent.NetworkLoginUrl__c, logEntryArchive.NetworkLoginUrl__c, 'logEntryArchive.NetworkLoginUrl__c was not properly set');
-        System.assertEquals(mockEvent.NetworkLogoutUrl__c, logEntryArchive.NetworkLogoutUrl__c, 'logEntryArchive.NetworkLogoutUrl__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.LoginApplication__c, logEntryArchive.LoginApplication__c, 'logEntryArchive.LoginApplication__c was not properly set');
+        System.Assert.areEqual(mockEvent.LoginBrowser__c, logEntryArchive.LoginBrowser__c, 'logEntryArchive.LoginBrowser__c was not properly set');
+        System.Assert.areEqual(mockEvent.LoginHistoryId__c, logEntryArchive.LoginHistoryId__c, 'logEntryArchive.LoginHistoryId__c was not properly set');
+        System.Assert.areEqual(mockEvent.LoginPlatform__c, logEntryArchive.LoginPlatform__c, 'logEntryArchive.LoginPlatform__c was not properly set');
+        System.Assert.areEqual(mockEvent.LoginType__c, logEntryArchive.LoginType__c, 'logEntryArchive.LoginType__c was not properly set');
+        System.Assert.areEqual(mockEvent.LogoutUrl__c, logEntryArchive.LogoutUrl__c, 'logEntryArchive.LogoutUrl__c was not properly set');
+        System.Assert.areEqual(mockEvent.Message__c, logEntryArchive.Message__c, 'logEntryArchive.Message__c was not properly set');
+        System.Assert.areEqual(mockEvent.NetworkId__c, logEntryArchive.NetworkId__c, 'logEntryArchive.NetworkId__c was not properly set');
+        System.Assert.areEqual(mockEvent.NetworkLoginUrl__c, logEntryArchive.NetworkLoginUrl__c, 'logEntryArchive.NetworkLoginUrl__c was not properly set');
+        System.Assert.areEqual(mockEvent.NetworkLogoutUrl__c, logEntryArchive.NetworkLogoutUrl__c, 'logEntryArchive.NetworkLogoutUrl__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.NetworkSelfRegistrationUrl__c,
             logEntryArchive.NetworkSelfRegistrationUrl__c,
             'logEntryArchive.NetworkSelfRegistrationUrl__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.NetworkUrlPathPrefix__c,
             logEntryArchive.NetworkUrlPathPrefix__c,
             'logEntryArchive.NetworkUrlPathPrefix__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.OrganizationDomainUrl__c,
             logEntryArchive.OrganizationDomainUrl__c,
             'logEntryArchive.OrganizationDomainUrl__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.OrganizationEnvironmentType__c,
             logEntryArchive.OrganizationEnvironmentType__c,
             'logEntryArchive.OrganizationEnvironmentType__c was not properly set'
         );
-        System.assertEquals(mockEvent.OrganizationId__c, logEntryArchive.OrganizationId__c, 'logEntryArchive.OrganizationId__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.OrganizationId__c, logEntryArchive.OrganizationId__c, 'logEntryArchive.OrganizationId__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.OrganizationInstanceName__c,
             logEntryArchive.OrganizationInstanceName__c,
             'logEntryArchive.OrganizationInstanceName__c was not properly set'
         );
-        System.assertEquals(mockEvent.OrganizationName__c, logEntryArchive.OrganizationName__c, 'logEntryArchive.OrganizationName__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.OrganizationName__c, logEntryArchive.OrganizationName__c, 'logEntryArchive.OrganizationName__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.OrganizationNamespacePrefix__c,
             logEntryArchive.OrganizationNamespacePrefix__c,
             'logEntryArchive.OrganizationNamespacePrefix__c was not properly set'
         );
-        System.assertEquals(mockEvent.OrganizationType__c, logEntryArchive.OrganizationType__c, 'logEntryArchive.OrganizationType__c was not properly set');
-        System.assertEquals(mockEvent.OriginLocation__c, logEntryArchive.OriginLocation__c, 'logEntryArchive.OriginLocation__c was not properly set');
-        System.assertEquals(mockEvent.OriginType__c, logEntryArchive.OriginType__c, 'logEntryArchive.OriginType__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.OrganizationType__c, logEntryArchive.OrganizationType__c, 'logEntryArchive.OrganizationType__c was not properly set');
+        System.Assert.areEqual(mockEvent.OriginLocation__c, logEntryArchive.OriginLocation__c, 'logEntryArchive.OriginLocation__c was not properly set');
+        System.Assert.areEqual(mockEvent.OriginType__c, logEntryArchive.OriginType__c, 'logEntryArchive.OriginType__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.ParentLogTransactionId__c,
             logEntryArchive.ParentLogTransactionId__c,
             'logEntryArchive.ParentLogTransactionId__c was not properly set'
         );
-        System.assertEquals(mockEvent.ProfileId__c, logEntryArchive.ProfileId__c, 'logEntryArchive.ProfileId__c was not properly set');
-        System.assertEquals(mockEvent.ProfileName__c, logEntryArchive.ProfileName__c, 'logEntryArchive.ProfileName__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.ProfileId__c, logEntryArchive.ProfileId__c, 'logEntryArchive.ProfileId__c was not properly set');
+        System.Assert.areEqual(mockEvent.ProfileName__c, logEntryArchive.ProfileName__c, 'logEntryArchive.ProfileName__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.RecordCollectionSize__c,
             logEntryArchive.RecordCollectionSize__c,
             'logEntryArchive.RecordCollectionSize__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.RecordCollectionType__c,
             logEntryArchive.RecordCollectionType__c,
             'logEntryArchive.RecordCollectionType__c was not properly set'
         );
-        System.assertEquals(mockEvent.RecordId__c, logEntryArchive.RecordId__c, 'logEntryArchive.RecordId__c was not properly set');
-        System.assertEquals(mockEvent.RecordJson__c, logEntryArchive.RecordJson__c, 'logEntryArchive.RecordJson__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.RecordId__c, logEntryArchive.RecordId__c, 'logEntryArchive.RecordId__c was not properly set');
+        System.Assert.areEqual(mockEvent.RecordJson__c, logEntryArchive.RecordJson__c, 'logEntryArchive.RecordJson__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.RecordSObjectClassification__c,
             logEntryArchive.RecordSObjectClassification__c,
             'logEntryArchive.RecordSObjectClassification__c was not properly set'
         );
-        System.assertEquals(mockEvent.RecordSObjectType__c, logEntryArchive.RecordSObjectType__c, 'logEntryArchive.RecordSObjectType__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(
+            mockEvent.RecordSObjectType__c,
+            logEntryArchive.RecordSObjectType__c,
+            'logEntryArchive.RecordSObjectType__c was not properly set'
+        );
+        System.Assert.areEqual(
             mockEvent.RecordSObjectTypeNamespace__c,
             logEntryArchive.RecordSObjectTypeNamespace__c,
             'logEntryArchive.RecordSObjectTypeNamespace__c was not properly set'
         );
-        System.assertEquals(mockEvent.SessionId__c, logEntryArchive.SessionId__c, 'logEntryArchive.SessionId__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.SessionId__c, logEntryArchive.SessionId__c, 'logEntryArchive.SessionId__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.SessionSecurityLevel__c,
             logEntryArchive.SessionSecurityLevel__c,
             'logEntryArchive.SessionSecurityLevel__c was not properly set'
         );
-        System.assertEquals(mockEvent.SessionType__c, logEntryArchive.SessionType__c, 'logEntryArchive.SessionType__c was not properly set');
-        System.assertEquals(mockEvent.SourceIp__c, logEntryArchive.SourceIp__c, 'logEntryArchive.SourceIp__c was not properly set');
-        System.assertEquals(mockEvent.StackTrace__c, logEntryArchive.StackTrace__c, 'logEntryArchive.StackTrace__c was not properly set');
-        System.assertEquals(mockEvent.SystemMode__c, logEntryArchive.SystemMode__c, 'logEntryArchive.SystemMode__c was not properly set');
-        System.assertEquals(mockEvent.Tags__c, logEntryArchive.Tags__c, 'logEntryArchive.Tags__c was not properly set');
-        System.assertEquals(mockEvent.ThemeDisplayed__c, logEntryArchive.ThemeDisplayed__c, 'logEntryArchive.ThemeDisplayed__c was not properly set');
-        System.assertEquals(timestamp, logEntryArchive.Timestamp__c, 'logEntryArchive.Timestamp__c was not properly set');
-        System.assertEquals(String.valueOf(timestamp.getTime()), logEntryArchive.TimestampString__c, 'logEntryArchive.TimestampString__c was not properly set');
-        System.assertEquals(mockEvent.TimeZoneId__c, logEntryArchive.TimeZoneId__c, 'logEntryArchive.TimeZoneId__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.SessionType__c, logEntryArchive.SessionType__c, 'logEntryArchive.SessionType__c was not properly set');
+        System.Assert.areEqual(mockEvent.SourceIp__c, logEntryArchive.SourceIp__c, 'logEntryArchive.SourceIp__c was not properly set');
+        System.Assert.areEqual(mockEvent.StackTrace__c, logEntryArchive.StackTrace__c, 'logEntryArchive.StackTrace__c was not properly set');
+        System.Assert.areEqual(mockEvent.SystemMode__c, logEntryArchive.SystemMode__c, 'logEntryArchive.SystemMode__c was not properly set');
+        System.Assert.areEqual(mockEvent.Tags__c, logEntryArchive.Tags__c, 'logEntryArchive.Tags__c was not properly set');
+        System.Assert.areEqual(mockEvent.ThemeDisplayed__c, logEntryArchive.ThemeDisplayed__c, 'logEntryArchive.ThemeDisplayed__c was not properly set');
+        System.Assert.areEqual(timestamp, logEntryArchive.Timestamp__c, 'logEntryArchive.Timestamp__c was not properly set');
+        System.Assert.areEqual(
+            String.valueOf(timestamp.getTime()),
+            logEntryArchive.TimestampString__c,
+            'logEntryArchive.TimestampString__c was not properly set'
+        );
+        System.Assert.areEqual(mockEvent.TimeZoneId__c, logEntryArchive.TimeZoneId__c, 'logEntryArchive.TimeZoneId__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.TransactionEntryNumber__c,
             logEntryArchive.TransactionEntryNumber__c,
             'logEntryArchive.TransactionEntryNumber__c was not properly set'
         );
-        System.assertEquals(mockEvent.TransactionId__c, logEntryArchive.TransactionId__c, 'logEntryArchive.TransactionId__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.TransactionId__c, logEntryArchive.TransactionId__c, 'logEntryArchive.TransactionId__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.TriggerOperationType__c,
             logEntryArchive.TriggerOperationType__c,
             'logEntryArchive.TriggerOperationType__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.TriggerSObjectType__c,
             logEntryArchive.TriggerSObjectType__c,
             'logEntryArchive.TriggerSObjectType__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             mockEvent.UserLicenseDefinitionKey__c,
             logEntryArchive.UserLicenseDefinitionKey__c,
             'logEntryArchive.UserLicenseDefinitionKey__c was not properly set'
         );
-        System.assertEquals(mockEvent.UserLicenseName__c, logEntryArchive.UserLicenseName__c, 'logEntryArchive.UserLicenseName__c was not properly set');
-        System.assertEquals(mockEvent.UserLoggingLevel__c, logEntryArchive.UserLoggingLevel__c, 'logEntryArchive.UserLoggingLevel__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(mockEvent.UserLicenseName__c, logEntryArchive.UserLicenseName__c, 'logEntryArchive.UserLicenseName__c was not properly set');
+        System.Assert.areEqual(mockEvent.UserLoggingLevel__c, logEntryArchive.UserLoggingLevel__c, 'logEntryArchive.UserLoggingLevel__c was not properly set');
+        System.Assert.areEqual(
             mockEvent.UserLoggingLevelOrdinal__c,
             logEntryArchive.UserLoggingLevelOrdinal__c,
             'logEntryArchive.UserLoggingLevelOrdinal__c was not properly set'
         );
-        System.assertEquals(mockEvent.UserRoleId__c, logEntryArchive.UserRoleId__c, 'logEntryArchive.UserRoleId__c was not properly set');
-        System.assertEquals(mockEvent.UserRoleName__c, logEntryArchive.UserRoleName__c, 'logEntryArchive.UserRoleName__c was not properly set');
-        System.assertEquals(mockEvent.UserType__c, logEntryArchive.UserType__c, 'logEntryArchive.UserType__c was not properly set');
+        System.Assert.areEqual(mockEvent.UserRoleId__c, logEntryArchive.UserRoleId__c, 'logEntryArchive.UserRoleId__c was not properly set');
+        System.Assert.areEqual(mockEvent.UserRoleName__c, logEntryArchive.UserRoleName__c, 'logEntryArchive.UserRoleName__c was not properly set');
+        System.Assert.areEqual(mockEvent.UserType__c, logEntryArchive.UserType__c, 'logEntryArchive.UserType__c was not properly set');
     }
 
     @SuppressWarnings('PMD.NcssMethodCount')
@@ -443,421 +467,453 @@ private class LogEntryArchiveBuilder_Tests {
         tagNames.sort();
         String tags = String.join(tagNames, '\n');
 
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.Log__r.ApiReleaseNumber__c,
             logEntryArchive.ApiReleaseNumber__c,
             'logEntryArchive.ApiReleaseNumber__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.Log__r.ApiReleaseVersion__c,
             logEntryArchive.ApiReleaseVersion__c,
             'logEntryArchive.ApiReleaseVersion__c was not properly set'
         );
-        System.assertEquals(logEntry.Log__r.ApiVersion__c, logEntryArchive.ApiVersion__c, 'logEntryArchive.ApiVersion__c was not properly set');
-        System.assertEquals(UserInfo.getUserId(), logEntryArchive.ArchivedById__c, 'logEntryArchive.ArchivedById__c was not properly set');
-        System.assertNotEquals(null, logEntryArchive.ArchivedDate__c, 'logEntryArchive.ArchivedDate__c was not properly set');
-        System.assertEquals(System.today(), logEntryArchive.ArchivedDate__c.date(), 'logEntryArchive.ArchivedDate__c was not properly set');
-        System.assertEquals(UserInfo.getUsername(), logEntryArchive.ArchivedByUsername__c, 'logEntryArchive.ArchivedByUsername__c was not properly set');
-        System.assertEquals(logEntry.Log__r.ClosedBy__c, logEntryArchive.ClosedById__c, 'logEntryArchive.ClosedById__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.Log__r.ApiVersion__c, logEntryArchive.ApiVersion__c, 'logEntryArchive.ApiVersion__c was not properly set');
+        System.Assert.areEqual(UserInfo.getUserId(), logEntryArchive.ArchivedById__c, 'logEntryArchive.ArchivedById__c was not properly set');
+        System.Assert.isNotNull(logEntryArchive.ArchivedDate__c, 'logEntryArchive.ArchivedDate__c was not properly set');
+        System.Assert.areEqual(System.today(), logEntryArchive.ArchivedDate__c.date(), 'logEntryArchive.ArchivedDate__c was not properly set');
+        System.Assert.areEqual(UserInfo.getUsername(), logEntryArchive.ArchivedByUsername__c, 'logEntryArchive.ArchivedByUsername__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.ClosedBy__c, logEntryArchive.ClosedById__c, 'logEntryArchive.ClosedById__c was not properly set');
+        System.Assert.areEqual(
             logEntry.Log__r.ClosedBy__r?.Username,
             logEntryArchive.ClosedByUsername__c,
             'logEntryArchive.ClosedByUsername__c was not properly set'
         );
-        System.assertEquals(logEntry.Log__r.ClosedDate__c, logEntryArchive.ClosedDate__c, 'logEntryArchive.ClosedDate__c was not properly set');
-        System.assertEquals(logEntry.Log__r.Comments__c, logEntryArchive.Comments__c, 'logEntryArchive.Comments__c was not properly set');
-        System.assertEquals(logEntry.ComponentType__c, logEntryArchive.ComponentType__c, 'logEntryArchive.ComponentType__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.Log__r.ClosedDate__c, logEntryArchive.ClosedDate__c, 'logEntryArchive.ClosedDate__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.Comments__c, logEntryArchive.Comments__c, 'logEntryArchive.Comments__c was not properly set');
+        System.Assert.areEqual(logEntry.ComponentType__c, logEntryArchive.ComponentType__c, 'logEntryArchive.ComponentType__c was not properly set');
+        System.Assert.areEqual(
             logEntry.DatabaseResultCollectionSize__c,
             logEntryArchive.DatabaseResultCollectionSize__c,
             'logEntryArchive.DatabaseResultCollectionSize__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.DatabaseResultCollectionType__c,
             logEntryArchive.DatabaseResultCollectionType__c,
             'logEntryArchive.DatabaseResultCollectionType__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.DatabaseResultJson__c,
             logEntryArchive.DatabaseResultJson__c,
             'logEntryArchive.DatabaseResultJson__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.DatabaseResultType__c,
             logEntryArchive.DatabaseResultType__c,
             'logEntryArchive.DatabaseResultType__c was not properly set'
         );
-        System.assertEquals(logEntry.EpochTimestamp__c, logEntryArchive.EpochTimestamp__c, 'logEntryArchive.EpochTimestamp__c was not properly set');
-        System.assertEquals(logEntry.EventUuid__c, logEntryArchive.EventUuid__c, 'logEntryArchive.EventUuid__c was not properly set');
-        System.assertEquals(logEntry.ExceptionMessage__c, logEntryArchive.ExceptionMessage__c, 'logEntryArchive.ExceptionMessage__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.EpochTimestamp__c, logEntryArchive.EpochTimestamp__c, 'logEntryArchive.EpochTimestamp__c was not properly set');
+        System.Assert.areEqual(logEntry.EventUuid__c, logEntryArchive.EventUuid__c, 'logEntryArchive.EventUuid__c was not properly set');
+        System.Assert.areEqual(logEntry.ExceptionMessage__c, logEntryArchive.ExceptionMessage__c, 'logEntryArchive.ExceptionMessage__c was not properly set');
+        System.Assert.areEqual(
             logEntry.ExceptionStackTrace__c,
             logEntryArchive.ExceptionStackTrace__c,
             'logEntryArchive.ExceptionStackTrace__c was not properly set'
         );
-        System.assertEquals(logEntry.ExceptionType__c, logEntryArchive.ExceptionType__c, 'logEntryArchive.ExceptionType__c was not properly set');
-        System.assertEquals(logEntry.HttpRequestBody__c, logEntryArchive.HttpRequestBody__c, 'logEntryArchive.HttpRequestBody__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.ExceptionType__c, logEntryArchive.ExceptionType__c, 'logEntryArchive.ExceptionType__c was not properly set');
+        System.Assert.areEqual(logEntry.HttpRequestBody__c, logEntryArchive.HttpRequestBody__c, 'logEntryArchive.HttpRequestBody__c was not properly set');
+        System.Assert.areEqual(
             String.valueOf(logEntry.HttpRequestBodyMasked__c),
             logEntryArchive.HttpRequestBodyMasked__c,
             'logEntryArchive.HttpRequestBodyMasked__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.HttpRequestEndpoint__c,
             logEntryArchive.HttpRequestEndpoint__c,
             'logEntryArchive.HttpRequestEndpoint__c was not properly set'
         );
-        System.assertEquals(logEntry.HttpRequestMethod__c, logEntryArchive.HttpRequestMethod__c, 'logEntryArchive.HttpRequestMethod__c was not properly set');
-        System.assertEquals(logEntry.HttpResponseBody__c, logEntryArchive.HttpResponseBody__c, 'logEntryArchive.HttpResponseBody__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(
+            logEntry.HttpRequestMethod__c,
+            logEntryArchive.HttpRequestMethod__c,
+            'logEntryArchive.HttpRequestMethod__c was not properly set'
+        );
+        System.Assert.areEqual(logEntry.HttpResponseBody__c, logEntryArchive.HttpResponseBody__c, 'logEntryArchive.HttpResponseBody__c was not properly set');
+        System.Assert.areEqual(
             String.valueOf(logEntry.HttpResponseBodyMasked__c),
             logEntryArchive.HttpResponseBodyMasked__c,
             'logEntryArchive.HttpResponseBodyMasked__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.HttpResponseHeaderKeys__c,
             logEntryArchive.HttpResponseHeaderKeys__c,
             'logEntryArchive.HttpResponseHeaderKeys__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.HttpResponseStatus__c,
             logEntryArchive.HttpResponseStatus__c,
             'logEntryArchive.HttpResponseStatus__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.HttpResponseStatusCode__c,
             logEntryArchive.HttpResponseStatusCode__c,
             'logEntryArchive.HttpResponseStatusCode__c was not properly set'
         );
-        System.assertEquals(String.valueOf(logEntry.Log__r.IsClosed__c), logEntryArchive.IsClosed__c, 'logEntryArchive.IsClosed__c was not properly set');
-        System.assertEquals(String.valueOf(logEntry.Log__r.IsResolved__c), logEntryArchive.IsResolved__c, 'logEntryArchive.IsResolved__c was not properly set');
-        System.assertEquals(logEntry.Log__r.Issue__c, logEntryArchive.Issue__c, 'logEntryArchive.Issue__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(String.valueOf(logEntry.Log__r.IsClosed__c), logEntryArchive.IsClosed__c, 'logEntryArchive.IsClosed__c was not properly set');
+        System.Assert.areEqual(
+            String.valueOf(logEntry.Log__r.IsResolved__c),
+            logEntryArchive.IsResolved__c,
+            'logEntryArchive.IsResolved__c was not properly set'
+        );
+        System.Assert.areEqual(logEntry.Log__r.Issue__c, logEntryArchive.Issue__c, 'logEntryArchive.Issue__c was not properly set');
+        System.Assert.areEqual(
             logEntry.LimitsAggregateQueriesMax__c,
             logEntryArchive.LimitsAggregateQueriesMax__c,
             'logEntryArchive.LimitsAggregateQueriesMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsAggregateQueriesUsed__c,
             logEntryArchive.LimitsAggregateQueriesUsed__c,
             'logEntryArchive.LimitsAggregateQueriesUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsAsyncCallsMax__c,
             logEntryArchive.LimitsAsyncCallsMax__c,
             'logEntryArchive.LimitsAsyncCallsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsAsyncCallsUsed__c,
             logEntryArchive.LimitsAsyncCallsUsed__c,
             'logEntryArchive.LimitsAsyncCallsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsCalloutsUsed__c,
             logEntryArchive.LimitsCalloutsUsed__c,
             'logEntryArchive.LimitsCalloutsUsed__c was not properly set'
         );
-        System.assertEquals(logEntry.LimitsCpuTimeMax__c, logEntryArchive.LimitsCpuTimeMax__c, 'logEntryArchive.LimitsCpuTimeMax__c was not properly set');
-        System.assertEquals(logEntry.LimitsCpuTimeUsed__c, logEntryArchive.LimitsCpuTimeUsed__c, 'logEntryArchive.LimitsCpuTimeUsed__c was not properly set');
-        System.assertEquals(logEntry.LimitsDmlRowsMax__c, logEntryArchive.LimitsDmlRowsMax__c, 'logEntryArchive.LimitsDmlRowsMax__c was not properly set');
-        System.assertEquals(logEntry.LimitsDmlRowsUsed__c, logEntryArchive.LimitsDmlRowsUsed__c, 'logEntryArchive.LimitsDmlRowsUsed__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.LimitsCpuTimeMax__c, logEntryArchive.LimitsCpuTimeMax__c, 'logEntryArchive.LimitsCpuTimeMax__c was not properly set');
+        System.Assert.areEqual(
+            logEntry.LimitsCpuTimeUsed__c,
+            logEntryArchive.LimitsCpuTimeUsed__c,
+            'logEntryArchive.LimitsCpuTimeUsed__c was not properly set'
+        );
+        System.Assert.areEqual(logEntry.LimitsDmlRowsMax__c, logEntryArchive.LimitsDmlRowsMax__c, 'logEntryArchive.LimitsDmlRowsMax__c was not properly set');
+        System.Assert.areEqual(
+            logEntry.LimitsDmlRowsUsed__c,
+            logEntryArchive.LimitsDmlRowsUsed__c,
+            'logEntryArchive.LimitsDmlRowsUsed__c was not properly set'
+        );
+        System.Assert.areEqual(
             logEntry.LimitsDmlStatementsMax__c,
             logEntryArchive.LimitsDmlStatementsMax__c,
             'logEntryArchive.LimitsDmlStatementsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsDmlStatementsUsed__c,
             logEntryArchive.LimitsDmlStatementsUsed__c,
             'logEntryArchive.LimitsDmlStatementsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsEmailInvocationsMax__c,
             logEntryArchive.LimitsEmailInvocationsMax__c,
             'logEntryArchive.LimitsEmailInvocationsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsEmailInvocationsUsed__c,
             logEntryArchive.LimitsEmailInvocationsUsed__c,
             'logEntryArchive.LimitsEmailInvocationsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsFutureCallsMax__c,
             logEntryArchive.LimitsFutureCallsMax__c,
             'logEntryArchive.LimitsFutureCallsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsFutureCallsUsed__c,
             logEntryArchive.LimitsFutureCallsUsed__c,
             'logEntryArchive.LimitsFutureCallsUsed__c was not properly set'
         );
-        System.assertEquals(logEntry.LimitsHeapSizeMax__c, logEntryArchive.LimitsHeapSizeMax__c, 'logEntryArchive.LimitsHeapSizeMax__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(
+            logEntry.LimitsHeapSizeMax__c,
+            logEntryArchive.LimitsHeapSizeMax__c,
+            'logEntryArchive.LimitsHeapSizeMax__c was not properly set'
+        );
+        System.Assert.areEqual(
             logEntry.LimitsHeapSizeUsed__c,
             logEntryArchive.LimitsHeapSizeUsed__c,
             'logEntryArchive.LimitsHeapSizeUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsMobilePushApexCallsMax__c,
             logEntryArchive.LimitsMobilePushApexCallsMax__c,
             'logEntryArchive.LimitsMobilePushApexCallsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsMobilePushApexCallsUsed__c,
             logEntryArchive.LimitsMobilePushApexCallsUsed__c,
             'logEntryArchive.LimitsMobilePushApexCallsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsPublishImmediateDmlStatementsMax__c,
             logEntryArchive.LimitsPublishImmediateDmlStatementsMax__c,
             'logEntryArchive.LimitsPublishImmediateDmlStatementsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsPublishImmediateDmlStatementsUsed__c,
             logEntryArchive.LimitsPublishImmediateDmlStatementsUsed__c,
             'logEntryArchive.LimitsPublishImmediateDmlStatementsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsQueueableJobsMax__c,
             logEntryArchive.LimitsQueueableJobsMax__c,
             'logEntryArchive.LimitsQueueableJobsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsQueueableJobsUsed__c,
             logEntryArchive.LimitsQueueableJobsUsed__c,
             'logEntryArchive.LimitsQueueableJobsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsSoqlQueriesMax__c,
             logEntryArchive.LimitsSoqlQueriesMax__c,
             'logEntryArchive.LimitsSoqlQueriesMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsSoqlQueriesUsed__c,
             logEntryArchive.LimitsSoqlQueriesUsed__c,
             'logEntryArchive.LimitsSoqlQueriesUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsSoqlQueryLocatorRowsMax__c,
             logEntryArchive.LimitsSoqlQueryLocatorRowsMax__c,
             'logEntryArchive.LimitsSoqlQueryLocatorRowsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsSoqlQueryLocatorRowsUsed__c,
             logEntryArchive.LimitsSoqlQueryLocatorRowsUsed__c,
             'logEntryArchive.LimitsSoqlQueryLocatorRowsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsSoqlQueryRowsMax__c,
             logEntryArchive.LimitsSoqlQueryRowsMax__c,
             'logEntryArchive.LimitsSoqlQueryRowsMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsSoqlQueryRowsUsed__c,
             logEntryArchive.LimitsSoqlQueryRowsUsed__c,
             'logEntryArchive.LimitsSoqlQueryRowsUsed__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsSoslSearchesMax__c,
             logEntryArchive.LimitsSoslSearchesMax__c,
             'logEntryArchive.LimitsSoslSearchesMax__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.LimitsSoslSearchesUsed__c,
             logEntryArchive.LimitsSoslSearchesUsed__c,
             'logEntryArchive.LimitsSoslSearchesUsed__c was not properly set'
         );
-        System.assertEquals(logEntry.Log__r.Locale__c, logEntryArchive.Locale__c, 'logEntryArchive.Locale__c was not properly set');
-        System.assertEquals(logEntry.Log__r.LoggedBy__c, logEntryArchive.LoggedById__c, 'logEntryArchive.LoggedById__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.Log__r.Locale__c, logEntryArchive.Locale__c, 'logEntryArchive.Locale__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.LoggedBy__c, logEntryArchive.LoggedById__c, 'logEntryArchive.LoggedById__c was not properly set');
+        System.Assert.areEqual(
             logEntry.Log__r.LoggedByUsername__c,
             logEntryArchive.LoggedByUsername__c,
             'logEntryArchive.LoggedByUsername__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.Log__r.LoggerVersionNumber__c,
             logEntryArchive.LoggerVersionNumber__c,
             'logEntryArchive.LoggerVersionNumber__c was not properly set'
         );
-        System.assertEquals(logEntry.LoggingLevel__c, logEntryArchive.LoggingLevel__c, 'logEntryArchive.LoggingLevel__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.LoggingLevel__c, logEntryArchive.LoggingLevel__c, 'logEntryArchive.LoggingLevel__c was not properly set');
+        System.Assert.areEqual(
             logEntry.LoggingLevelOrdinal__c,
             logEntryArchive.LoggingLevelOrdinal__c,
             'logEntryArchive.LoggingLevelOrdinal__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.Log__r.LoginApplication__c,
             logEntryArchive.LoginApplication__c,
             'logEntryArchive.LoginApplication__c was not properly set'
         );
-        System.assertEquals(logEntry.Log__r.LoginBrowser__c, logEntryArchive.LoginBrowser__c, 'logEntryArchive.LoginBrowser__c was not properly set');
-        System.assertEquals(logEntry.Log__r.LoginHistoryId__c, logEntryArchive.LoginHistoryId__c, 'logEntryArchive.LoginHistoryId__c was not properly set');
-        System.assertEquals(logEntry.Log__r.LoginPlatform__c, logEntryArchive.LoginPlatform__c, 'logEntryArchive.LoginPlatform__c was not properly set');
-        System.assertEquals(logEntry.Log__r.LoginType__c, logEntryArchive.LoginType__c, 'logEntryArchive.LoginType__c was not properly set');
-        System.assertEquals(logEntry.Log__r.LogoutUrl__c, logEntryArchive.LogoutUrl__c, 'logEntryArchive.LogoutUrl__c was not properly set');
-        System.assertEquals(logEntry.Log__r.LogPurgeAction__c, logEntryArchive.LogPurgeAction__c, 'logEntryArchive.LogPurgeAction__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.Log__r.LoginBrowser__c, logEntryArchive.LoginBrowser__c, 'logEntryArchive.LoginBrowser__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.LoginHistoryId__c, logEntryArchive.LoginHistoryId__c, 'logEntryArchive.LoginHistoryId__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.LoginPlatform__c, logEntryArchive.LoginPlatform__c, 'logEntryArchive.LoginPlatform__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.LoginType__c, logEntryArchive.LoginType__c, 'logEntryArchive.LoginType__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.LogoutUrl__c, logEntryArchive.LogoutUrl__c, 'logEntryArchive.LogoutUrl__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.LogPurgeAction__c, logEntryArchive.LogPurgeAction__c, 'logEntryArchive.LogPurgeAction__c was not properly set');
+        System.Assert.areEqual(
             logEntry.Log__r.LogRetentionDate__c,
             logEntryArchive.LogRetentionDate__c,
             'logEntryArchive.LogRetentionDate__c was not properly set'
         );
-        System.assertEquals(logEntry.Message__c, logEntryArchive.Message__c, 'logEntryArchive.Message__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.Message__c, logEntryArchive.Message__c, 'logEntryArchive.Message__c was not properly set');
+        System.Assert.areEqual(
             String.valueOf(logEntry.MessageMasked__c),
             logEntryArchive.MessageMasked__c,
             'logEntryArchive.MessageMasked__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             String.valueOf(logEntry.MessageTruncated__c),
             logEntryArchive.MessageTruncated__c,
             'logEntryArchive.MessageTruncated__c was not properly set'
         );
-        System.assertEquals(logEntry.Log__r.NetworkId__c, logEntryArchive.NetworkId__c, 'logEntryArchive.NetworkId__c was not properly set');
-        System.assertEquals(logEntry.Log__r.NetworkLoginUrl__c, logEntryArchive.NetworkLoginUrl__c, 'logEntryArchive.NetworkLoginUrl__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.Log__r.NetworkId__c, logEntryArchive.NetworkId__c, 'logEntryArchive.NetworkId__c was not properly set');
+        System.Assert.areEqual(
+            logEntry.Log__r.NetworkLoginUrl__c,
+            logEntryArchive.NetworkLoginUrl__c,
+            'logEntryArchive.NetworkLoginUrl__c was not properly set'
+        );
+        System.Assert.areEqual(
             logEntry.Log__r.NetworkLogoutUrl__c,
             logEntryArchive.NetworkLogoutUrl__c,
             'logEntryArchive.NetworkLogoutUrl__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.Log__r.NetworkSelfRegistrationUrl__c,
             logEntryArchive.NetworkSelfRegistrationUrl__c,
             'logEntryArchive.NetworkSelfRegistrationUrl__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.Log__r.NetworkUrlPathPrefix__c,
             logEntryArchive.NetworkUrlPathPrefix__c,
             'logEntryArchive.NetworkUrlPathPrefix__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.Log__r.OrganizationDomainUrl__c,
             logEntryArchive.OrganizationDomainUrl__c,
             'logEntryArchive.OrganizationDomainUrl__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.Log__r.OrganizationEnvironmentType__c,
             logEntryArchive.OrganizationEnvironmentType__c,
             'logEntryArchive.OrganizationEnvironmentType__c was not properly set'
         );
-        System.assertEquals(logEntry.Log__r.OrganizationId__c, logEntryArchive.OrganizationId__c, 'logEntryArchive.OrganizationId__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.Log__r.OrganizationId__c, logEntryArchive.OrganizationId__c, 'logEntryArchive.OrganizationId__c was not properly set');
+        System.Assert.areEqual(
             logEntry.Log__r.OrganizationInstanceName__c,
             logEntryArchive.OrganizationInstanceName__c,
             'logEntryArchive.OrganizationInstanceName__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.Log__r.OrganizationName__c,
             logEntryArchive.OrganizationName__c,
             'logEntryArchive.OrganizationName__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.Log__r.OrganizationNamespacePrefix__c,
             logEntryArchive.OrganizationNamespacePrefix__c,
             'logEntryArchive.OrganizationNamespacePrefix__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.Log__r.OrganizationType__c,
             logEntryArchive.OrganizationType__c,
             'logEntryArchive.OrganizationType__c was not properly set'
         );
-        System.assertEquals(logEntry.OriginLocation__c, logEntryArchive.OriginLocation__c, 'logEntryArchive.OriginLocation__c was not properly set');
-        System.assertEquals(logEntry.OriginType__c, logEntryArchive.OriginType__c, 'logEntryArchive.OriginType__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.OriginLocation__c, logEntryArchive.OriginLocation__c, 'logEntryArchive.OriginLocation__c was not properly set');
+        System.Assert.areEqual(logEntry.OriginType__c, logEntryArchive.OriginType__c, 'logEntryArchive.OriginType__c was not properly set');
+        System.Assert.areEqual(
             logEntry.Log__r.ParentLog__r?.TransactionId__c,
             logEntryArchive.ParentLogTransactionId__c,
             'logEntryArchive.ParentLogTransactionId__c was not properly set'
         );
-        System.assertEquals(logEntry.Log__r.Priority__c, logEntryArchive.Priority__c, 'logEntryArchive.Priority__c was not properly set');
-        System.assertEquals(logEntry.Log__r.ProfileId__c, logEntryArchive.ProfileId__c, 'logEntryArchive.ProfileId__c was not properly set');
-        System.assertEquals(logEntry.Log__r.ProfileName__c, logEntryArchive.ProfileName__c, 'logEntryArchive.ProfileName__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.Log__r.Priority__c, logEntryArchive.Priority__c, 'logEntryArchive.Priority__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.ProfileId__c, logEntryArchive.ProfileId__c, 'logEntryArchive.ProfileId__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.ProfileName__c, logEntryArchive.ProfileName__c, 'logEntryArchive.ProfileName__c was not properly set');
+        System.Assert.areEqual(
             logEntry.RecordCollectionSize__c,
             logEntryArchive.RecordCollectionSize__c,
             'logEntryArchive.RecordCollectionSize__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.RecordCollectionType__c,
             logEntryArchive.RecordCollectionType__c,
             'logEntryArchive.RecordCollectionType__c was not properly set'
         );
-        System.assertEquals(logEntry.RecordId__c, logEntryArchive.RecordId__c, 'logEntryArchive.RecordId__c was not properly set');
-        System.assertEquals(logEntry.RecordJson__c, logEntryArchive.RecordJson__c, 'logEntryArchive.RecordJson__c was not properly set');
-        System.assertEquals(logEntry.RecordName__c, logEntryArchive.RecordName__c, 'logEntryArchive.RecordName__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.RecordId__c, logEntryArchive.RecordId__c, 'logEntryArchive.RecordId__c was not properly set');
+        System.Assert.areEqual(logEntry.RecordJson__c, logEntryArchive.RecordJson__c, 'logEntryArchive.RecordJson__c was not properly set');
+        System.Assert.areEqual(logEntry.RecordName__c, logEntryArchive.RecordName__c, 'logEntryArchive.RecordName__c was not properly set');
+        System.Assert.areEqual(
             String.valueOf(logEntry.RecordJsonMasked__c),
             logEntryArchive.RecordJsonMasked__c,
             'logEntryArchive.RecordJsonMasked__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.RecordSObjectClassification__c,
             logEntryArchive.RecordSObjectClassification__c,
             'logEntryArchive.RecordSObjectClassification__c was not properly set'
         );
-        System.assertEquals(logEntry.RecordSObjectType__c, logEntryArchive.RecordSObjectType__c, 'logEntryArchive.RecordSObjectType__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(
+            logEntry.RecordSObjectType__c,
+            logEntryArchive.RecordSObjectType__c,
+            'logEntryArchive.RecordSObjectType__c was not properly set'
+        );
+        System.Assert.areEqual(
             logEntry.RecordSObjectTypeNamespace__c,
             logEntryArchive.RecordSObjectTypeNamespace__c,
             'logEntryArchive.RecordSObjectTypeNamespace__c was not properly set'
         );
-        System.assertEquals(logEntry.Log__r.SessionId__c, logEntryArchive.SessionId__c, 'logEntryArchive.SessionId__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.Log__r.SessionId__c, logEntryArchive.SessionId__c, 'logEntryArchive.SessionId__c was not properly set');
+        System.Assert.areEqual(
             logEntry.Log__r.SessionSecurityLevel__c,
             logEntryArchive.SessionSecurityLevel__c,
             'logEntryArchive.SessionSecurityLevel__c was not properly set'
         );
-        System.assertEquals(logEntry.Log__r.SessionType__c, logEntryArchive.SessionType__c, 'logEntryArchive.SessionType__c was not properly set');
-        System.assertEquals(logEntry.Log__r.SourceIp__c, logEntryArchive.SourceIp__c, 'logEntryArchive.SourceIp__c was not properly set');
-        System.assertEquals(logEntry.StackTrace__c, logEntryArchive.StackTrace__c, 'logEntryArchive.StackTrace__c was not properly set');
-        System.assertEquals(logEntry.Log__r.Status__c, logEntryArchive.Status__c, 'logEntryArchive.Status__c was not properly set');
-        System.assertEquals(logEntry.Log__r.SystemMode__c, logEntryArchive.SystemMode__c, 'logEntryArchive.SystemMode__c was not properly set');
-        System.assertEquals(tags, logEntryArchive.Tags__c, 'logEntryArchive.Tags__c was not properly set');
-        System.assertEquals(logEntry.Log__r.ThemeDisplayed__c, logEntryArchive.ThemeDisplayed__c, 'logEntryArchive.ThemeDisplayed__c was not properly set');
-        System.assertEquals(logEntry.Timestamp__c, logEntryArchive.Timestamp__c, 'logEntryArchive.Timestamp__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.Log__r.SessionType__c, logEntryArchive.SessionType__c, 'logEntryArchive.SessionType__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.SourceIp__c, logEntryArchive.SourceIp__c, 'logEntryArchive.SourceIp__c was not properly set');
+        System.Assert.areEqual(logEntry.StackTrace__c, logEntryArchive.StackTrace__c, 'logEntryArchive.StackTrace__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.Status__c, logEntryArchive.Status__c, 'logEntryArchive.Status__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.SystemMode__c, logEntryArchive.SystemMode__c, 'logEntryArchive.SystemMode__c was not properly set');
+        System.Assert.areEqual(tags, logEntryArchive.Tags__c, 'logEntryArchive.Tags__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.ThemeDisplayed__c, logEntryArchive.ThemeDisplayed__c, 'logEntryArchive.ThemeDisplayed__c was not properly set');
+        System.Assert.areEqual(logEntry.Timestamp__c, logEntryArchive.Timestamp__c, 'logEntryArchive.Timestamp__c was not properly set');
+        System.Assert.areEqual(
             String.valueOf(logEntry.Timestamp__c),
             logEntryArchive.TimestampString__c,
             'logEntryArchive.TimestampString__c was not properly set'
         );
-        System.assertEquals(logEntry.Log__r.TimeZoneId__c, logEntryArchive.TimeZoneId__c, 'logEntryArchive.TimeZoneId__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.Log__r.TimeZoneId__c, logEntryArchive.TimeZoneId__c, 'logEntryArchive.TimeZoneId__c was not properly set');
+        System.Assert.areEqual(
             logEntry.TransactionEntryNumber__c,
             logEntryArchive.TransactionEntryNumber__c,
             'logEntryArchive.TransactionEntryNumber__c was not properly set'
         );
-        System.assertEquals(logEntry.Log__r.TransactionId__c, logEntryArchive.TransactionId__c, 'logEntryArchive.TransactionId__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(logEntry.Log__r.TransactionId__c, logEntryArchive.TransactionId__c, 'logEntryArchive.TransactionId__c was not properly set');
+        System.Assert.areEqual(
             String.valueOf(logEntry.TriggerIsExecuting__c),
             logEntryArchive.TriggerIsExecuting__c,
             'logEntryArchive.TriggerIsExecuting__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.TriggerOperationType__c,
             logEntryArchive.TriggerOperationType__c,
             'logEntryArchive.TriggerOperationType__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.TriggerSObjectType__c,
             logEntryArchive.TriggerSObjectType__c,
             'logEntryArchive.TriggerSObjectType__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.Log__r.UserLicenseDefinitionKey__c,
             logEntryArchive.UserLicenseDefinitionKey__c,
             'logEntryArchive.UserLicenseDefinitionKey__c was not properly set'
         );
-        System.assertEquals(logEntry.Log__r.UserLicenseName__c, logEntryArchive.UserLicenseName__c, 'logEntryArchive.UserLicenseName__c was not properly set');
-        System.assertEquals(
+        System.Assert.areEqual(
+            logEntry.Log__r.UserLicenseName__c,
+            logEntryArchive.UserLicenseName__c,
+            'logEntryArchive.UserLicenseName__c was not properly set'
+        );
+        System.Assert.areEqual(
             logEntry.Log__r.UserLoggingLevel__c,
             logEntryArchive.UserLoggingLevel__c,
             'logEntryArchive.UserLoggingLevel__c was not properly set'
         );
-        System.assertEquals(
+        System.Assert.areEqual(
             logEntry.Log__r.UserLoggingLevelOrdinal__c,
             logEntryArchive.UserLoggingLevelOrdinal__c,
             'logEntryArchive.UserLoggingLevelOrdinal__c was not properly set'
         );
-        System.assertEquals(logEntry.Log__r.UserRoleId__c, logEntryArchive.UserRoleId__c, 'logEntryArchive.UserRoleId__c was not properly set');
-        System.assertEquals(logEntry.Log__r.UserRoleName__c, logEntryArchive.UserRoleName__c, 'logEntryArchive.UserRoleName__c was not properly set');
-        System.assertEquals(logEntry.Log__r.UserType__c, logEntryArchive.UserType__c, 'logEntryArchive.UserType__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.UserRoleId__c, logEntryArchive.UserRoleId__c, 'logEntryArchive.UserRoleId__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.UserRoleName__c, logEntryArchive.UserRoleName__c, 'logEntryArchive.UserRoleName__c was not properly set');
+        System.Assert.areEqual(logEntry.Log__r.UserType__c, logEntryArchive.UserType__c, 'logEntryArchive.UserType__c was not properly set');
     }
 }

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveBuilder_Tests.cls
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveBuilder_Tests.cls
@@ -90,10 +90,14 @@ private class LogEntryArchiveBuilder_Tests {
     @SuppressWarnings('PMD.NcssMethodCount')
     private static void assertAllFieldsMatch(Datetime timestamp, LogEntryEvent__e mockEvent, LogEntryArchive__b logEntryArchive) {
         System.Assert.areEqual(mockEvent.ApiVersion__c, logEntryArchive.ApiVersion__c, 'logEntryArchive.ApiVersion__c was not properly set');
-        System.Assert.areEqual(UserInfo.getUserId(), logEntryArchive.ArchivedById__c, 'logEntryArchive.ArchivedById__c was not properly set');
+        System.Assert.areEqual(System.UserInfo.getUserId(), logEntryArchive.ArchivedById__c, 'logEntryArchive.ArchivedById__c was not properly set');
         System.Assert.isNotNull(logEntryArchive.ArchivedDate__c, 'logEntryArchive.ArchivedDate__c was not properly set');
         System.Assert.areEqual(System.today(), logEntryArchive.ArchivedDate__c.date(), 'logEntryArchive.ArchivedDate__c was not properly set');
-        System.Assert.areEqual(UserInfo.getUsername(), logEntryArchive.ArchivedByUsername__c, 'logEntryArchive.ArchivedByUsername__c was not properly set');
+        System.Assert.areEqual(
+            System.UserInfo.getUsername(),
+            logEntryArchive.ArchivedByUsername__c,
+            'logEntryArchive.ArchivedByUsername__c was not properly set'
+        );
         System.Assert.areEqual(mockEvent.ComponentType__c, logEntryArchive.ComponentType__c, 'logEntryArchive.ComponentType__c was not properly set');
         System.Assert.areEqual(
             mockEvent.DatabaseResultCollectionSize__c,
@@ -478,10 +482,14 @@ private class LogEntryArchiveBuilder_Tests {
             'logEntryArchive.ApiReleaseVersion__c was not properly set'
         );
         System.Assert.areEqual(logEntry.Log__r.ApiVersion__c, logEntryArchive.ApiVersion__c, 'logEntryArchive.ApiVersion__c was not properly set');
-        System.Assert.areEqual(UserInfo.getUserId(), logEntryArchive.ArchivedById__c, 'logEntryArchive.ArchivedById__c was not properly set');
+        System.Assert.areEqual(System.UserInfo.getUserId(), logEntryArchive.ArchivedById__c, 'logEntryArchive.ArchivedById__c was not properly set');
         System.Assert.isNotNull(logEntryArchive.ArchivedDate__c, 'logEntryArchive.ArchivedDate__c was not properly set');
         System.Assert.areEqual(System.today(), logEntryArchive.ArchivedDate__c.date(), 'logEntryArchive.ArchivedDate__c was not properly set');
-        System.Assert.areEqual(UserInfo.getUsername(), logEntryArchive.ArchivedByUsername__c, 'logEntryArchive.ArchivedByUsername__c was not properly set');
+        System.Assert.areEqual(
+            System.UserInfo.getUsername(),
+            logEntryArchive.ArchivedByUsername__c,
+            'logEntryArchive.ArchivedByUsername__c was not properly set'
+        );
         System.Assert.areEqual(logEntry.Log__r.ClosedBy__c, logEntryArchive.ClosedById__c, 'logEntryArchive.ClosedById__c was not properly set');
         System.Assert.areEqual(
             logEntry.Log__r.ClosedBy__r?.Username,

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveController_Tests.cls
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveController_Tests.cls
@@ -8,7 +8,7 @@
 private class LogEntryArchiveController_Tests {
     @IsTest
     static void it_returns_subset_of_log_entry_archives_when_row_limit_met() {
-        List<LogEntryArchive__b> expectedLogEntryArchives = createLogEntryArchive(5, LoggingLevel.DEBUG);
+        List<LogEntryArchive__b> expectedLogEntryArchives = createLogEntryArchive(5, System.LoggingLevel.DEBUG);
         LogEntryArchiveController.MOCK_RECORDS.addAll(expectedLogEntryArchives);
         Integer rowLimit = expectedLogEntryArchives.size() - 2;
 
@@ -26,7 +26,7 @@ private class LogEntryArchiveController_Tests {
 
     @IsTest
     static void it_returns_all_log_entry_archives_when_logging_level_and_message_search_term_are_null() {
-        List<LogEntryArchive__b> expectedLogEntryArchives = createLogEntryArchive(5, LoggingLevel.DEBUG);
+        List<LogEntryArchive__b> expectedLogEntryArchives = createLogEntryArchive(5, System.LoggingLevel.DEBUG);
         LogEntryArchiveController.MOCK_RECORDS.addAll(expectedLogEntryArchives);
 
         List<LogEntryArchive__b> returnedLogEntryArchives = LogEntryArchiveController.getLogEntryArchives(
@@ -43,10 +43,10 @@ private class LogEntryArchiveController_Tests {
 
     @IsTest
     static void it_returns_filtered_log_entry_archives_whenlogging_level_filter_is_specified() {
-        List<LogEntryArchive__b> expectedLogEntryArchives = createLogEntryArchive(5, LoggingLevel.DEBUG);
-        LoggingLevel minimumLoggingLevel = LoggingLevel.INFO;
-        expectedLogEntryArchives.get(0).LoggingLevel__c = LoggingLevel.WARN.name();
-        expectedLogEntryArchives.get(0).LoggingLevelOrdinal__c = LoggingLevel.WARN.ordinal();
+        List<LogEntryArchive__b> expectedLogEntryArchives = createLogEntryArchive(5, System.LoggingLevel.DEBUG);
+        System.LoggingLevel minimumLoggingLevel = System.LoggingLevel.INFO;
+        expectedLogEntryArchives.get(0).LoggingLevel__c = System.LoggingLevel.WARN.name();
+        expectedLogEntryArchives.get(0).LoggingLevelOrdinal__c = System.LoggingLevel.WARN.ordinal();
         LogEntryArchiveController.MOCK_RECORDS.addAll(expectedLogEntryArchives);
 
         List<LogEntryArchive__b> returnedLogEntryArchives = LogEntryArchiveController.getLogEntryArchives(
@@ -63,7 +63,7 @@ private class LogEntryArchiveController_Tests {
 
     @IsTest
     static void it_returns_filtered_log_entry_archives_when_message_search_term_is_specified() {
-        List<LogEntryArchive__b> expectedLogEntryArchives = createLogEntryArchive(5, LoggingLevel.DEBUG);
+        List<LogEntryArchive__b> expectedLogEntryArchives = createLogEntryArchive(5, System.LoggingLevel.DEBUG);
         String messageSearchTerm = 'some substring';
         expectedLogEntryArchives.get(0).Message__c = 'some extra text and ' + messageSearchTerm + ' and then also some more text, blah blah blah';
         LogEntryArchiveController.MOCK_RECORDS.addAll(expectedLogEntryArchives);
@@ -80,7 +80,7 @@ private class LogEntryArchiveController_Tests {
         System.Assert.isTrue(returnedLogEntryArchives.get(0).Message__c.contains(messageSearchTerm));
     }
 
-    private static List<LogEntryArchive__b> createLogEntryArchive(Integer numberOfRecordsToCreate, LoggingLevel logLevel) {
+    private static List<LogEntryArchive__b> createLogEntryArchive(Integer numberOfRecordsToCreate, System.LoggingLevel logLevel) {
         List<LogEntryArchive__b> records = new List<LogEntryArchive__b>();
         for (Integer i = 0; i < numberOfRecordsToCreate; i++) {
             records.add(

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveController_Tests.cls
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveController_Tests.cls
@@ -20,8 +20,8 @@ private class LogEntryArchiveController_Tests {
             null
         );
 
-        System.assertNotEquals(0, returnedLogEntryArchives.size(), 'Records should have been returned');
-        System.assertEquals(rowLimit, returnedLogEntryArchives.size(), 'Returned records should match the specified row limit');
+        System.Assert.areNotEqual(0, returnedLogEntryArchives.size(), 'Records should have been returned');
+        System.Assert.areEqual(rowLimit, returnedLogEntryArchives.size(), 'Returned records should match the specified row limit');
     }
 
     @IsTest
@@ -37,8 +37,8 @@ private class LogEntryArchiveController_Tests {
             null
         );
 
-        System.assertNotEquals(0, returnedLogEntryArchives.size(), 'Records should have been returned');
-        System.assertEquals(expectedLogEntryArchives.size(), returnedLogEntryArchives.size(), 'Returned records should match the expected records');
+        System.Assert.areNotEqual(0, returnedLogEntryArchives.size(), 'Records should have been returned');
+        System.Assert.areEqual(expectedLogEntryArchives.size(), returnedLogEntryArchives.size(), 'Returned records should match the expected records');
     }
 
     @IsTest
@@ -57,8 +57,8 @@ private class LogEntryArchiveController_Tests {
             null
         );
 
-        System.assertEquals(1, returnedLogEntryArchives.size(), 'Only one matching record should have been returned');
-        System.assertEquals(true, returnedLogEntryArchives.get(0).LoggingLevelOrdinal__c > minimumLoggingLevel.ordinal());
+        System.Assert.areEqual(1, returnedLogEntryArchives.size(), 'Only one matching record should have been returned');
+        System.Assert.isTrue(returnedLogEntryArchives.get(0).LoggingLevelOrdinal__c > minimumLoggingLevel.ordinal());
     }
 
     @IsTest
@@ -76,8 +76,8 @@ private class LogEntryArchiveController_Tests {
             messageSearchTerm
         );
 
-        System.assertEquals(1, returnedLogEntryArchives.size(), 'Only one matching record should have been returned');
-        System.assertEquals(true, returnedLogEntryArchives.get(0).Message__c.contains(messageSearchTerm));
+        System.Assert.areEqual(1, returnedLogEntryArchives.size(), 'Only one matching record should have been returned');
+        System.Assert.isTrue(returnedLogEntryArchives.get(0).Message__c.contains(messageSearchTerm));
     }
 
     private static List<LogEntryArchive__b> createLogEntryArchive(Integer numberOfRecordsToCreate, LoggingLevel logLevel) {

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchivePlugin_Tests.cls
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchivePlugin_Tests.cls
@@ -39,9 +39,9 @@ private class LogEntryArchivePlugin_Tests {
         Database.executeBatch(batchPurger);
 
         System.Test.stopTest();
-        System.assertEquals(log.LogEntries__r.size(), LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.size());
+        System.Assert.areEqual(log.LogEntries__r.size(), LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.size());
         List<Log__c> existingLogs = [SELECT Id FROM Log__c WHERE LogPurgeAction__c = :LogEntryArchivePlugin.BIG_OBJECT_LOG_PURGE_ACTION];
-        System.assertEquals(0, existingLogs.size());
+        System.Assert.areEqual(0, existingLogs.size());
     }
 
     @IsTest
@@ -55,13 +55,13 @@ private class LogEntryArchivePlugin_Tests {
             FROM Log__c
             WHERE LogPurgeAction__c = :LogEntryArchivePlugin.BIG_OBJECT_LOG_PURGE_ACTION
         ];
-        System.assertNotEquals(
+        System.Assert.areNotEqual(
             true,
             logToArchive.LogEntries__r.isEmpty(),
             'Test has started under the wrong condiations - log record should have some related log entries'
         );
         Log__c logToSkip = [SELECT Id, (SELECT Id FROM LogEntries__r) FROM Log__c WHERE LogPurgeAction__c = 'Delete'];
-        System.assertNotEquals(
+        System.Assert.areNotEqual(
             true,
             logToSkip.LogEntries__r.isEmpty(),
             'Test has started under the wrong condiations - log record should have some related log entries'
@@ -71,13 +71,13 @@ private class LogEntryArchivePlugin_Tests {
         Database.executeBatch(batchPurger);
 
         System.Test.stopTest();
-        System.assertEquals(
+        System.Assert.areEqual(
             logToArchive.LogEntries__r.size(),
             LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.size(),
             'Only the log entries for logToArchive should have been archived'
         );
         List<Log__c> existingLogs = [SELECT Id FROM Log__c];
-        System.assertEquals(0, existingLogs.size(), 'All logs should havve been deleted');
+        System.Assert.areEqual(0, existingLogs.size(), 'All logs should havve been deleted');
     }
 
     @IsTest
@@ -102,15 +102,15 @@ private class LogEntryArchivePlugin_Tests {
 
         Database.executeBatch(batchPurger);
 
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
         System.Test.stopTest();
-        System.assertEquals(0, System.Limits.getPublishImmediateDml());
-        System.assertEquals(logToArchive.LogEntries__r.size(), LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.size());
+        System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
+        System.Assert.areEqual(logToArchive.LogEntries__r.size(), LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.size());
         for (LogEntryArchive__b logEntryArchive : LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE) {
-            System.assertEquals(tag.Name, logEntryArchive.Tags__c);
+            System.Assert.areEqual(tag.Name, logEntryArchive.Tags__c);
         }
         List<Log__c> existingLogs = [SELECT Id FROM Log__c];
-        System.assertEquals(0, existingLogs.size());
+        System.Assert.areEqual(0, existingLogs.size());
     }
 
     @IsTest
@@ -133,7 +133,7 @@ private class LogEntryArchivePlugin_Tests {
 
         new LogEntryArchivePlugin().execute(pluginConfiguration, pluginInput);
 
-        System.assertEquals(0, LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.size(), 'Should not have tried to create big object');
+        System.Assert.areEqual(0, LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.size(), 'Should not have tried to create big object');
     }
 
     @IsTest
@@ -147,22 +147,22 @@ private class LogEntryArchivePlugin_Tests {
         System.Test.startTest();
         String transactionId = Logger.getTransactionId();
         Logger.info('Testing big object creation');
-        System.assertEquals(1, Logger.getBufferSize(), 'Should have one record in Logger\'s platform event buffer');
+        System.Assert.areEqual(1, Logger.getBufferSize(), 'Should have one record in Logger\'s platform event buffer');
 
         Logger.saveLog();
         System.Test.getEventBus().deliver();
 
-        System.assertEquals(0, Logger.getBufferSize(), 'Should have been cleared from Logger\'s platform event buffer');
-        System.assertEquals(
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Should have been cleared from Logger\'s platform event buffer');
+        System.Assert.areEqual(
             'BIG_OBJECT_QUEUEABLE',
             LogEntryArchivePlugin.lastSaveMethodUsed,
             'Last save method used should have been set to BIG_OBJECT_EVENT_BUS'
         );
         System.Test.stopTest();
-        System.assertEquals(1, LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.size(), 'Should have been put into big object buffer');
-        System.assertNotEquals(null, transactionId, 'Should have a value for transaction ID');
-        System.assertEquals(transactionId, LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.get(0).TransactionId__c, 'Transaction ID should match');
-        System.assertEquals(0, [SELECT COUNT() FROM Log__c WHERE TransactionId__c = :transactionId], 'No custom object data should have been created');
+        System.Assert.areEqual(1, LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.size(), 'Should have been put into big object buffer');
+        System.Assert.isNotNull(transactionId, 'Should have a value for transaction ID');
+        System.Assert.areEqual(transactionId, LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.get(0).TransactionId__c, 'Transaction ID should match');
+        System.Assert.areEqual(0, [SELECT COUNT() FROM Log__c WHERE TransactionId__c = :transactionId], 'No custom object data should have been created');
     }
 
     @IsTest
@@ -176,14 +176,14 @@ private class LogEntryArchivePlugin_Tests {
 
         Logger.saveLog();
 
-        System.assertEquals(
+        System.Assert.areEqual(
             0,
             System.Limits.getPublishImmediateDml(),
             'Should not have actually used any DML statements in tests because big objects actually get inserted, yikes'
         );
-        System.assertEquals(0, Logger.getBufferSize(), 'Should not have been put into Logger\'s platform event buffer');
-        System.assertEquals(1, LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.size(), 'Should have been put into big object buffer');
-        System.assertEquals(
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Should not have been put into Logger\'s platform event buffer');
+        System.Assert.areEqual(1, LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.size(), 'Should have been put into big object buffer');
+        System.Assert.areEqual(
             'BIG_OBJECT_IMMEDIATE',
             LogEntryArchivePlugin.lastSaveMethodUsed,
             'Last save method used should have been set to BIG_OBJECT_IMMEDIATE'
@@ -199,19 +199,19 @@ private class LogEntryArchivePlugin_Tests {
         createPluginConfiguration();
         Logger.info('Testing big object creation').getLogEntryEvent();
         System.Test.startTest();
-        System.assertEquals(0, System.Limits.getAsyncCalls(), 'Should not have executed any queueable jobs');
+        System.Assert.areEqual(0, System.Limits.getAsyncCalls(), 'Should not have executed any queueable jobs');
 
         Logger.saveLog();
 
-        System.assertEquals(1, System.Limits.getAsyncCalls(), 'Should have executed queueable saver job');
-        System.assertEquals(
+        System.Assert.areEqual(1, System.Limits.getAsyncCalls(), 'Should have executed queueable saver job');
+        System.Assert.areEqual(
             0,
             System.Limits.getPublishImmediateDml(),
             'Should not have actually used any DML statements in tests because big objects actually get inserted, yikes'
         );
-        System.assertEquals(0, Logger.getBufferSize(), 'Should not have been put into Logger\'s platform event buffer');
-        System.assertEquals(1, LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.size(), 'Should have been put into big object buffer');
-        System.assertEquals(
+        System.Assert.areEqual(0, Logger.getBufferSize(), 'Should not have been put into Logger\'s platform event buffer');
+        System.Assert.areEqual(1, LogEntryArchivePlugin.LOG_ENTRY_ARCHIVES_TO_SAVE.size(), 'Should have been put into big object buffer');
+        System.Assert.areEqual(
             'BIG_OBJECT_QUEUEABLE',
             LogEntryArchivePlugin.lastSaveMethodUsed,
             'Last save method used should have been set to BIG_OBJECT_QUEUEABLE'

--- a/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter.cls
+++ b/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter.cls
@@ -251,7 +251,7 @@ public without sharing class LogRetentionFilter {
         // Example of what you can't do in Apex:
         //          Object today = System.today();
         //          Object yesterday = System.today().addDays(-1);
-        //          System.assert(today > yesterday); // This line cannot execute since it's comparing Object
+        //          System.Assert.isTrue(today > yesterday); // This line cannot execute since it's comparing Object
         private Boolean compareDatetime(Datetime recordFieldValue, Datetime comparisonValue) {
             // TODO In a future release, it'd be great to switch (ha!) these hardcoded strings to instead use
             // a (new) private enum

--- a/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter.cls
+++ b/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter.cls
@@ -192,7 +192,7 @@ public without sharing class LogRetentionFilter {
                     return this.compareString((String) recordFieldValue, String.valueOf(comparisonValue));
                 }
                 when else {
-                    throw new IllegalArgumentException('Could not process field path: ' + this.filterCondition.FieldPath__c);
+                    throw new System.IllegalArgumentException('Could not process field path: ' + this.filterCondition.FieldPath__c);
                 }
             }
         }
@@ -218,7 +218,7 @@ public without sharing class LogRetentionFilter {
                     return this.filterCondition.Value__c;
                 }
                 when else {
-                    throw new IllegalArgumentException('Unknown Value Type, cannot parse comparison value');
+                    throw new System.IllegalArgumentException('Unknown Value Type, cannot parse comparison value');
                 }
             }
         }
@@ -275,7 +275,7 @@ public without sharing class LogRetentionFilter {
                     return recordFieldValue >= comparisonValue;
                 }
                 when else {
-                    throw new IllegalArgumentException('Unsupported operator for Datetime: ' + this.filterCondition.Operator__c);
+                    throw new System.IllegalArgumentException('Unsupported operator for Datetime: ' + this.filterCondition.Operator__c);
                 }
             }
         }
@@ -303,7 +303,7 @@ public without sharing class LogRetentionFilter {
                     return recordFieldValue >= comparisonValue;
                 }
                 when else {
-                    throw new IllegalArgumentException('Unsupported operator for Decimal: ' + this.filterCondition.Operator__c);
+                    throw new System.IllegalArgumentException('Unsupported operator for Decimal: ' + this.filterCondition.Operator__c);
                 }
             }
         }
@@ -328,7 +328,7 @@ public without sharing class LogRetentionFilter {
                     return recordFieldValue.endsWith(comparisonValue);
                 }
                 when else {
-                    throw new IllegalArgumentException('Unsupported operator for String: ' + this.filterCondition.Operator__c);
+                    throw new System.IllegalArgumentException('Unsupported operator for String: ' + this.filterCondition.Operator__c);
                 }
             }
         }

--- a/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter_Tests.cls
+++ b/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter_Tests.cls
@@ -27,8 +27,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -52,8 +52,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -77,8 +77,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -100,8 +100,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -123,8 +123,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -146,8 +146,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -168,8 +168,8 @@ private class LogRetentionFilter_Tests {
             thrownIllegalArgumentException = ex;
         }
 
-        System.assertNotEquals(null, thrownIllegalArgumentException);
-        System.assertEquals('Unsupported operator for Datetime: ' + invalidOperator, thrownIllegalArgumentException.getMessage());
+        System.Assert.isNotNull(thrownIllegalArgumentException);
+        System.Assert.areEqual('Unsupported operator for Datetime: ' + invalidOperator, thrownIllegalArgumentException.getMessage());
     }
 
     @IsTest
@@ -191,8 +191,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -214,8 +214,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -237,8 +237,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -260,8 +260,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -283,8 +283,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -300,8 +300,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -321,8 +321,8 @@ private class LogRetentionFilter_Tests {
             thrownIllegalArgumentException = ex;
         }
 
-        System.assertNotEquals(null, thrownIllegalArgumentException);
-        System.assertEquals('Unsupported operator for Decimal: ' + invalidOperator, thrownIllegalArgumentException.getMessage());
+        System.Assert.isNotNull(thrownIllegalArgumentException);
+        System.Assert.areEqual('Unsupported operator for Decimal: ' + invalidOperator, thrownIllegalArgumentException.getMessage());
     }
 
     @IsTest
@@ -338,8 +338,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -355,8 +355,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -372,8 +372,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -391,8 +391,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -408,8 +408,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     @IsTest
@@ -429,8 +429,8 @@ private class LogRetentionFilter_Tests {
             thrownIllegalArgumentException = ex;
         }
 
-        System.assertNotEquals(null, thrownIllegalArgumentException);
-        System.assertEquals('Unsupported operator for String: ' + invalidOperator, thrownIllegalArgumentException.getMessage());
+        System.Assert.isNotNull(thrownIllegalArgumentException);
+        System.Assert.areEqual('Unsupported operator for String: ' + invalidOperator, thrownIllegalArgumentException.getMessage());
     }
 
     @IsTest
@@ -446,8 +446,8 @@ private class LogRetentionFilter_Tests {
         LogRetentionFilter.FilterResult expectedMatchResult = new LogRetentionFilter(matchingLogEntry, rule, conditions).getFilterResult();
         LogRetentionFilter.FilterResult expectedNonMatchResult = new LogRetentionFilter(nonMatchingLogEntry, rule, conditions).getFilterResult();
 
-        System.assertEquals(true, expectedMatchResult.matchesFilter());
-        System.assertEquals(false, expectedNonMatchResult.matchesFilter());
+        System.Assert.isTrue(expectedMatchResult.matchesFilter());
+        System.Assert.isFalse(expectedNonMatchResult.matchesFilter());
     }
 
     static LogRetentionRule__mdt createMockRule(String developerName) {

--- a/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter_Tests.cls
+++ b/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter_Tests.cls
@@ -174,7 +174,7 @@ private class LogRetentionFilter_Tests {
 
     @IsTest
     static void it_should_match_one_condition_on_decimal_equal_to() {
-        Integer exampleLoggingLevelOrdinal = LoggingLevel.INFO.ordinal();
+        Integer exampleLoggingLevelOrdinal = System.LoggingLevel.INFO.ordinal();
         LogRetentionRule__mdt rule = createMockRule('number_equal_to');
         List<LogRetentionRuleCondition__mdt> conditions = new List<LogRetentionRuleCondition__mdt>{
             createMockRuleCondition('LoggingLevelOrdinal__c', 'EQUAL_TO', 'Value', exampleLoggingLevelOrdinal)
@@ -197,7 +197,7 @@ private class LogRetentionFilter_Tests {
 
     @IsTest
     static void it_should_match_one_condition_on_decimal_not_equal_to() {
-        Integer exampleLoggingLevelOrdinal = LoggingLevel.INFO.ordinal();
+        Integer exampleLoggingLevelOrdinal = System.LoggingLevel.INFO.ordinal();
         LogRetentionRule__mdt rule = createMockRule('number_not_equal_to');
         List<LogRetentionRuleCondition__mdt> conditions = new List<LogRetentionRuleCondition__mdt>{
             createMockRuleCondition('LoggingLevelOrdinal__c', 'NOT_EQUAL_TO', 'Value', exampleLoggingLevelOrdinal)
@@ -220,7 +220,7 @@ private class LogRetentionFilter_Tests {
 
     @IsTest
     static void it_should_match_one_condition_on_decimal_less_than() {
-        Integer exampleLoggingLevelOrdinal = LoggingLevel.INFO.ordinal();
+        Integer exampleLoggingLevelOrdinal = System.LoggingLevel.INFO.ordinal();
         LogRetentionRule__mdt rule = createMockRule('number_less_than');
         List<LogRetentionRuleCondition__mdt> conditions = new List<LogRetentionRuleCondition__mdt>{
             createMockRuleCondition('LoggingLevelOrdinal__c', 'LESS_THAN', 'Value', exampleLoggingLevelOrdinal)
@@ -243,7 +243,7 @@ private class LogRetentionFilter_Tests {
 
     @IsTest
     static void it_should_match_one_condition_on_decimal_less_than_or_equal_to() {
-        Integer exampleLoggingLevelOrdinal = LoggingLevel.INFO.ordinal();
+        Integer exampleLoggingLevelOrdinal = System.LoggingLevel.INFO.ordinal();
         LogRetentionRule__mdt rule = createMockRule('number_less_than_or_equal_to');
         List<LogRetentionRuleCondition__mdt> conditions = new List<LogRetentionRuleCondition__mdt>{
             createMockRuleCondition('LoggingLevelOrdinal__c', 'LESS_THAN_OR_EQUAL_TO', 'Value', exampleLoggingLevelOrdinal)
@@ -266,7 +266,7 @@ private class LogRetentionFilter_Tests {
 
     @IsTest
     static void it_should_match_one_condition_on_decimal_greater_than() {
-        Integer exampleLoggingLevelOrdinal = LoggingLevel.INFO.ordinal();
+        Integer exampleLoggingLevelOrdinal = System.LoggingLevel.INFO.ordinal();
         LogRetentionRule__mdt rule = createMockRule('number_greater_than');
         List<LogRetentionRuleCondition__mdt> conditions = new List<LogRetentionRuleCondition__mdt>{
             createMockRuleCondition('LoggingLevelOrdinal__c', 'GREATER_THAN', 'Value', exampleLoggingLevelOrdinal)
@@ -289,7 +289,7 @@ private class LogRetentionFilter_Tests {
 
     @IsTest
     static void it_should_match_one_condition_on_decimal_greater_than_or_equal_to() {
-        Integer exampleLoggingLevelOrdinal = LoggingLevel.INFO.ordinal();
+        Integer exampleLoggingLevelOrdinal = System.LoggingLevel.INFO.ordinal();
         LogRetentionRule__mdt rule = createMockRule('number_greater_than_or_equal_to');
         List<LogRetentionRuleCondition__mdt> conditions = new List<LogRetentionRuleCondition__mdt>{
             createMockRuleCondition('LoggingLevelOrdinal__c', 'GREATER_THAN_OR_EQUAL_TO', 'Value', exampleLoggingLevelOrdinal)
@@ -307,7 +307,7 @@ private class LogRetentionFilter_Tests {
     @IsTest
     static void it_should_throw_illegal_argument_exception_on_decimal_when_invalid_operator() {
         String invalidOperator = 'THIS_IS_AN_INVALID_OPERATOR';
-        Integer exampleLoggingLevelOrdinal = LoggingLevel.INFO.ordinal();
+        Integer exampleLoggingLevelOrdinal = System.LoggingLevel.INFO.ordinal();
         LogRetentionRule__mdt rule = createMockRule('number_with_invalid_operator');
         List<LogRetentionRuleCondition__mdt> conditions = new List<LogRetentionRuleCondition__mdt>{
             createMockRuleCondition('LoggingLevelOrdinal__c', invalidOperator, 'Value', exampleLoggingLevelOrdinal)

--- a/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter_Tests.cls
+++ b/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter_Tests.cls
@@ -161,10 +161,10 @@ private class LogRetentionFilter_Tests {
         LogEntry__c mockLogEntry = (LogEntry__c) LoggerMockDataCreator.createDataBuilder(Schema.LogEntry__c.SObjectType).populateRequiredFields().getRecord();
         mockLogEntry.Timestamp__c = mockTimestamp;
 
-        Exception thrownIllegalArgumentException;
+        System.Exception thrownIllegalArgumentException;
         try {
             new LogRetentionFilter(mockLogEntry, rule, conditions).getFilterResult();
-        } catch (IllegalArgumentException ex) {
+        } catch (System.IllegalArgumentException ex) {
             thrownIllegalArgumentException = ex;
         }
 
@@ -314,10 +314,10 @@ private class LogRetentionFilter_Tests {
         };
         LogEntry__c mockLogEntry = new LogEntry__c(LoggingLevelOrdinal__c = exampleLoggingLevelOrdinal);
 
-        Exception thrownIllegalArgumentException;
+        System.Exception thrownIllegalArgumentException;
         try {
             new LogRetentionFilter(mockLogEntry, rule, conditions).getFilterResult();
-        } catch (IllegalArgumentException ex) {
+        } catch (System.IllegalArgumentException ex) {
             thrownIllegalArgumentException = ex;
         }
 
@@ -422,10 +422,10 @@ private class LogRetentionFilter_Tests {
         };
         LogEntry__c mockLogEntry = new LogEntry__c(Message__c = mockStringValue);
 
-        Exception thrownIllegalArgumentException;
+        System.Exception thrownIllegalArgumentException;
         try {
             new LogRetentionFilter(mockLogEntry, rule, conditions).getFilterResult();
-        } catch (IllegalArgumentException ex) {
+        } catch (System.IllegalArgumentException ex) {
             thrownIllegalArgumentException = ex;
         }
 

--- a/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionRulesPlugin_Tests.cls
+++ b/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionRulesPlugin_Tests.cls
@@ -29,7 +29,7 @@ private class LogRetentionRulesPlugin_Tests {
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
         System.Assert.areEqual(originalLogRetentionDate, log.LogRetentionDate__c);
 
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
+        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = System.LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
         insert logEntry;
 
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
@@ -58,7 +58,7 @@ private class LogRetentionRulesPlugin_Tests {
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
         System.Assert.areEqual(originalLogRetentionDate, log.LogRetentionDate__c);
 
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
+        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = System.LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
         insert logEntry;
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
         System.Assert.areEqual(expectedLogRetentionDate, log.LogRetentionDate__c);
@@ -85,7 +85,7 @@ private class LogRetentionRulesPlugin_Tests {
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
         System.Assert.areEqual(originalLogRetentionDate, log.LogRetentionDate__c);
 
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
+        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = System.LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
         insert logEntry;
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
         System.Assert.areEqual(expectedLogRetentionDate, log.LogRetentionDate__c);
@@ -99,7 +99,7 @@ private class LogRetentionRulesPlugin_Tests {
         Integer numberOfDaysToRetainLogs = 90;
         Date expectedLogRetentionDate = System.today().addDays(numberOfDaysToRetainLogs);
         String scenario = 'Some scenario';
-        Integer userLoggingLevelOrdinal = LoggingLevel.WARN.ordinal();
+        Integer userLoggingLevelOrdinal = System.LoggingLevel.WARN.ordinal();
         LogRetentionRule__mdt rule = createMockRule('rule_with_multiple_AND_conditions', 'AND', numberOfDaysToRetainLogs);
         LogRetentionRulesPlugin.setMockRetentionRule(rule);
         List<LogRetentionRuleCondition__mdt> conditions = new List<LogRetentionRuleCondition__mdt>{
@@ -112,7 +112,7 @@ private class LogRetentionRulesPlugin_Tests {
         insert log;
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
         System.Assert.areEqual(originalLogRetentionDate, log.LogRetentionDate__c);
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
+        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = System.LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
         insert logEntry;
 
         log = [SELECT Id, LogRetentionDate__c, Scenario__c, TotalERRORLogEntries__c FROM Log__c WHERE Id = :log.Id];
@@ -140,7 +140,7 @@ private class LogRetentionRulesPlugin_Tests {
         insert log;
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
         System.Assert.areEqual(originalLogRetentionDate, log.LogRetentionDate__c);
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
+        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = System.LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
         insert logEntry;
 
         log = [SELECT Id, LogRetentionDate__c, Scenario__c, TotalERRORLogEntries__c FROM Log__c WHERE Id = :log.Id];
@@ -156,7 +156,7 @@ private class LogRetentionRulesPlugin_Tests {
         Date expectedLogRetentionDate = System.today().addDays(numberOfDaysToRetainLogs);
         String scenario1 = 'Some scenario';
         String scenario2 = 'Another scenario';
-        Integer userLoggingLevelOrdinal = LoggingLevel.WARN.ordinal();
+        Integer userLoggingLevelOrdinal = System.LoggingLevel.WARN.ordinal();
         LogRetentionRule__mdt rule = createMockRule('rule_with_multiple_OR_conditions', 'Custom', numberOfDaysToRetainLogs);
         rule.CustomConditionLogic__c = '((1 OR 2) AND 3)';
         LogRetentionRulesPlugin.setMockRetentionRule(rule);
@@ -171,7 +171,7 @@ private class LogRetentionRulesPlugin_Tests {
         insert log;
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
         System.Assert.areEqual(originalLogRetentionDate, log.LogRetentionDate__c);
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
+        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = System.LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
         insert logEntry;
 
         log = [SELECT Id, LogRetentionDate__c, Scenario__c, TotalERRORLogEntries__c FROM Log__c WHERE Id = :log.Id];

--- a/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionRulesPlugin_Tests.cls
+++ b/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionRulesPlugin_Tests.cls
@@ -27,13 +27,13 @@ private class LogRetentionRulesPlugin_Tests {
         insert log;
         System.Test.setCreatedDate(log.Id, now.addDays(-1));
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(originalLogRetentionDate, log.LogRetentionDate__c);
+        System.Assert.areEqual(originalLogRetentionDate, log.LogRetentionDate__c);
 
         LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
         insert logEntry;
 
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(expectedLogRetentionDate, log.LogRetentionDate__c);
+        System.Assert.areEqual(expectedLogRetentionDate, log.LogRetentionDate__c);
     }
 
     @IsTest
@@ -56,12 +56,12 @@ private class LogRetentionRulesPlugin_Tests {
         insert log;
         System.Test.setCreatedDate(log.Id, now);
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(originalLogRetentionDate, log.LogRetentionDate__c);
+        System.Assert.areEqual(originalLogRetentionDate, log.LogRetentionDate__c);
 
         LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
         insert logEntry;
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(expectedLogRetentionDate, log.LogRetentionDate__c);
+        System.Assert.areEqual(expectedLogRetentionDate, log.LogRetentionDate__c);
     }
 
     @IsTest
@@ -83,12 +83,12 @@ private class LogRetentionRulesPlugin_Tests {
         Log__c log = new Log__c(Scenario__c = scenario, TransactionId__c = '1234');
         insert log;
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(originalLogRetentionDate, log.LogRetentionDate__c);
+        System.Assert.areEqual(originalLogRetentionDate, log.LogRetentionDate__c);
 
         LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
         insert logEntry;
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(expectedLogRetentionDate, log.LogRetentionDate__c);
+        System.Assert.areEqual(expectedLogRetentionDate, log.LogRetentionDate__c);
     }
 
     @IsTest
@@ -111,12 +111,12 @@ private class LogRetentionRulesPlugin_Tests {
         Log__c log = new Log__c(Scenario__c = scenario, TransactionId__c = '1234', UserLoggingLevelOrdinal__c = userLoggingLevelOrdinal);
         insert log;
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(originalLogRetentionDate, log.LogRetentionDate__c);
+        System.Assert.areEqual(originalLogRetentionDate, log.LogRetentionDate__c);
         LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
         insert logEntry;
 
         log = [SELECT Id, LogRetentionDate__c, Scenario__c, TotalERRORLogEntries__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(expectedLogRetentionDate, log.LogRetentionDate__c, log);
+        System.Assert.areEqual(expectedLogRetentionDate, log.LogRetentionDate__c, JSON.serializePretty(log));
     }
 
     @IsTest
@@ -139,12 +139,12 @@ private class LogRetentionRulesPlugin_Tests {
         Log__c log = new Log__c(Scenario__c = scenario1, TransactionId__c = '1234');
         insert log;
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(originalLogRetentionDate, log.LogRetentionDate__c);
+        System.Assert.areEqual(originalLogRetentionDate, log.LogRetentionDate__c);
         LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
         insert logEntry;
 
         log = [SELECT Id, LogRetentionDate__c, Scenario__c, TotalERRORLogEntries__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(expectedLogRetentionDate, log.LogRetentionDate__c, log);
+        System.Assert.areEqual(expectedLogRetentionDate, log.LogRetentionDate__c, JSON.serializePretty(log));
     }
 
     @IsTest
@@ -170,12 +170,12 @@ private class LogRetentionRulesPlugin_Tests {
         Log__c log = new Log__c(Scenario__c = scenario1, TransactionId__c = '1234', UserLoggingLevelOrdinal__c = userLoggingLevelOrdinal);
         insert log;
         log = [SELECT Id, LogRetentionDate__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(originalLogRetentionDate, log.LogRetentionDate__c);
+        System.Assert.areEqual(originalLogRetentionDate, log.LogRetentionDate__c);
         LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, LoggingLevel__c = LoggingLevel.ERROR.name(), TransactionEntryNumber__c = 1);
         insert logEntry;
 
         log = [SELECT Id, LogRetentionDate__c, Scenario__c, TotalERRORLogEntries__c FROM Log__c WHERE Id = :log.Id];
-        System.assertEquals(expectedLogRetentionDate, log.LogRetentionDate__c, log);
+        System.Assert.areEqual(expectedLogRetentionDate, log.LogRetentionDate__c, JSON.serializePretty(log));
     }
 
     static void enablePlugin() {

--- a/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin.cls
+++ b/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin.cls
@@ -12,7 +12,9 @@ public without sharing class SlackLoggerPlugin implements LoggerPlugin.Triggerab
     @TestVisible
     private static final String ENDPOINT = LoggerParameter.getString('SlackEndpoint', null);
     @TestVisible
-    private static final LoggingLevel NOTIFICATION_LOGGING_LEVEL = Logger.getLoggingLevel(LoggerParameter.getString('SlackNotificationLoggingLevel', null));
+    private static final System.LoggingLevel NOTIFICATION_LOGGING_LEVEL = Logger.getLoggingLevel(
+        LoggerParameter.getString('SlackNotificationLoggingLevel', null)
+    );
 
     private List<Log__c> logs;
 

--- a/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin.cls
+++ b/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin.cls
@@ -73,7 +73,7 @@ public without sharing class SlackLoggerPlugin implements LoggerPlugin.Triggerab
                 // add them to the unsentLogs list, which will be queued as a separate job
                 unsentLogs.add(log);
             } else {
-                HttpRequest request = this.createSlackHttpRequest();
+                System.HttpRequest request = this.createSlackHttpRequest();
 
                 NotificationDto notification = new NotificationDto();
                 notification.text = 'Salesforce Log Alert';
@@ -86,7 +86,7 @@ public without sharing class SlackLoggerPlugin implements LoggerPlugin.Triggerab
                     Logger.finest('Sending log entries to Slack endpoint').setHttpRequestDetails(request);
                 }
 
-                HttpResponse response = new Http().send(request);
+                System.HttpResponse response = new System.Http().send(request);
                 if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
                     Logger.finest('Sent log entries to Slack endpoint').setHttpResponseDetails(response);
                 }
@@ -173,8 +173,8 @@ public without sharing class SlackLoggerPlugin implements LoggerPlugin.Triggerab
         ];
     }
 
-    private HttpRequest createSlackHttpRequest() {
-        HttpRequest request = new HttpRequest();
+    private System.HttpRequest createSlackHttpRequest() {
+        System.HttpRequest request = new System.HttpRequest();
         request.setEndpoint(ENDPOINT);
         request.setMethod('POST');
         request.setHeader('Content-Type', 'application/json');

--- a/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin_Tests.cls
+++ b/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin_Tests.cls
@@ -23,19 +23,22 @@ private class SlackLoggerPlugin_Tests {
         insert logEntry;
         verifyLogEntryCountEquals(1);
         List<Log__c> logs = queryLogs(logEntryLoggingLevel);
-        System.assertEquals(1, logs.size(), 'Logs size did not match expected value of 1.');
+        System.Assert.areEqual(1, logs.size(), 'Logs size did not match expected value of 1.');
         log = logs.get(0);
-        System.assertEquals(1, log.LogEntries__r.size(), 'Log entries size was not equal to 1.');
-        System.assertEquals(false, log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to true.');
-        System.assertEquals(null, log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
+        System.Assert.areEqual(1, log.LogEntries__r.size(), 'Log entries size was not equal to 1.');
+        System.Assert.isFalse(log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to true.');
+        System.Assert.isNull(log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
         System.Test.startTest();
         LoggerMockDataCreator.MockHttpCallout calloutMock = LoggerMockDataCreator.createHttpCallout().setStatusCode(200);
         System.Test.setMock(HttpCalloutMock.class, calloutMock);
         // Load the mock configurations - the plugin framework won't load actual CMDT records during tests
         LoggingLevel slackLoggingLevel = LoggingLevel.ERROR;
-        System.assert(logEntryLoggingLevel.ordinal() < slackLoggingLevel.ordinal(), 'Slack logging level ordinal was incorrect.');
+        System.Assert.isTrue(logEntryLoggingLevel.ordinal() < slackLoggingLevel.ordinal(), 'Slack logging level ordinal was incorrect.');
         mockConfigurations(slackLoggingLevel);
-        System.assert(logEntryLoggingLevel.ordinal() < SlackLoggerPlugin.NOTIFICATION_LOGGING_LEVEL.ordinal(), 'Slack logging level ordinal was incorrect.');
+        System.Assert.isTrue(
+            logEntryLoggingLevel.ordinal() < SlackLoggerPlugin.NOTIFICATION_LOGGING_LEVEL.ordinal(),
+            'Slack logging level ordinal was incorrect.'
+        );
         LoggerSObjectHandler.shouldExecute(true);
         LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
 
@@ -43,13 +46,13 @@ private class SlackLoggerPlugin_Tests {
         update log;
 
         // Verify that the internal queueable job has been enqueued
-        System.assertEquals(0, System.Limits.getAsyncCalls(), 'The queueable job should not have been enqueued');
+        System.Assert.areEqual(0, System.Limits.getAsyncCalls(), 'The queueable job should not have been enqueued');
         // Stop the test so the internal queueable job runs
         System.Test.stopTest();
         log = queryLogs(logEntryLoggingLevel).get(0);
-        System.assertEquals(1, log.LogEntries__r.size(), 'Log entries size was not equal to 1.');
-        System.assertEquals(false, log.SendSlackNotification__c, 'SendSlackNotification incorrectly set to true.');
-        System.assertEquals(null, log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
+        System.Assert.areEqual(1, log.LogEntries__r.size(), 'Log entries size was not equal to 1.');
+        System.Assert.isFalse(log.SendSlackNotification__c, 'SendSlackNotification incorrectly set to true.');
+        System.Assert.isNull(log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
     }
 
     @IsTest
@@ -70,17 +73,17 @@ private class SlackLoggerPlugin_Tests {
         insert logEntry;
         verifyLogEntryCountEquals(1);
         List<Log__c> logs = queryLogs(logEntryLoggingLevel);
-        System.assertEquals(1, logs.size(), 'Logs size did not match expected value of 1.');
+        System.Assert.areEqual(1, logs.size(), 'Logs size did not match expected value of 1.');
         log = logs.get(0);
-        System.assertEquals(1, log.LogEntries__r.size(), 'Log entries did not match the expected count of 1.');
-        System.assertEquals(false, log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to true.');
-        System.assertEquals(null, log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
+        System.Assert.areEqual(1, log.LogEntries__r.size(), 'Log entries did not match the expected count of 1.');
+        System.Assert.isFalse(log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to true.');
+        System.Assert.isNull(log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
         System.Test.startTest();
         LoggerMockDataCreator.MockHttpCallout calloutMock = LoggerMockDataCreator.createHttpCallout().setStatusCode(200);
         System.Test.setMock(HttpCalloutMock.class, calloutMock);
         // Load the mock configurations - the plugin framework won't load actual CMDT records during tests
         mockConfigurations(logEntryLoggingLevel);
-        System.assert(
+        System.Assert.isTrue(
             logEntryLoggingLevel.ordinal() >= SlackLoggerPlugin.NOTIFICATION_LOGGING_LEVEL.ordinal(),
             'The notification logging level ordinal was incorrect.'
         );
@@ -91,13 +94,13 @@ private class SlackLoggerPlugin_Tests {
         update log;
 
         // Verify that the internal queueable job has been enqueued
-        System.assertEquals(1, System.Limits.getAsyncCalls(), 'The queueable job should have been enqueued');
+        System.Assert.areEqual(1, System.Limits.getAsyncCalls(), 'The queueable job should have been enqueued');
         // Stop the test so the internal queueable job runs
         System.Test.stopTest();
         log = [SELECT Id, MaxLogEntryLoggingLevelOrdinal__c, SendSlackNotification__c, SlackNotificationDate__c FROM Log__c];
-        System.assertEquals(true, log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to false.');
-        System.assertNotEquals(null, log.SlackNotificationDate__c, 'SlackNotificationDate was null.');
-        System.assertEquals(System.today(), log.SlackNotificationDate__c.date(), 'SlackNotificationDate was not set to TODAY.');
+        System.Assert.isTrue(log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to false.');
+        System.Assert.isNotNull(log.SlackNotificationDate__c, 'SlackNotificationDate was null.');
+        System.Assert.areEqual(System.today(), log.SlackNotificationDate__c.date(), 'SlackNotificationDate was not set to TODAY.');
     }
 
     @IsTest
@@ -118,17 +121,17 @@ private class SlackLoggerPlugin_Tests {
         insert logEntry;
         verifyLogEntryCountEquals(1);
         List<Log__c> logs = queryLogs(logEntryLoggingLevel);
-        System.assertEquals(1, logs.size(), 'Logs size did not match expected value of 1.');
+        System.Assert.areEqual(1, logs.size(), 'Logs size did not match expected value of 1.');
         log = logs.get(0);
-        System.assertEquals(1, log.LogEntries__r.size(), 'Log entries did not match the expected count of 1.');
-        System.assertEquals(false, log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to true.');
-        System.assertEquals(null, log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
+        System.Assert.areEqual(1, log.LogEntries__r.size(), 'Log entries did not match the expected count of 1.');
+        System.Assert.isFalse(log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to true.');
+        System.Assert.isNull(log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
         System.Test.startTest();
         LoggerMockDataCreator.MockHttpCallout calloutMock = LoggerMockDataCreator.createHttpCallout().setStatusCode(200);
         System.Test.setMock(HttpCalloutMock.class, calloutMock);
         // Load the mock configurations - the plugin framework won't load actual CMDT records during tests
         mockConfigurations(logEntryLoggingLevel);
-        System.assert(
+        System.Assert.isTrue(
             logEntryLoggingLevel.ordinal() >= SlackLoggerPlugin.NOTIFICATION_LOGGING_LEVEL.ordinal(),
             'The notification logging level ordinal was incorrect.'
         );
@@ -139,13 +142,13 @@ private class SlackLoggerPlugin_Tests {
         update log;
 
         // Verify that the internal queueable job has been enqueued
-        System.assertEquals(1, System.Limits.getAsyncCalls(), 'The queueable job should have been enqueued');
+        System.Assert.areEqual(1, System.Limits.getAsyncCalls(), 'The queueable job should have been enqueued');
         // Stop the test so the internal queueable job runs
         System.Test.stopTest();
         log = [SELECT Id, MaxLogEntryLoggingLevelOrdinal__c, SendSlackNotification__c, SlackNotificationDate__c FROM Log__c];
-        System.assertEquals(true, log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to false.');
-        System.assertNotEquals(null, log.SlackNotificationDate__c, 'SlackNotificationDate was null.');
-        System.assertEquals(System.today(), log.SlackNotificationDate__c.date(), 'SlackNotificationDate was not set to TODAY.');
+        System.Assert.isTrue(log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to false.');
+        System.Assert.isNotNull(log.SlackNotificationDate__c, 'SlackNotificationDate was null.');
+        System.Assert.areEqual(System.today(), log.SlackNotificationDate__c.date(), 'SlackNotificationDate was not set to TODAY.');
     }
 
     @IsTest
@@ -166,17 +169,17 @@ private class SlackLoggerPlugin_Tests {
         insert logEntry;
         verifyLogEntryCountEquals(1);
         List<Log__c> logs = queryLogs(logEntryLoggingLevel);
-        System.assertEquals(1, logs.size(), 'Logs size did not match expected value of 1.');
+        System.Assert.areEqual(1, logs.size(), 'Logs size did not match expected value of 1.');
         log = logs.get(0);
-        System.assertEquals(1, log.LogEntries__r.size(), 'Log entries did not match the expected count of 1.');
-        System.assertEquals(false, log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to true.');
-        System.assertEquals(null, log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
+        System.Assert.areEqual(1, log.LogEntries__r.size(), 'Log entries did not match the expected count of 1.');
+        System.Assert.isFalse(log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to true.');
+        System.Assert.isNull(log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
         System.Test.startTest();
         LoggerMockDataCreator.MockHttpCallout calloutMock = LoggerMockDataCreator.createHttpCallout().setStatusCode(200);
         System.Test.setMock(HttpCalloutMock.class, calloutMock);
         // Load the mock configurations - the plugin framework won't load actual CMDT records during tests
         mockConfigurations(logEntryLoggingLevel);
-        System.assert(
+        System.Assert.isTrue(
             logEntryLoggingLevel.ordinal() >= SlackLoggerPlugin.NOTIFICATION_LOGGING_LEVEL.ordinal(),
             'The notification logging level ordinal was incorrect.'
         );
@@ -187,13 +190,13 @@ private class SlackLoggerPlugin_Tests {
         update log;
 
         // Verify that the internal queueable job has been enqueued
-        System.assertEquals(1, System.Limits.getAsyncCalls(), 'The queueable job should have been enqueued');
+        System.Assert.areEqual(1, System.Limits.getAsyncCalls(), 'The queueable job should have been enqueued');
         // Stop the test so the internal queueable job runs
         System.Test.stopTest();
         log = [SELECT Id, MaxLogEntryLoggingLevelOrdinal__c, SendSlackNotification__c, SlackNotificationDate__c FROM Log__c];
-        System.assertEquals(true, log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to false.');
-        System.assertNotEquals(null, log.SlackNotificationDate__c, 'SlackNotificationDate was null.');
-        System.assertEquals(System.today(), log.SlackNotificationDate__c.date(), 'SlackNotificationDate was not set to TODAY.');
+        System.Assert.isTrue(log.SendSlackNotification__c, 'SendSlackNotification was incorrectly set to false.');
+        System.Assert.isNotNull(log.SlackNotificationDate__c, 'SlackNotificationDate was null.');
+        System.Assert.areEqual(System.today(), log.SlackNotificationDate__c.date(), 'SlackNotificationDate was not set to TODAY.');
     }
 
     static void mockConfigurations(LoggingLevel notificationLoggingLevel) {
@@ -206,7 +209,7 @@ private class SlackLoggerPlugin_Tests {
 
     static void verifyLogEntryCountEquals(Integer expectedCount) {
         Integer existingLogEntriesCount = [SELECT COUNT() FROM LogEntry__c];
-        System.assertEquals(expectedCount, existingLogEntriesCount, 'Existing log entries did NOT match the expected count.');
+        System.Assert.areEqual(expectedCount, existingLogEntriesCount, 'Existing log entries did NOT match the expected count.');
     }
 
     static List<Log__c> queryLogs(LoggingLevel notificationLoggingLevel) {

--- a/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin_Tests.cls
+++ b/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin_Tests.cls
@@ -11,7 +11,7 @@ private class SlackLoggerPlugin_Tests {
         verifyLogEntryCountEquals(0);
         Log__c log = new Log__c(LoggedBy__c = System.UserInfo.getUserId(), SendSlackNotification__c = false, TransactionId__c = '1234');
         insert log;
-        LoggingLevel logEntryLoggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLoggingLevel = System.LoggingLevel.WARN;
         LogEntry__c logEntry = new LogEntry__c(
             ExceptionStackTrace__c = 'Some exception stack trace',
             Log__c = log.Id,
@@ -32,7 +32,7 @@ private class SlackLoggerPlugin_Tests {
         LoggerMockDataCreator.MockHttpCallout calloutMock = LoggerMockDataCreator.createHttpCallout().setStatusCode(200);
         System.Test.setMock(HttpCalloutMock.class, calloutMock);
         // Load the mock configurations - the plugin framework won't load actual CMDT records during tests
-        LoggingLevel slackLoggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel slackLoggingLevel = System.LoggingLevel.ERROR;
         System.Assert.isTrue(logEntryLoggingLevel.ordinal() < slackLoggingLevel.ordinal(), 'Slack logging level ordinal was incorrect.');
         mockConfigurations(slackLoggingLevel);
         System.Assert.isTrue(
@@ -61,7 +61,7 @@ private class SlackLoggerPlugin_Tests {
         LoggerSObjectHandler.shouldExecute(false);
         Log__c log = new Log__c(LoggedBy__c = System.UserInfo.getUserId(), SendSlackNotification__c = false, TransactionId__c = '1234');
         insert log;
-        LoggingLevel logEntryLoggingLevel = LoggingLevel.ERROR;
+        System.LoggingLevel logEntryLoggingLevel = System.LoggingLevel.ERROR;
         LogEntry__c logEntry = new LogEntry__c(
             ExceptionStackTrace__c = 'Some exception stack trace',
             Log__c = log.Id,
@@ -109,7 +109,7 @@ private class SlackLoggerPlugin_Tests {
         LoggerSObjectHandler.shouldExecute(false);
         Log__c log = new Log__c(LoggedBy__c = System.UserInfo.getUserId(), SendSlackNotification__c = false, TransactionId__c = '1234');
         insert log;
-        LoggingLevel logEntryLoggingLevel = LoggingLevel.WARN;
+        System.LoggingLevel logEntryLoggingLevel = System.LoggingLevel.WARN;
         LogEntry__c logEntry = new LogEntry__c(
             ExceptionStackTrace__c = 'Some exception stack trace',
             Log__c = log.Id,
@@ -157,7 +157,7 @@ private class SlackLoggerPlugin_Tests {
         LoggerSObjectHandler.shouldExecute(false);
         Log__c log = new Log__c(LoggedBy__c = System.UserInfo.getUserId(), SendSlackNotification__c = false, TransactionId__c = '1234');
         insert log;
-        LoggingLevel logEntryLoggingLevel = LoggingLevel.INFO;
+        System.LoggingLevel logEntryLoggingLevel = System.LoggingLevel.INFO;
         LogEntry__c logEntry = new LogEntry__c(
             ExceptionStackTrace__c = 'Some exception stack trace',
             Log__c = log.Id,
@@ -199,7 +199,7 @@ private class SlackLoggerPlugin_Tests {
         System.Assert.areEqual(System.today(), log.SlackNotificationDate__c.date(), 'SlackNotificationDate was not set to TODAY.');
     }
 
-    static void mockConfigurations(LoggingLevel notificationLoggingLevel) {
+    static void mockConfigurations(System.LoggingLevel notificationLoggingLevel) {
         LoggerTestConfigurator.setMock(
             new LoggerPlugin__mdt(DeveloperName = 'SlackPlugin', IsEnabled__c = true, SObjectHandlerApexClass__c = SlackLoggerPlugin.class.getName())
         );
@@ -212,7 +212,7 @@ private class SlackLoggerPlugin_Tests {
         System.Assert.areEqual(expectedCount, existingLogEntriesCount, 'Existing log entries did NOT match the expected count.');
     }
 
-    static List<Log__c> queryLogs(LoggingLevel notificationLoggingLevel) {
+    static List<Log__c> queryLogs(System.LoggingLevel notificationLoggingLevel) {
         return [
             SELECT
                 Id,

--- a/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin_Tests.cls
+++ b/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin_Tests.cls
@@ -9,7 +9,7 @@ private class SlackLoggerPlugin_Tests {
     @IsTest
     static void it_should_not_push_log_when_logging_level_is_not_met() {
         verifyLogEntryCountEquals(0);
-        Log__c log = new Log__c(LoggedBy__c = UserInfo.getUserId(), SendSlackNotification__c = false, TransactionId__c = '1234');
+        Log__c log = new Log__c(LoggedBy__c = System.UserInfo.getUserId(), SendSlackNotification__c = false, TransactionId__c = '1234');
         insert log;
         LoggingLevel logEntryLoggingLevel = LoggingLevel.WARN;
         LogEntry__c logEntry = new LogEntry__c(
@@ -59,7 +59,7 @@ private class SlackLoggerPlugin_Tests {
     static void it_should_push_log_when_logging_level_is_met_for_error() {
         verifyLogEntryCountEquals(0);
         LoggerSObjectHandler.shouldExecute(false);
-        Log__c log = new Log__c(LoggedBy__c = UserInfo.getUserId(), SendSlackNotification__c = false, TransactionId__c = '1234');
+        Log__c log = new Log__c(LoggedBy__c = System.UserInfo.getUserId(), SendSlackNotification__c = false, TransactionId__c = '1234');
         insert log;
         LoggingLevel logEntryLoggingLevel = LoggingLevel.ERROR;
         LogEntry__c logEntry = new LogEntry__c(
@@ -107,7 +107,7 @@ private class SlackLoggerPlugin_Tests {
     static void it_should_push_log_when_logging_level_is_met_for_warn() {
         verifyLogEntryCountEquals(0);
         LoggerSObjectHandler.shouldExecute(false);
-        Log__c log = new Log__c(LoggedBy__c = UserInfo.getUserId(), SendSlackNotification__c = false, TransactionId__c = '1234');
+        Log__c log = new Log__c(LoggedBy__c = System.UserInfo.getUserId(), SendSlackNotification__c = false, TransactionId__c = '1234');
         insert log;
         LoggingLevel logEntryLoggingLevel = LoggingLevel.WARN;
         LogEntry__c logEntry = new LogEntry__c(
@@ -155,7 +155,7 @@ private class SlackLoggerPlugin_Tests {
     static void it_should_push_log_when_logging_level_is_met_for_info() {
         verifyLogEntryCountEquals(0);
         LoggerSObjectHandler.shouldExecute(false);
-        Log__c log = new Log__c(LoggedBy__c = UserInfo.getUserId(), SendSlackNotification__c = false, TransactionId__c = '1234');
+        Log__c log = new Log__c(LoggedBy__c = System.UserInfo.getUserId(), SendSlackNotification__c = false, TransactionId__c = '1234');
         insert log;
         LoggingLevel logEntryLoggingLevel = LoggingLevel.INFO;
         LogEntry__c logEntry = new LogEntry__c(

--- a/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin_Tests.cls
+++ b/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin_Tests.cls
@@ -30,7 +30,7 @@ private class SlackLoggerPlugin_Tests {
         System.Assert.isNull(log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
         System.Test.startTest();
         LoggerMockDataCreator.MockHttpCallout calloutMock = LoggerMockDataCreator.createHttpCallout().setStatusCode(200);
-        System.Test.setMock(HttpCalloutMock.class, calloutMock);
+        System.Test.setMock(System.HttpCalloutMock.class, calloutMock);
         // Load the mock configurations - the plugin framework won't load actual CMDT records during tests
         System.LoggingLevel slackLoggingLevel = System.LoggingLevel.ERROR;
         System.Assert.isTrue(logEntryLoggingLevel.ordinal() < slackLoggingLevel.ordinal(), 'Slack logging level ordinal was incorrect.');
@@ -80,7 +80,7 @@ private class SlackLoggerPlugin_Tests {
         System.Assert.isNull(log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
         System.Test.startTest();
         LoggerMockDataCreator.MockHttpCallout calloutMock = LoggerMockDataCreator.createHttpCallout().setStatusCode(200);
-        System.Test.setMock(HttpCalloutMock.class, calloutMock);
+        System.Test.setMock(System.HttpCalloutMock.class, calloutMock);
         // Load the mock configurations - the plugin framework won't load actual CMDT records during tests
         mockConfigurations(logEntryLoggingLevel);
         System.Assert.isTrue(
@@ -128,7 +128,7 @@ private class SlackLoggerPlugin_Tests {
         System.Assert.isNull(log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
         System.Test.startTest();
         LoggerMockDataCreator.MockHttpCallout calloutMock = LoggerMockDataCreator.createHttpCallout().setStatusCode(200);
-        System.Test.setMock(HttpCalloutMock.class, calloutMock);
+        System.Test.setMock(System.HttpCalloutMock.class, calloutMock);
         // Load the mock configurations - the plugin framework won't load actual CMDT records during tests
         mockConfigurations(logEntryLoggingLevel);
         System.Assert.isTrue(
@@ -176,7 +176,7 @@ private class SlackLoggerPlugin_Tests {
         System.Assert.isNull(log.SlackNotificationDate__c, 'SlackNotificationDate was not null.');
         System.Test.startTest();
         LoggerMockDataCreator.MockHttpCallout calloutMock = LoggerMockDataCreator.createHttpCallout().setStatusCode(200);
-        System.Test.setMock(HttpCalloutMock.class, calloutMock);
+        System.Test.setMock(System.HttpCalloutMock.class, calloutMock);
         // Load the mock configurations - the plugin framework won't load actual CMDT records during tests
         mockConfigurations(logEntryLoggingLevel);
         System.Assert.isTrue(

--- a/nebula-logger/recipes/classes/LoggerLWCDemoController.cls
+++ b/nebula-logger/recipes/classes/LoggerLWCDemoController.cls
@@ -2,6 +2,6 @@
 public with sharing class LoggerLWCDemoController {
     @AuraEnabled
     public static void throwSomeError() {
-        throw new DmlException('Some Error!!');
+        throw new System.DmlException('Some Error!!');
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.9.3",
+    "version": "4.9.4",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -147,6 +147,7 @@
         "Nebula Logger - Core@4.9.1-track-impersonating-user": "04t5Y0000023R79QAE",
         "Nebula Logger - Core@4.9.2-enhancements-for-log-entry-event-stream-lwc": "04t5Y0000023R7iQAE",
         "Nebula Logger - Core@4.9.3-new-indicator-icons": "04t5Y0000023R7sQAE",
+        "Nebula Logger - Core@4.9.4-new-indicator-icons": "04t5Y0000023R8WQAU",
         "Nebula Logger - Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -14,7 +14,7 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.9.3.NEXT",
+            "versionNumber": "4.9.4.NEXT",
             "versionName": "New Indicator Icons",
             "versionDescription": "Updated formula fields on LogEntry__c to replace old flag icons with emojis that are more visually distinct from one another, updated format of LogEntry__c limits formula fields to display percentage first (after new indicators) with limit used & max fields displayed in parenthesis",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",


### PR DESCRIPTION
This PR doesn't have any functional changes (hopefully 😅 ) - this is to cover some tech-debt & cleanup in several classes, so it seemed cleaner to do this as a dedicated PR/release

- Migrated all asserts to use the new class `System.Assert`
- Added the `System` namespace to all of the following references 
  - Classes
    - `Exception`, `AuraHandledException`, `CalloutException`, and `IllegalArgumentException`
    - `Http`, `HttpRequest`, and `HttpResponse`
    - `SObjectAccessDecision` 
    - `UserInfo`
  - Enums 
    - `AccessType`
    - `LoggingLevel`