### PR TITLE
Added a custom index for LogEntry__c.OriginLocation__c

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.10.5
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SC7QAM)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SC7QAM)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SCHQA2)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SCHQA2)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sfdx package install --wait 20 --security-type AdminsOnly --package 04t5Y0000023SC7QAM`
+`sfdx package install --wait 20 --security-type AdminsOnly --package 04t5Y0000023SCHQA2`
 
 ## Managed Package - v4.10.0
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.10.4
+## Unlocked Package - v4.10.5
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SC7QAM)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SC7QAM)

--- a/nebula-logger/core/main/log-management/customindex/LogEntry__c.OriginLocation__c.indx-meta.xml
+++ b/nebula-logger/core/main/log-management/customindex/LogEntry__c.OriginLocation__c.indx-meta.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomIndex xmlns="http://soap.sforce.com/2006/04/metadata">
+    <allowNullValues>true</allowNullValues>
+</CustomIndex>

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.10.4';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.10.5';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final Set<String> IGNORED_APEX_CLASSES = initializeIgnoredApexClasses();
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
@@ -6,7 +6,7 @@
 import { LightningElement, api } from 'lwc';
 import { createLoggerService } from './loggerService';
 
-const CURRENT_VERSION_NUMBER = 'v4.10.4';
+const CURRENT_VERSION_NUMBER = 'v4.10.5';
 
 export default class Logger extends LightningElement {
     #loggerService = createLoggerService();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.10.4",
+    "version": "4.10.5",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -145,6 +145,7 @@
         "Nebula Logger - Core@4.10.2-logger-lwc-enhancements": "04t5Y0000023SAGQA2",
         "Nebula Logger - Core@4.10.3-logger-settings-start-and-end-times": "04t5Y0000023SAfQAM",
         "Nebula Logger - Core@4.10.4-new-logger-home-page": "04t5Y0000023SC7QAM",
+        "Nebula Logger - Core@4.10.5-new-custom-index-for-origin-location-field": "04t5Y0000023SCHQA2",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -13,9 +13,9 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.10.4.NEXT",
-            "versionName": "New Logger Home Page",
-            "versionDescription": "Added a new home page to the Logger Console app, deprecated some existing custom tabs",
+            "versionNumber": "4.10.5.NEXT",
+            "versionName": "New Custom Index for Origin Location Field",
+            "versionDescription": "Added a custom index on the field LogEntry__c.OriginLocation__c (using the new CustomIndex metadatatype) to improve queries & reports that filter on this field",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"


### PR DESCRIPTION
Fixes #400 by adding a custom index for the field `LogEntry__c.OriginLocation__c`, using the new `CustomIndex` metadatatype. This should help to improve queries & reports that filter on this field.