### PR TITLE
Configurable Platform Cache partition name

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -7,6 +7,7 @@ coverage:
                 if_ci_failed: success
         patch: off
 ignore:
+    - 'config/experience-cloud/**/*'
     - 'nebula-logger/recipes/**/*'
 comment:
     behavior: new

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.9.5
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R8WQAU)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R8WQAU)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9KQAU)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9KQAU)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
 ## Managed Package - v4.9.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.9.4
+## Unlocked Package - v4.9.5
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R8WQAU)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R8WQAU)

--- a/docs/apex/Configuration/LoggerParameter.md
+++ b/docs/apex/Configuration/LoggerParameter.md
@@ -26,6 +26,10 @@ Indicates if Nebula Logger will append its own log entries about the logging sys
 
 Indicates if Nebula Logger&apos;s tagging system is enabled. Controlled by the custom metadata record `LoggerParameter.EnableTagging`, or `true` as the default
 
+#### `PLATFORM_CACHE_PARTITION_NAME` → `String`
+
+The name of the Platform Cache partition to use for caching (when platform cache is enabled). Controlled by the custom metadata record `LoggerParameter.PlatformCachePartitionName`, or `LoggerCache` as the default
+
 #### `QUERY_APEX_CLASS_DATA` → `Boolean`
 
 Controls if Nebula Logger queries `ApexClass` data. When set to `false`, any `ApexClass` fields on `LogEntryEvent__e` and `Log__c` will not be populated Controlled by the custom metadata record `LoggerParameter.QueryApexClassData`, or `true` as the default

--- a/nebula-logger/core/main/configuration/classes/LoggerCache.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerCache.cls
@@ -9,6 +9,7 @@
  */
 @SuppressWarnings('PMD.ExcessivePublicCount')
 public without sharing class LoggerCache {
+    private static final String DEFAULT_PARTITION_NAME = 'LoggerCache';
     private static final Boolean PLATFORM_CACHE_IS_IMMUTABLE = false;
     @TestVisible
     private static final String PLATFORM_CACHE_NULL_VALUE = '<{(CACHE_VALUE_IS_NULL)}>'; // Presumably, no one will ever use this as an actual value
@@ -104,8 +105,15 @@ public without sharing class LoggerCache {
     }
 
     private static String getQualifiedParitionName(String unqualifiedPartitionName) {
-        String className = LoggerCache.class.getName();
-        String namespacePrefix = unqualifiedPartitionName == 'LoggerCache' && className.contains('.') ? className.substringBefore('.') + '.' : '';
+        // Since Nebula Logger includes a cache partition (LoggerCache), the included partition's name
+        // needs to be qualified in order to work in the managed package. If a custom partition is being
+        // used instead, then just use the partition name as-is - no namespace is added.
+        if (unqualifiedPartitionName != DEFAULT_PARTITION_NAME) {
+            return unqualifiedPartitionName;
+        }
+
+        String qualifiedClassName = LoggerCache.class.getName();
+        String namespacePrefix = qualifiedClassName.contains('.') ? qualifiedClassName.substringBefore('.') + '.' : '';
         return namespacePrefix + unqualifiedPartitionName;
     }
 

--- a/nebula-logger/core/main/configuration/classes/LoggerCache.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerCache.cls
@@ -123,19 +123,29 @@ public without sharing class LoggerCache {
      * @description Manages interacting with platform cache partitions, and can be mocked during unit tests
      *              so that tests don't have to rely on the actual platform cache partitions configured in the org.
      */
-    @SuppressWarnings('PMD.ApexDoc')
+    @SuppressWarnings('PMD.ApexDoc, PMD.EmptyCatchBlock')
     @TestVisible
     private virtual class PlatformCachePartitionDelegate {
         private final Cache.Partition platformCachePartition;
 
         protected PlatformCachePartitionDelegate(PlatformCachePartitionType partitionType, String partitionName) {
-            switch on partitionType {
-                when ORGANIZATION {
-                    this.platformCachePartition = Cache.Org.getPartition(partitionName);
+            // Since orgs can customize the platform cache partition (via LoggerParameter__mdt.PlatformCachePartitionName),
+            // some orgs could have problematic configurations (or may have even deleted the included LoggerCache partition),
+            // and it seems better to eat the exceptions & fallback to the transaction cache (which doesn't rely on Platform Cache).
+            // The alternative is a runtime exception, which isn't ideal.
+            try {
+                switch on partitionType {
+                    when ORGANIZATION {
+                        this.platformCachePartition = Cache.Org.getPartition(partitionName);
+                    }
+                    when SESSION {
+                        this.platformCachePartition = Cache.Session.getPartition(partitionName);
+                    }
                 }
-                when SESSION {
-                    this.platformCachePartition = Cache.Session.getPartition(partitionName);
-                }
+            } catch (Cache.Org.OrgCacheException orgCacheException) {
+                // No-op if the partition can't be found - the rest of the code will fallback to using the transaction cache
+            } catch (Cache.Session.SessionCacheException sessionCacheException) {
+                // No-op if the partition can't be found - the rest of the code will fallback to using the transaction cache
             }
         }
 

--- a/nebula-logger/core/main/configuration/classes/LoggerCache.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerCache.cls
@@ -13,18 +13,26 @@ public without sharing class LoggerCache {
     @TestVisible
     private static final String PLATFORM_CACHE_NULL_VALUE = '<{(CACHE_VALUE_IS_NULL)}>'; // Presumably, no one will ever use this as an actual value
     @TestVisible
-    private static final String PLATFORM_CACHE_PARTITION_NAME = getQualifiedParitionName('LoggerCache');
+    private static final String PLATFORM_CACHE_PARTITION_NAME = getQualifiedParitionName(LoggerParameter.PLATFORM_CACHE_PARTITION_NAME);
     private static final Cache.Visibility PLATFORM_CACHE_VISIBILITY = Cache.Visibility.NAMESPACE;
     private static final TransactionCache TRANSACTION_CACHE_INSTANCE = new TransactionCache();
 
     private static PlatformCachePartitionDelegate organizationPartitionDelegate = new PlatformCachePartitionDelegate(
-        Cache.Org.getPartition(PLATFORM_CACHE_PARTITION_NAME)
+        PlatformCachePartitionType.ORGANIZATION,
+        PLATFORM_CACHE_PARTITION_NAME
     );
     private static PlatformCachePartitionDelegate sessionPartitionDelegate = new PlatformCachePartitionDelegate(
-        Cache.Session.getPartition(PLATFORM_CACHE_PARTITION_NAME)
+        PlatformCachePartitionType.SESSION,
+        PLATFORM_CACHE_PARTITION_NAME
     );
     private static PlatformCache organizationCacheInstance;
     private static PlatformCache sessionCacheInstance;
+
+    @TestVisible
+    private enum PlatformCachePartitionType {
+        ORGANIZATION,
+        SESSION
+    }
 
     /**
      * @description Interface used to define caches that can be used to store values via different mechanisms
@@ -97,7 +105,7 @@ public without sharing class LoggerCache {
 
     private static String getQualifiedParitionName(String unqualifiedPartitionName) {
         String className = LoggerCache.class.getName();
-        String namespacePrefix = className.contains('.') ? className.substringBefore('.') + '.' : '';
+        String namespacePrefix = unqualifiedPartitionName == 'LoggerCache' && className.contains('.') ? className.substringBefore('.') + '.' : '';
         return namespacePrefix + unqualifiedPartitionName;
     }
 
@@ -120,29 +128,36 @@ public without sharing class LoggerCache {
     private virtual class PlatformCachePartitionDelegate {
         private final Cache.Partition platformCachePartition;
 
-        protected PlatformCachePartitionDelegate(Cache.Partition platformCachePartition) {
-            this.platformCachePartition = platformCachePartition;
+        protected PlatformCachePartitionDelegate(PlatformCachePartitionType partitionType, String partitionName) {
+            switch on partitionType {
+                when ORGANIZATION {
+                    this.platformCachePartition = Cache.Org.getPartition(partitionName);
+                }
+                when SESSION {
+                    this.platformCachePartition = Cache.Session.getPartition(partitionName);
+                }
+            }
         }
 
         public virtual Boolean contains(String key) {
-            return this.platformCachePartition.contains(key);
+            return this.platformCachePartition != null && this.platformCachePartition.contains(key);
         }
 
         public virtual Object get(String key) {
-            return this.platformCachePartition.get(key);
+            return this.platformCachePartition?.get(key);
         }
 
         public virtual Boolean isAvailable() {
-            return this.platformCachePartition.isAvailable();
+            return this.platformCachePartition != null && this.platformCachePartition.isAvailable();
         }
 
         @SuppressWarnings('PMD.ExcessiveParameterList')
         public virtual void put(String key, Object value, Integer cacheTtlSeconds, Cache.Visibility cacheVisiblity, Boolean isCacheImmutable) {
-            this.platformCachePartition.put(key, value, cacheTtlSeconds, cacheVisiblity, isCacheImmutable);
+            this.platformCachePartition?.put(key, value, cacheTtlSeconds, cacheVisiblity, isCacheImmutable);
         }
 
         public virtual void remove(String key) {
-            this.platformCachePartition.remove(key);
+            this.platformCachePartition?.remove(key);
         }
     }
 
@@ -152,7 +167,6 @@ public without sharing class LoggerCache {
      */
     @SuppressWarnings('PMD.ApexDoc')
     private class PlatformCache implements Cacheable {
-        private final Cache.Partition cachePartition;
         private final PlatformCachePartitionDelegate cachePartitionDelegate;
         private final Integer cacheTtlSeconds;
         private final Cacheable transactionCache;

--- a/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
@@ -74,6 +74,20 @@ public class LoggerParameter {
     }
 
     /**
+     * @description The name of the Platform Cache partition to use for caching (when platform cache is enabled).
+     *              Controlled by the custom metadata record `LoggerParameter.PlatformCachePartitionName`, or `LoggerCache` as the default
+     */
+    public static final String PLATFORM_CACHE_PARTITION_NAME {
+        get {
+            if (PLATFORM_CACHE_PARTITION_NAME == null) {
+                PLATFORM_CACHE_PARTITION_NAME = getString('PlatformCachePartitionName', 'LoggerCache');
+            }
+            return PLATFORM_CACHE_PARTITION_NAME;
+        }
+        private set;
+    }
+
+    /**
      * @description Controls if Nebula Logger queries `ApexClass` data.
      *              When set to `false`, any `ApexClass` fields on `LogEntryEvent__e` and `Log__c` will not be populated
      *              Controlled by the custom metadata record `LoggerParameter.QueryApexClassData`, or `true` as the default

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.PlatformCachePartitionName.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.PlatformCachePartitionName.md-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomMetadata
+    xmlns="http://soap.sforce.com/2006/04/metadata"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+>
+    <label>Platform Cache Partition Name</label>
+    <protected>false</protected>
+    <values>
+        <field>Description__c</field>
+        <value xsi:type="xsd:string">Indicates the name of the Platform Cache partition to use for caching (when platform cache is enabled).
+
+By default, the included cache partition &apos;LoggerCache&apos; is used.</value>
+    </values>
+    <values>
+        <field>Value__c</field>
+        <value xsi:type="xsd:string">LoggerCache</value>
+    </values>
+</CustomMetadata>

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.9.4';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.9.5';
     private static final System.LoggingLevel DEFAULT_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final Set<String> IGNORED_APEX_CLASSES = initializeIgnoredApexClasses();
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();

--- a/nebula-logger/core/tests/configuration/classes/LoggerCache_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerCache_Tests.cls
@@ -369,7 +369,7 @@ private class LoggerCache_Tests {
         public Integer removeMethodCallCount = 0;
 
         private MockPlatformCachePartitionDelegate(Boolean isAvailable) {
-            super(null);
+            super(null, null);
             this.isAvailable = isAvailable;
         }
 

--- a/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
@@ -69,9 +69,9 @@ private class LoggerParameter_Tests {
     }
 
     @IsTest
-    static void it_should_return_constant_value_for_platform_cache_partition_Name() {
+    static void it_should_return_constant_value_for_platform_cache_partition_name() {
         String mockValue = 'SomeValue';
-        LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'PlatformCachePartitionName', Value__c = JSON.serialize(mockValue));
+        LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'PlatformCachePartitionName', Value__c = mockValue);
         LoggerParameter.setMock(mockParameter);
 
         String returnedValue = LoggerParameter.PLATFORM_CACHE_PARTITION_NAME;

--- a/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
@@ -69,6 +69,17 @@ private class LoggerParameter_Tests {
     }
 
     @IsTest
+    static void it_should_return_constant_value_for_platform_cache_partition_Name() {
+        String mockValue = 'SomeValue';
+        LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'PlatformCachePartitionName', Value__c = JSON.serialize(mockValue));
+        LoggerParameter.setMock(mockParameter);
+
+        String returnedValue = LoggerParameter.PLATFORM_CACHE_PARTITION_NAME;
+
+        System.Assert.areEqual(mockValue, returnedValue);
+    }
+
+    @IsTest
     static void it_should_return_constant_value_for_query_apex_class_data() {
         Boolean mockValue = false;
         LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'QueryApexClassData', Value__c = JSON.serialize(mockValue));

--- a/nebula-logger/extra-tests/tests/LoggerCache_Tests_PlatformCache.cls
+++ b/nebula-logger/extra-tests/tests/LoggerCache_Tests_PlatformCache.cls
@@ -14,6 +14,92 @@
 @IsTest(IsParallel=true)
 private class LoggerCache_Tests_PlatformCache {
     @IsTest
+    static void it_gracefully_handles_nonexistent_platform_cache_partition_name_for_organization_cache() {
+        LoggerParameter__mdt platformCachePartitionNameParameter = new LoggerParameter__mdt(
+            DeveloperName = 'PlatformCachePartitionName',
+            Value__c = 'SomeValueThatWillHopefullyAndProbablyNeverExistForAPlatformCachePartitionName'
+        );
+        LoggerParameter.setMock(platformCachePartitionNameParameter);
+
+        LoggerCache.Cacheable organizationCache = LoggerCache.getOrganizationCache();
+
+        // Run the different Cacheable methods to ensure everything works
+        String testKey = 'someKey';
+        Object testValue = System.now();
+        System.Assert.isNotNull(organizationCache);
+        System.Assert.isFalse(organizationCache.contains(testKey));
+        System.Assert.areEqual(
+            organizationCache.contains(testKey),
+            LoggerCache.getTransactionCache().contains(testKey),
+            'Organization and transaction cache should be in sync'
+        );
+        System.Assert.isNull(organizationCache.get(testKey));
+        System.Assert.areEqual(
+            organizationCache.get(testKey),
+            LoggerCache.getTransactionCache().get(testKey),
+            'Organization and transaction cache should be in sync'
+        );
+        organizationCache.remove(testKey);
+        organizationCache.put(testKey, testValue);
+        System.Assert.isTrue(organizationCache.contains(testKey));
+        System.Assert.areEqual(
+            organizationCache.contains(testKey),
+            LoggerCache.getTransactionCache().contains(testKey),
+            'Organization and transaction cache should be in sync'
+        );
+        System.Assert.areEqual(testValue, organizationCache.get(testKey));
+        System.Assert.areEqual(
+            organizationCache.get(testKey),
+            LoggerCache.getTransactionCache().get(testKey),
+            'Organization and transaction cache should be in sync'
+        );
+        organizationCache.remove(testKey);
+        System.Assert.isNull(organizationCache.get(testKey));
+        System.Assert.areEqual(
+            organizationCache.get(testKey),
+            LoggerCache.getTransactionCache().get(testKey),
+            'Organization and transaction cache should be in sync'
+        );
+    }
+
+    @IsTest
+    static void it_gracefully_handles_nonexistent_platform_cache_partition_name_for_session_cache() {
+        LoggerParameter__mdt platformCachePartitionNameParameter = new LoggerParameter__mdt(
+            DeveloperName = 'PlatformCachePartitionName',
+            Value__c = 'SomeValueThatWillHopefullyAndProbablyNeverExistForAPlatformCachePartitionName'
+        );
+        LoggerParameter.setMock(platformCachePartitionNameParameter);
+
+        LoggerCache.Cacheable sessionCache = LoggerCache.getSessionCache();
+
+        // Run the different Cacheable methods to ensure everything works
+        String testKey = 'someKey';
+        Object testValue = System.now();
+        System.Assert.isNotNull(sessionCache);
+        System.Assert.isFalse(sessionCache.contains(testKey));
+        System.Assert.areEqual(
+            sessionCache.contains(testKey),
+            LoggerCache.getTransactionCache().contains(testKey),
+            'Session and transaction cache should be in sync'
+        );
+        System.Assert.isNull(sessionCache.get(testKey));
+        System.Assert.areEqual(sessionCache.get(testKey), LoggerCache.getTransactionCache().get(testKey), 'Session and transaction cache should be in sync');
+        sessionCache.remove(testKey);
+        sessionCache.put(testKey, testValue);
+        System.Assert.isTrue(sessionCache.contains(testKey));
+        System.Assert.areEqual(
+            sessionCache.contains(testKey),
+            LoggerCache.getTransactionCache().contains(testKey),
+            'Session and transaction cache should be in sync'
+        );
+        System.Assert.areEqual(testValue, sessionCache.get(testKey));
+        System.Assert.areEqual(sessionCache.get(testKey), LoggerCache.getTransactionCache().get(testKey), 'Session and transaction cache should be in sync');
+        sessionCache.remove(testKey);
+        System.Assert.isNull(sessionCache.get(testKey));
+        System.Assert.areEqual(sessionCache.get(testKey), LoggerCache.getTransactionCache().get(testKey), 'Session and transaction cache should be in sync');
+    }
+
+    @IsTest
     static void it_adds_new_key_to_organization_and_transaction_cache() {
         String mockKey = 'SomeKey';
         User mockValue = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.9.4",
+    "version": "4.9.5",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -14,9 +14,9 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.9.4.NEXT",
-            "versionName": "New Indicator Icons",
-            "versionDescription": "Updated formula fields on LogEntry__c to replace old flag icons with emojis that are more visually distinct from one another, updated format of LogEntry__c limits formula fields to display percentage first (after new indicators) with limit used & max fields displayed in parenthesis",
+            "versionNumber": "4.9.5.NEXT",
+            "versionName": "Configurable Platform Cache Partition Name",
+            "versionDescription": "Added new CMDT record LoggerParameter.PlatformCachePartitionName to control which platform cache partition is used for caching",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -148,6 +148,7 @@
         "Nebula Logger - Core@4.9.2-enhancements-for-log-entry-event-stream-lwc": "04t5Y0000023R7iQAE",
         "Nebula Logger - Core@4.9.3-new-indicator-icons": "04t5Y0000023R7sQAE",
         "Nebula Logger - Core@4.9.4-new-indicator-icons": "04t5Y0000023R8WQAU",
+        "Nebula Logger - Core@4.9.5-configurable-platform-cache-partition-name": "04t5Y0000023R9KQAU",
         "Nebula Logger - Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
- Added new CMDT record `LoggerParameter.PlatformCachePartitionName` to control which platform cache partition is used for caching
  
  ![image](https://user-images.githubusercontent.com/1267157/204599735-d5522121-b5ec-46ee-b27e-42f838db5c84.png)

- Updated `LoggerCache` to gracefully handle a nonexistent Platform Cache partition - it internally falls back to using the transaction cache, which doesn't rely on Platform Cache. This is helpful in ensuring that Nebula Logger still works, even if the `LoggerParameter.PlatformCachePartitionName` record has been misconfigured and/or the corresponding platform cache partition cannot be found.
- Updated codecov.yml to ignore sample metadata used in the pipeline for creating an Experience Cloud site