### PR TITLE
Updated Logger.getUserSettings() to set defaults based on the environment type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,10 +175,10 @@ jobs:
             # Utlimately, this could/should probably be better mocked during tests, but the AuthSession is read-only in Apex, so it's a bit difficult to work with.
             # Running the Apex tests sync & async serves as an extra level of integration testing to ensure that everything works with or without an active session.
             - name: 'Run Apex Tests Asynchronously'
-              run: npm run test:apex
+              run: npm run test:apex:nocoverage
 
             - name: 'Run Apex Tests Synchronously'
-              run: npm run test:apex -- --synchronous
+              run: npm run test:apex:nocoverage -- --synchronous
 
             - name: 'Delete Base Scratch Org'
               run: npm run org:delete:noprompt
@@ -239,7 +239,7 @@ jobs:
             # Utlimately, this could/should probably be better mocked during tests, but the AuthSession is read-only in Apex, so it's a bit difficult to work with.
             # Running the Apex tests sync & async serves as an extra level of integration testing to ensure that everything works with or without an active session.
             - name: 'Run Apex Tests Asynchronously'
-              run: npm run test:apex
+              run: npm run test:apex:nocoverage
 
             - name: 'Run Apex Tests Synchronously'
               run: npm run test:apex -- --synchronous

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.9.6
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9KQAU)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9KQAU)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9eQAE)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9eQAE)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
 ## Managed Package - v4.9.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.9.5
+## Unlocked Package - v4.9.6
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9KQAU)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9KQAU)

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsApexSystemDebugLoggingEnabled__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsApexSystemDebugLoggingEnabled__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>IsApexSystemDebugLoggingEnabled__c</fullName>
     <businessStatus>Active</businessStatus>
     <complianceGroup>CCPA;GDPR;PII</complianceGroup>
-    <defaultValue>true</defaultValue>
+    <defaultValue>false</defaultValue>
     <externalId>false</externalId>
     <inlineHelpText
     >When enabled, Logger will automatically call Apex&apos;s System.debug(). To help with performance, this option should be disabled in production unless you are actively troubleshooting an issue.</inlineHelpText>

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsJavaScriptConsoleLoggingEnabled__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsJavaScriptConsoleLoggingEnabled__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>IsJavaScriptConsoleLoggingEnabled__c</fullName>
     <businessStatus>Active</businessStatus>
     <complianceGroup>CCPA;GDPR;PII</complianceGroup>
-    <defaultValue>true</defaultValue>
+    <defaultValue>false</defaultValue>
     <externalId>false</externalId>
     <inlineHelpText
     >When enabled, Logger will automatically call the browser&apos;s console.log() function when logging via lightning components. To help with performance, this option should be disabled in production unless you are actively troubleshooting an issue.</inlineHelpText>

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/LoggingLevel__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/LoggingLevel__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>LoggingLevel__c</fullName>
     <businessStatus>Active</businessStatus>
     <complianceGroup>CCPA;GDPR;PII</complianceGroup>
-    <defaultValue>&apos;DEBUG&apos;</defaultValue>
+    <defaultValue>&apos;INFO&apos;</defaultValue>
     <externalId>false</externalId>
     <label>Logging Level</label>
     <length>255</length>

--- a/nebula-logger/core/main/log-management/classes/LogBatchPurgeController.cls
+++ b/nebula-logger/core/main/log-management/classes/LogBatchPurgeController.cls
@@ -130,9 +130,9 @@ public with sharing class LogBatchPurgeController {
      * @return true if the current user has delete permission on the Log__c object.
      */
     @AuraEnabled
-    public static boolean canUserRunLogBatchPurger() {
+    public static Boolean canUserRunLogBatchPurger() {
         return Schema.Log__c.SObjectType.getDescribe().isDeletable() == true ||
-            FeatureManagement.checkPermission(CAN_EXECUTE_LOG_BATCH_PURGER_PERMISSION) == true;
+            System.FeatureManagement.checkPermission(CAN_EXECUTE_LOG_BATCH_PURGER_PERMISSION) == true;
     }
 
     /**

--- a/nebula-logger/core/main/log-management/classes/LoggerSettingsController.cls
+++ b/nebula-logger/core/main/log-management/classes/LoggerSettingsController.cls
@@ -29,7 +29,7 @@ public without sharing class LoggerSettingsController {
     @AuraEnabled(cacheable=true)
     public static Boolean canUserModifyLoggerSettings() {
         return Schema.LoggerSettings__c.SObjectType.getDescribe().isUpdateable() == true ||
-            FeatureManagement.checkPermission('CanModifyLoggerSettings') == true;
+            System.FeatureManagement.checkPermission('CanModifyLoggerSettings') == true;
     }
 
     /**
@@ -85,7 +85,9 @@ public without sharing class LoggerSettingsController {
      */
     @AuraEnabled(cacheable=true)
     public static LoggerSettings__c createRecord() {
-        return (LoggerSettings__c) Schema.LoggerSettings__c.SObjectType.newSObject(null, true);
+        // By passing an empty User record, it ensures that the returned LoggerSettings__c record
+        // is not tied to a specific User or Profile (or Organization)
+        return Logger.getUserSettings(new User());
     }
 
     /**

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -16,11 +16,14 @@ global with sharing class LogEntryEventBuilder {
     private static final User CURRENT_USER = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
     private static final String NEW_LINE_DELIMITER = '\n';
 
+    private static String cachedOrganizationEnvironmentType;
+
     @TestVisible
     private static Id networkId = System.Network.getNetworkId();
 
     private final LogEntryEvent__e logEntryEvent;
     private final System.LoggingLevel entryLoggingLevel;
+    private final String organizationEnvironmentType;
     private final LoggerSettings__c userSettings;
 
     @TestVisible
@@ -37,16 +40,6 @@ global with sharing class LogEntryEventBuilder {
                 CACHED_DATA_MASK_RULES = loadDataMaskRules();
             }
             return CACHED_DATA_MASK_RULES;
-        }
-        set;
-    }
-
-    private static final String CACHED_ORGANIZATION_ENVIRONMENT_TYPE {
-        get {
-            if (CACHED_ORGANIZATION_ENVIRONMENT_TYPE == null) {
-                CACHED_ORGANIZATION_ENVIRONMENT_TYPE = getOrganizationEnvironmentType();
-            }
-            return CACHED_ORGANIZATION_ENVIRONMENT_TYPE;
         }
         set;
     }
@@ -106,6 +99,7 @@ global with sharing class LogEntryEventBuilder {
         }
 
         this.userSettings = userSettings;
+        this.organizationEnvironmentType = getOrganizationEnvironmentType(userSettings);
         this.entryLoggingLevel = entryLoggingLevel;
         if (ignoredOrigins != null) {
             this.ignoredApexClasses.addAll(ignoredOrigins);
@@ -655,6 +649,13 @@ global with sharing class LogEntryEventBuilder {
             for (String fieldName : LOG_ENTRY_EVENT_TEMPLATE.getPopulatedFieldsAsMap().keySet()) {
                 this.logEntryEvent.put(fieldName, LOG_ENTRY_EVENT_TEMPLATE.get(fieldName));
             }
+            if (this.userSettings.IsAnonymousModeEnabled__c == false) {
+                setUserInfoDetails(this.logEntryEvent);
+                setQueriedAuthSessionDetails(this.logEntryEvent, this.userSettings);
+                setQueriedUserDetails(this.logEntryEvent, this.userSettings);
+            }
+            setQueriedNetworkDetails(this.logEntryEvent, this.userSettings);
+            setQueriedOrganizationDetails(this.logEntryEvent, this.userSettings);
             this.detailsAreSet = true;
         }
 
@@ -679,7 +680,7 @@ global with sharing class LogEntryEventBuilder {
 
     @SuppressWarnings('PMD.AvoidDebugStatements')
     private void logToApexDebug(String message) {
-        if (Logger.getUserSettings().IsApexSystemDebugLoggingEnabled__c == false) {
+        if (this.userSettings.IsApexSystemDebugLoggingEnabled__c == false) {
             return;
         }
 
@@ -769,19 +770,11 @@ global with sharing class LogEntryEventBuilder {
             OrganizationDomainUrl__c = Url.getOrgDomainUrl()?.toExternalForm()
         );
 
-        if (Logger.getUserSettings().IsAnonymousModeEnabled__c == false) {
-            setUserInfoDetails(templateLogEntryEvent);
-            setQueriedAuthSessionDetails(templateLogEntryEvent);
-            setQueriedUserDetails(templateLogEntryEvent);
-        }
-        setQueriedNetworkDetails(templateLogEntryEvent);
-        setQueriedOrganizationDetails(templateLogEntryEvent);
-
         return templateLogEntryEvent;
     }
 
-    private static void setQueriedAuthSessionDetails(LogEntryEvent__e logEntryEvent) {
-        if (LoggerParameter.QUERY_AUTH_SESSION_DATA_SYNCHRONOUSLY == false) {
+    private static void setQueriedAuthSessionDetails(LogEntryEvent__e logEntryEvent, LoggerSettings__c userSettings) {
+        if (userSettings.IsEnabled__c == false || LoggerParameter.QUERY_AUTH_SESSION_DATA_SYNCHRONOUSLY == false) {
             return;
         }
 
@@ -806,8 +799,8 @@ global with sharing class LogEntryEventBuilder {
         }
     }
 
-    private static void setQueriedNetworkDetails(LogEntryEvent__e logEntryEvent) {
-        if (LoggerParameter.QUERY_NETWORK_DATA_SYNCHRONOUSLY == false || String.isBlank(networkId) == true) {
+    private static void setQueriedNetworkDetails(LogEntryEvent__e logEntryEvent, LoggerSettings__c userSettings) {
+        if (userSettings.IsEnabled__c == false || LoggerParameter.QUERY_NETWORK_DATA_SYNCHRONOUSLY == false || String.isBlank(networkId) == true) {
             return;
         }
 
@@ -824,8 +817,8 @@ global with sharing class LogEntryEventBuilder {
         logEntryEvent.NetworkUrlPathPrefix__c = cachedNetworkProxy.UrlPathPrefix;
     }
 
-    private static void setQueriedOrganizationDetails(LogEntryEvent__e logEntryEvent) {
-        if (LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY == false) {
+    private static void setQueriedOrganizationDetails(LogEntryEvent__e logEntryEvent, LoggerSettings__c userSettings) {
+        if (userSettings.IsEnabled__c == false || LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY == false) {
             return;
         }
 
@@ -834,7 +827,7 @@ global with sharing class LogEntryEventBuilder {
             return;
         }
 
-        logEntryEvent.OrganizationEnvironmentType__c = CACHED_ORGANIZATION_ENVIRONMENT_TYPE;
+        logEntryEvent.OrganizationEnvironmentType__c = getOrganizationEnvironmentType(userSettings);
         logEntryEvent.OrganizationId__c = cachedOrganization?.Id;
         logEntryEvent.OrganizationInstanceName__c = cachedOrganization?.InstanceName;
         logEntryEvent.OrganizationName__c = cachedOrganization?.Name;
@@ -842,13 +835,12 @@ global with sharing class LogEntryEventBuilder {
         logEntryEvent.OrganizationType__c = cachedOrganization?.OrganizationType;
     }
 
-    private static void setQueriedUserDetails(LogEntryEvent__e logEntryEvent) {
-        if (LoggerParameter.QUERY_USER_DATA_SYNCHRONOUSLY == false) {
+    private static void setQueriedUserDetails(LogEntryEvent__e logEntryEvent, LoggerSettings__c userSettings) {
+        if (userSettings.IsEnabled__c == false || LoggerParameter.QUERY_USER_DATA_SYNCHRONOUSLY == false) {
             return;
         }
 
         User cachedUser = LoggerEngineDataSelector.getInstance().getCachedUser();
-
         if (cachedUser == null) {
             return;
         }
@@ -878,8 +870,8 @@ global with sharing class LogEntryEventBuilder {
         CACHED_DATA_MASK_RULES.put(dataMaskRule.DeveloperName, dataMaskRule);
     }
 
-    private static String applyDataMaskRules(String dataInput) {
-        if (Logger.getUserSettings().IsDataMaskingEnabled__c == false || String.isBlank(dataInput) == true) {
+    private String applyDataMaskRules(String dataInput) {
+        if (this.userSettings.IsDataMaskingEnabled__c == false || String.isBlank(dataInput) == true) {
             return dataInput;
         }
 
@@ -918,19 +910,27 @@ global with sharing class LogEntryEventBuilder {
         return userJson.substringAfter('/data/').substringBefore('/sobjects/User');
     }
 
-    private static String getOrganizationEnvironmentType() {
-        Organization cachedOrganization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
-        String orgEnvironmentType;
-        if (cachedOrganization == null) {
-            return '';
-        } else if (cachedOrganization.IsSandbox == true && cachedOrganization.TrialExpirationDate != null) {
-            orgEnvironmentType = 'Scratch Org';
-        } else if (cachedOrganization.IsSandbox == true) {
-            orgEnvironmentType = 'Sandbox';
-        } else {
-            orgEnvironmentType = 'Production';
+    private static String getOrganizationEnvironmentType(LoggerSettings__c userSettings) {
+        if (cachedOrganizationEnvironmentType != null) {
+            return cachedOrganizationEnvironmentType;
         }
-        return orgEnvironmentType;
+
+        if (userSettings.IsEnabled__c == false || LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY == false) {
+            return '';
+        }
+
+        Organization cachedOrganization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
+        String cachedOrganizationEnvironmentType;
+        if (cachedOrganization == null) {
+            cachedOrganizationEnvironmentType = '';
+        } else if (cachedOrganization.IsSandbox == true && cachedOrganization.TrialExpirationDate != null) {
+            cachedOrganizationEnvironmentType = 'Scratch Org';
+        } else if (cachedOrganization.IsSandbox == true) {
+            cachedOrganizationEnvironmentType = 'Sandbox';
+        } else {
+            cachedOrganizationEnvironmentType = 'Production';
+        }
+        return cachedOrganizationEnvironmentType;
     }
 
     private static String getNamespacePrefix() {

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,8 +15,8 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.9.5';
-    private static final System.LoggingLevel DEFAULT_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
+    private static final String CURRENT_VERSION_NUMBER = 'v4.9.6';
+    private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final Set<String> IGNORED_APEX_CLASSES = initializeIgnoredApexClasses();
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
     private static final String REQUEST_ID = System.Request.getCurrent().getRequestId();
@@ -289,6 +289,16 @@ global with sharing class Logger {
         if (loggingUser.Id != null && loggingUserSettings.SetupOwnerId != loggingUser.Id) {
             loggingUserSettings.Id = null;
             loggingUserSettings.SetupOwnerId = loggingUser.Id;
+        }
+
+        if (LoggerEngineDataSelector.getInstance().getCachedOrganization()?.IsSandbox == true) {
+            loggingUserSettings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
+            loggingUserSettings.IsApexSystemDebugLoggingEnabled__c = true;
+            loggingUserSettings.IsJavaScriptConsoleLoggingEnabled__c = true;
+        } else {
+            loggingUserSettings.LoggingLevel__c = System.LoggingLevel.INFO.name();
+            loggingUserSettings.IsApexSystemDebugLoggingEnabled__c = false;
+            loggingUserSettings.IsJavaScriptConsoleLoggingEnabled__c = false;
         }
 
         return loggingUserSettings;
@@ -2880,11 +2890,11 @@ global with sharing class Logger {
                 LogMessage logMessage = new LogMessage(
                     'Logger - Unknown logging level {0} specified, using {1}',
                     loggingLevelName,
-                    DEFAULT_LOGGING_LEVEL.name()
+                    FALLBACK_LOGGING_LEVEL.name()
                 );
                 finest(logMessage);
             }
-            return DEFAULT_LOGGING_LEVEL;
+            return FALLBACK_LOGGING_LEVEL;
         }
     }
 

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -106,6 +106,7 @@ global with sharing class Logger {
         return CURRENT_VERSION_NUMBER;
     }
 
+    // TODO delete
     /**
      * @description Returns the current namespace of Nebula Logger
      * @return   The current namespace prefix, or an empty string when no namespace is being used
@@ -281,6 +282,14 @@ global with sharing class Logger {
             loggingUserSettings = LoggerSettings__c.getOrgDefaults();
         } else {
             loggingUserSettings = (LoggerSettings__c) Schema.LoggerSettings__c.SObjectType.newSObject(null, true);
+            if (
+                LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY == true &&
+                LoggerEngineDataSelector.getInstance().getCachedOrganization()?.IsSandbox == true
+            ) {
+                loggingUserSettings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
+                loggingUserSettings.IsApexSystemDebugLoggingEnabled__c = true;
+                loggingUserSettings.IsJavaScriptConsoleLoggingEnabled__c = true;
+            }
         }
 
         // If the settings were loaded from the org or profile level, clear the ID and make the user the SetupOwnerId (since the method is getUserSettings)
@@ -289,16 +298,6 @@ global with sharing class Logger {
         if (loggingUser.Id != null && loggingUserSettings.SetupOwnerId != loggingUser.Id) {
             loggingUserSettings.Id = null;
             loggingUserSettings.SetupOwnerId = loggingUser.Id;
-        }
-
-        if (LoggerEngineDataSelector.getInstance().getCachedOrganization()?.IsSandbox == true) {
-            loggingUserSettings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
-            loggingUserSettings.IsApexSystemDebugLoggingEnabled__c = true;
-            loggingUserSettings.IsJavaScriptConsoleLoggingEnabled__c = true;
-        } else {
-            loggingUserSettings.LoggingLevel__c = System.LoggingLevel.INFO.name();
-            loggingUserSettings.IsApexSystemDebugLoggingEnabled__c = false;
-            loggingUserSettings.IsJavaScriptConsoleLoggingEnabled__c = false;
         }
 
         return loggingUserSettings;

--- a/nebula-logger/core/main/logger-engine/classes/LoggerEngineDataSelector.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerEngineDataSelector.cls
@@ -69,18 +69,17 @@ public without sharing virtual class LoggerEngineDataSelector {
      * @return   The cached `AuthSession` record
      */
     public virtual LoggerSObjectProxy.AuthSession getCachedAuthSessionProxy() {
-        if (LoggerParameter.QUERY_AUTH_SESSION_DATA == false) {
-            return null;
-        }
-
         Id userId = System.UserInfo.getUserId();
         String cacheKey = 'AuthSession' + userId;
         if (LoggerCache.getSessionCache().contains(cacheKey) == true) {
             return (LoggerSObjectProxy.AuthSession) LoggerCache.getSessionCache().get(cacheKey);
         }
 
-        LoggerSObjectProxy.AuthSession authSession = getAuthSessionProxies(new List<Id>{ userId }).get(userId);
-        LoggerCache.getSessionCache().put(cacheKey, authSession);
+        LoggerSObjectProxy.AuthSession authSession;
+        if (LoggerParameter.QUERY_AUTH_SESSION_DATA == true) {
+            authSession = getAuthSessionProxies(new List<Id>{ userId }).get(userId);
+            LoggerCache.getSessionCache().put(cacheKey, authSession);
+        }
         return authSession;
     }
 
@@ -111,10 +110,6 @@ public without sharing virtual class LoggerEngineDataSelector {
      * @return           The cached `Network` record
      */
     public virtual LoggerSObjectProxy.Network getCachedNetworkProxy(Id networkId) {
-        if (LoggerParameter.QUERY_NETWORK_DATA == false) {
-            return null;
-        }
-
         if (networkId == null || IS_EXPERIENCE_CLOUD_ENABLED == false) {
             return null;
         }
@@ -124,8 +119,11 @@ public without sharing virtual class LoggerEngineDataSelector {
             return (LoggerSObjectProxy.Network) LoggerCache.getOrganizationCache().get(cacheKey);
         }
 
-        LoggerSObjectProxy.Network networkProxy = getNetworkProxies(new List<Id>{ networkId }).get(networkId);
-        LoggerCache.getOrganizationCache().put(cacheKey, networkProxy);
+        LoggerSObjectProxy.Network networkProxy;
+        if (LoggerParameter.QUERY_NETWORK_DATA == false) {
+            networkProxy = getNetworkProxies(new List<Id>{ networkId }).get(networkId);
+            LoggerCache.getOrganizationCache().put(cacheKey, networkProxy);
+        }
         return networkProxy;
     }
 
@@ -134,17 +132,16 @@ public without sharing virtual class LoggerEngineDataSelector {
      * @return   The cached `Organization` record
      */
     public virtual Organization getCachedOrganization() {
-        if (LoggerParameter.QUERY_ORGANIZATION_DATA == false) {
-            return null;
-        }
-
         String cacheKey = 'Organization';
         if (LoggerCache.getOrganizationCache().contains(cacheKey) == true) {
             return (Organization) LoggerCache.getOrganizationCache().get(cacheKey);
         }
 
-        Organization organization = [SELECT Id, InstanceName, IsSandbox, Name, NamespacePrefix, OrganizationType, TrialExpirationDate FROM Organization];
-        LoggerCache.getOrganizationCache().put(cacheKey, organization);
+        Organization organization;
+        if (LoggerParameter.QUERY_ORGANIZATION_DATA == true) {
+            organization = [SELECT Id, InstanceName, IsSandbox, Name, NamespacePrefix, OrganizationType, TrialExpirationDate FROM Organization];
+            LoggerCache.getOrganizationCache().put(cacheKey, organization);
+        }
         return organization;
     }
 
@@ -179,18 +176,17 @@ public without sharing virtual class LoggerEngineDataSelector {
      * @return   The cached `User` record for the current user
      */
     public virtual User getCachedUser() {
-        if (LoggerParameter.QUERY_USER_DATA == false) {
-            return null;
-        }
-
         Id userId = System.UserInfo.getUserId();
         String cacheKey = 'User' + userId;
         if (LoggerCache.getSessionCache().contains(cacheKey) == true) {
             return (User) LoggerCache.getSessionCache().get(cacheKey);
         }
 
-        User user = getUsers(new List<Id>{ userId }).get(userId);
-        LoggerCache.getSessionCache().put(cacheKey, user);
+        User user;
+        if (LoggerParameter.QUERY_USER_DATA == true) {
+            user = getUsers(new List<Id>{ userId }).get(userId);
+            LoggerCache.getSessionCache().put(cacheKey, user);
+        }
         return user;
     }
 

--- a/nebula-logger/core/tests/log-management/classes/LogBatchPurgeController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogBatchPurgeController_Tests.cls
@@ -336,7 +336,10 @@ private class LogBatchPurgeController_Tests {
         insert new List<SObject>{ setupEntityAccess, permissionSetAssignment };
 
         System.runAs(standardUser) {
-            System.Assert.isTrue(FeatureManagement.checkPermission(CAN_EXECUTE_LOG_BATCH_PURGER_PERMISSION), JSON.serializePretty(permissionSetAssignment));
+            System.Assert.isTrue(
+                System.FeatureManagement.checkPermission(CAN_EXECUTE_LOG_BATCH_PURGER_PERMISSION),
+                JSON.serializePretty(permissionSetAssignment)
+            );
             System.Assert.areEqual(
                 true,
                 LogBatchPurgeController.canUserRunLogBatchPurger(),
@@ -375,7 +378,7 @@ private class LogBatchPurgeController_Tests {
         insert new List<SObject>{ setupEntityAccess };
 
         System.runAs(standardUser) {
-            System.Assert.isFalse(FeatureManagement.checkPermission(CAN_EXECUTE_LOG_BATCH_PURGER_PERMISSION), 'permission set assigned');
+            System.Assert.isFalse(System.FeatureManagement.checkPermission(CAN_EXECUTE_LOG_BATCH_PURGER_PERMISSION), 'permission set assigned');
             System.Assert.areEqual(
                 false,
                 LogBatchPurgeController.canUserRunLogBatchPurger(),

--- a/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
@@ -202,7 +202,7 @@ private class LoggerSettingsController_Tests {
 
     @IsTest
     static void it_should_create_new_record() {
-        LoggerSettings__c expectedNewRecord = (LoggerSettings__c) Schema.LoggerSettings__c.SObjectType.newSObject(null, true);
+        LoggerSettings__c expectedNewRecord = Logger.getUserSettings(new User());
 
         LoggerSettings__c newRecord = LoggerSettingsController.createRecord();
 

--- a/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
@@ -8,9 +8,10 @@
 private class LoggerSettingsController_Tests {
     @IsTest
     static void it_should_return_loggingLevel_picklist_options() {
-        //
         Integer expectedLoggingLevelSize = System.LoggingLevel.values().size() - 1; // LoggingLEVEL.NONE and System.LoggingLevel.INTERNAL are ignored, '--NONE--' is automatically included
+
         List<LoggerSettingsController.PicklistOption> picklistOptions = LoggerSettingsController.getPicklistOptions().loggingLevelOptions;
+
         System.Assert.areEqual(expectedLoggingLevelSize, picklistOptions.size());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
             if (String.isBlank(picklistOption.value) == true) {
@@ -54,7 +55,9 @@ private class LoggerSettingsController_Tests {
     @IsTest
     static void it_should_return_loggerSaveMethod_picklist_options() {
         Integer expectedLoggerSaveMethodSize = Logger.SaveMethod.values().size() + 1; // '--NONE--' is automatically included
+
         List<LoggerSettingsController.PicklistOption> picklistOptions = LoggerSettingsController.getPicklistOptions().saveMethodOptions;
+
         System.Assert.areEqual(expectedLoggerSaveMethodSize, picklistOptions.size());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
             if (String.isBlank(picklistOption.value) == true) {
@@ -127,7 +130,9 @@ private class LoggerSettingsController_Tests {
     static void it_should_return_setupOwnerType_picklist_options() {
         Set<String> expectedSetupOwnerType = new Set<String>{ 'Organization', 'Profile', 'User' };
         Integer expectedSetupOwnerTypeSize = 4; // Options are org, profile, and user, and '--NONE--' is automatically included
+
         List<LoggerSettingsController.PicklistOption> picklistOptions = LoggerSettingsController.getPicklistOptions().setupOwnerTypeOptions;
+
         System.Assert.areEqual(expectedSetupOwnerTypeSize, picklistOptions.size());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
             if (String.isBlank(picklistOption.value) == true) {
@@ -149,7 +154,9 @@ private class LoggerSettingsController_Tests {
             }
         }
         Integer expectedShareAccessLevelSize = expectedShareAccessLevels.size() + 1; // 'All' value is ignored, and '--NONE--' is automatically included
+
         List<LoggerSettingsController.PicklistOption> picklistOptions = LoggerSettingsController.getPicklistOptions().shareAccessLevelOptions;
+
         System.Assert.areEqual(expectedShareAccessLevelSize, picklistOptions.size(), picklistOptions.toString());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
             if (String.isBlank(picklistOption.value) == true) {
@@ -164,7 +171,9 @@ private class LoggerSettingsController_Tests {
     @IsTest
     static void it_should_return_empty_settings_records_list_when_not_configured() {
         System.Assert.areEqual(0, [SELECT COUNT() FROM LoggerSettings__c]);
+
         List<LoggerSettingsController.SettingsRecordResult> records = LoggerSettingsController.getRecords();
+
         System.Assert.areEqual(0, records.size());
     }
 
@@ -179,6 +188,7 @@ private class LoggerSettingsController_Tests {
         Map<Id, LoggerSettings__c> testSettingsRecordsById = queryLoggerSettingsRecords(testSettingsRecords);
 
         List<LoggerSettingsController.SettingsRecordResult> recordResults = LoggerSettingsController.getRecords();
+
         System.Assert.isFalse(recordResults.isEmpty());
         System.Assert.areEqual(testSettingsRecordsById.size(), recordResults.size());
         for (LoggerSettingsController.SettingsRecordResult result : recordResults) {
@@ -193,7 +203,9 @@ private class LoggerSettingsController_Tests {
     @IsTest
     static void it_should_create_new_record() {
         LoggerSettings__c expectedNewRecord = (LoggerSettings__c) Schema.LoggerSettings__c.SObjectType.newSObject(null, true);
+
         LoggerSettings__c newRecord = LoggerSettingsController.createRecord();
+
         System.Assert.areEqual(expectedNewRecord, newRecord);
         System.Assert.isNull(newRecord.Id);
         System.Assert.isNull(newRecord.SetupOwnerId);
@@ -206,6 +218,7 @@ private class LoggerSettingsController_Tests {
         System.Assert.isNull(newRecord.Id);
 
         LoggerSettingsController.saveRecord(newRecord);
+
         System.Assert.isNotNull(newRecord.Id);
     }
 
@@ -291,6 +304,7 @@ private class LoggerSettingsController_Tests {
         Profile currentProfile = [SELECT Id, Name FROM Profile WHERE Id = :System.UserInfo.getProfileId()];
         String searchTerm = '%' + currentProfile.Name.left(4) + '%';
         Map<Id, Profile> expectedResultsById = new Map<Id, Profile>([SELECT Id, Name, UserLicense.Name FROM Profile WHERE Name LIKE :searchTerm]);
+
         List<LoggerSettingsController.SetupOwnerSearchResult> results = LoggerSettingsController.searchForSetupOwner('Profile', searchTerm);
 
         System.Assert.isFalse(results.isEmpty());
@@ -308,7 +322,9 @@ private class LoggerSettingsController_Tests {
     @IsTest
     static void it_should_return_empty_user_search_results_list_when_no_matches_found() {
         String nonsenseSearchTerm = 'asdfqwert;lkhpoiy';
+
         List<LoggerSettingsController.SetupOwnerSearchResult> results = LoggerSettingsController.searchForSetupOwner('User', nonsenseSearchTerm);
+
         System.Assert.areEqual(0, results.size());
     }
 
@@ -318,6 +334,7 @@ private class LoggerSettingsController_Tests {
         Map<Id, User> expectedResultsById = new Map<Id, User>(
             [SELECT Id, Name, Username, SmallPhotoUrl FROM User WHERE Name LIKE :searchTerm OR Username LIKE :searchTerm]
         );
+
         List<LoggerSettingsController.SetupOwnerSearchResult> results = LoggerSettingsController.searchForSetupOwner('User', searchTerm);
 
         System.Assert.isFalse(results.isEmpty());
@@ -349,7 +366,6 @@ private class LoggerSettingsController_Tests {
         }
     }
 
-    // Helper methods
     private static Map<Id, LoggerSettings__c> queryLoggerSettingsRecords(List<LoggerSettings__c> recordsToQuery) {
         return new Map<Id, LoggerSettings__c>(
             [

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -48,18 +48,23 @@ private class LogEntryEventBuilder_Tests {
     }
 
     @IsTest
-    static void it_should_not_run_queries_when_logging_disabled() {
+    static void it_should_not_run_queries_when_logging_is_disabled_via_logger_settings() {
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryAuthSessionDataSynchronously', Value__c = String.valueOf(true)));
+        System.Assert.isTrue(LoggerParameter.QUERY_AUTH_SESSION_DATA_SYNCHRONOUSLY);
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryNetworkDataSynchronously', Value__c = String.valueOf(true)));
+        System.Assert.isTrue(LoggerParameter.QUERY_NETWORK_DATA_SYNCHRONOUSLY);
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryOrganizationDataSynchronously', Value__c = String.valueOf(true)));
+        System.Assert.isTrue(LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY);
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryUserDataSynchronously', Value__c = String.valueOf(true)));
-        Logger.getUserSettings().IsEnabled__c = false;
-        System.Assert.isFalse(Logger.isEnabled());
+        System.Assert.isTrue(LoggerParameter.QUERY_USER_DATA_SYNCHRONOUSLY);
+        LoggerSettings__c userSettings = getUserSettings();
+        userSettings.IsEnabled__c = false;
         System.Assert.areEqual(0, System.Limits.getQueries());
 
-        new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, Logger.getUserSettings().IsEnabled__c, new Set<String>())
+        new LogEntryEventBuilder(userSettings, System.LoggingLevel.INFO, userSettings.IsEnabled__c, new Set<String>())
             .setMessage('some message')
             .getLogEntryEvent();
+
         System.Assert.areEqual(0, System.Limits.getQueries());
     }
 
@@ -276,7 +281,8 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_not_apply_data_mask_rule_when_rule_disabled() {
-        Logger.getUserSettings().IsDataMaskingEnabled__c = true;
+        LoggerSettings__c userSettings = getUserSettings();
+        userSettings.IsDataMaskingEnabled__c = true;
         LogEntryDataMaskRule__mdt rule = getSocialSecurityNumberDataMaskRule();
         rule.IsEnabled__c = false;
         LogEntryEventBuilder.setMockDataMaskRule(rule);
@@ -284,7 +290,7 @@ private class LogEntryEventBuilder_Tests {
         Account account = new Account(Name = message);
         String accountJson = JSON.serializePretty(account);
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(userSettings, System.LoggingLevel.INFO, true, new Set<String>());
         builder.setMessage(message).setRecord(account);
 
         System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c, builder.getLogEntryEvent().Message__c);
@@ -295,7 +301,8 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_not_apply_data_mask_rule_when_disabled_for_user() {
-        Logger.getUserSettings().IsDataMaskingEnabled__c = false;
+        LoggerSettings__c userSettings = getUserSettings();
+        userSettings.IsDataMaskingEnabled__c = false;
         LogEntryDataMaskRule__mdt rule = getSocialSecurityNumberDataMaskRule();
         rule.IsEnabled__c = true;
         LogEntryEventBuilder.setMockDataMaskRule(rule);
@@ -303,7 +310,7 @@ private class LogEntryEventBuilder_Tests {
         Account account = new Account(Name = message);
         String accountJson = JSON.serializePretty(account);
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(userSettings, System.LoggingLevel.INFO, true, new Set<String>());
         builder.setMessage(message).setRecord(account);
 
         System.Assert.isFalse(builder.getLogEntryEvent().MessageMasked__c);
@@ -314,14 +321,15 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_apply_data_mask_rule_to_message_when_enabled() {
-        Logger.getUserSettings().IsDataMaskingEnabled__c = true;
+        LoggerSettings__c userSettings = getUserSettings();
+        userSettings.IsDataMaskingEnabled__c = true;
         LogEntryDataMaskRule__mdt rule = getSocialSecurityNumberDataMaskRule();
         rule.IsEnabled__c = true;
         LogEntryEventBuilder.setMockDataMaskRule(rule);
         String sensitiveString = 'Something, something, and my social is 400 11 9999 in case you want to steal my identity';
         String expectedSanitizedString = 'Something, something, and my social is XXX-XX-9999 in case you want to steal my identity';
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(userSettings, System.LoggingLevel.INFO, true, new Set<String>());
         builder.setMessage(sensitiveString);
 
         System.Assert.isTrue(builder.getLogEntryEvent().MessageMasked__c);
@@ -331,7 +339,8 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_apply_data_mask_rule_to_record_json_when_enabled() {
-        Logger.getUserSettings().IsDataMaskingEnabled__c = true;
+        LoggerSettings__c userSettings = getUserSettings();
+        userSettings.IsDataMaskingEnabled__c = true;
         LogEntryDataMaskRule__mdt rule = getSocialSecurityNumberDataMaskRule();
         rule.IsEnabled__c = true;
         LogEntryEventBuilder.setMockDataMaskRule(rule);
@@ -341,7 +350,7 @@ private class LogEntryEventBuilder_Tests {
         String accountJson = JSON.serializePretty(account);
         String expectedSanitizedAccountJson = JSON.serializePretty(new Account(Name = expectedSanitizedString));
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(userSettings, System.LoggingLevel.INFO, true, new Set<String>());
         builder.setRecord(account);
 
         System.Assert.isTrue(builder.getLogEntryEvent().RecordJsonMasked__c);
@@ -351,7 +360,8 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_apply_data_mask_rule_to_record_list_json_when_enabled() {
-        Logger.getUserSettings().IsDataMaskingEnabled__c = true;
+        LoggerSettings__c userSettings = getUserSettings();
+        userSettings.IsDataMaskingEnabled__c = true;
         LogEntryDataMaskRule__mdt rule = getSocialSecurityNumberDataMaskRule();
         rule.IsEnabled__c = true;
         LogEntryEventBuilder.setMockDataMaskRule(rule);
@@ -361,7 +371,7 @@ private class LogEntryEventBuilder_Tests {
         List<Account> accounts = new List<Account>{ new Account(Name = sensitiveString) };
         String accountListJson = JSON.serializePretty(accounts);
         String expectedSanitizedAccountListJson = JSON.serializePretty(new List<Account>{ new Account(Name = expectedSanitizedString) });
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(userSettings, System.LoggingLevel.INFO, true, new Set<String>());
         builder.setRecord(accounts);
 
         System.Assert.isTrue(builder.getLogEntryEvent().RecordJsonMasked__c);
@@ -371,7 +381,8 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_apply_data_mask_rule_to_http_request_body_when_enabled() {
-        Logger.getUserSettings().IsDataMaskingEnabled__c = true;
+        LoggerSettings__c userSettings = getUserSettings();
+        userSettings.IsDataMaskingEnabled__c = true;
         LogEntryDataMaskRule__mdt rule = getSocialSecurityNumberDataMaskRule();
         rule.IsEnabled__c = true;
         LogEntryEventBuilder.setMockDataMaskRule(rule);
@@ -380,7 +391,7 @@ private class LogEntryEventBuilder_Tests {
         System.HttpRequest httpRequest = LoggerMockDataCreator.createHttpRequest();
         httpRequest.setBody(sensitiveString);
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(userSettings, System.LoggingLevel.INFO, true, new Set<String>());
         builder.setHttpRequestDetails(httpRequest);
 
         System.Assert.isTrue(builder.getLogEntryEvent().HttpRequestBodyMasked__c);
@@ -390,7 +401,8 @@ private class LogEntryEventBuilder_Tests {
 
     @IsTest
     static void it_should_apply_data_mask_rule_to_http_response_body_when_enabled() {
-        Logger.getUserSettings().IsDataMaskingEnabled__c = true;
+        LoggerSettings__c userSettings = getUserSettings();
+        userSettings.IsDataMaskingEnabled__c = true;
         LogEntryDataMaskRule__mdt rule = getSocialSecurityNumberDataMaskRule();
         rule.IsEnabled__c = true;
         LogEntryEventBuilder.setMockDataMaskRule(rule);
@@ -399,7 +411,7 @@ private class LogEntryEventBuilder_Tests {
         System.HttpResponse httpResponse = LoggerMockDataCreator.createHttpResponse();
         httpResponse.setBody(sensitiveString);
 
-        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(userSettings, System.LoggingLevel.INFO, true, new Set<String>());
         builder.setHttpResponseDetails(httpResponse);
 
         System.Assert.isTrue(builder.getLogEntryEvent().HttpResponseBodyMasked__c);
@@ -813,8 +825,9 @@ private class LogEntryEventBuilder_Tests {
 
         LogEntryEventBuilder builder;
         System.runAs(standardUser) {
-            Logger.getUserSettings().IsRecordFieldStrippingEnabled__c = true;
-            builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAggregateResult);
+            LoggerSettings__c userSettings = getUserSettings();
+            userSettings.IsRecordFieldStrippingEnabled__c = true;
+            builder = new LogEntryEventBuilder(userSettings, System.LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAggregateResult);
         }
 
         System.Assert.areEqual(JSON.serializePretty(mockAggregateResult), builder.getLogEntryEvent().RecordJson__c);
@@ -827,8 +840,9 @@ private class LogEntryEventBuilder_Tests {
 
         LogEntryEventBuilder builder;
         System.runAs(standardUser) {
-            Logger.getUserSettings().IsRecordFieldStrippingEnabled__c = true;
-            builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAggregateResults);
+            LoggerSettings__c userSettings = getUserSettings();
+            userSettings.IsRecordFieldStrippingEnabled__c = true;
+            builder = new LogEntryEventBuilder(userSettings, System.LoggingLevel.INFO, true, new Set<String>()).setRecord(mockAggregateResults);
         }
 
         System.Assert.areEqual(JSON.serializePretty(mockAggregateResults), builder.getLogEntryEvent().RecordJson__c);
@@ -1018,7 +1032,7 @@ private class LogEntryEventBuilder_Tests {
     static void it_should_not_set_stack_trace_for_new_builder_instance_when_disabled_via_logger_parameter() {
         // Don't bother testing stack trace logic when using a namespace prefix - there are
         // some platform limitations that prevent these tests from behaving as expected
-        if (String.isNotBlank(Logger.getNamespacePrefix()) == true) {
+        if (LogEntryEventBuilder.class.getName().contains('.') == true) {
             return;
         }
 
@@ -1036,7 +1050,7 @@ private class LogEntryEventBuilder_Tests {
     static void it_should_not_set_stack_trace_for_parseStackTrace_method_when_disabled_via_logger_parameter() {
         // Don't bother testing stack trace logic when using a namespace prefix - there are
         // some platform limitations that prevent these tests from behaving as expected
-        if (String.isNotBlank(Logger.getNamespacePrefix()) == true) {
+        if (LogEntryEventBuilder.class.getName().contains('.') == true) {
             return;
         }
 
@@ -1055,7 +1069,7 @@ private class LogEntryEventBuilder_Tests {
     static void it_should_set_stack_trace_and_origin_location_for_class_constructor_trace_string() {
         // Don't bother testing stack trace logic when using a namespace prefix - there are
         // some platform limitations that prevent these tests from behaving as expected
-        if (String.isNotBlank(Logger.getNamespacePrefix()) == true) {
+        if (LogEntryEventBuilder.class.getName().contains('.') == true) {
             return;
         }
 
@@ -1079,7 +1093,7 @@ private class LogEntryEventBuilder_Tests {
     static void it_should_set_stack_trace_and_origin_location_for_method_stack_trace_string() {
         // Don't bother testing stack trace logic when using a namespace prefix - there are
         // some platform limitations that prevent these tests from behaving as expected
-        if (String.isNotBlank(Logger.getNamespacePrefix()) == true) {
+        if (LogEntryEventBuilder.class.getName().contains('.') == true) {
             return;
         }
 
@@ -1218,10 +1232,11 @@ private class LogEntryEventBuilder_Tests {
     }
 
     @IsTest
-    static void it_should_not_set_user_fields_when_anonymous_mode_enabled() {
-        Logger.getUserSettings().IsAnonymousModeEnabled__c = true;
+    static void it_should_not_set_user_fields_when_anonymous_mode_is_enabled() {
+        LoggerSettings__c userSettings = getUserSettings();
+        userSettings.IsAnonymousModeEnabled__c = true;
 
-        LogEntryEventBuilder builder = Logger.debug('test log entry');
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(userSettings, System.LoggingLevel.DEBUG, true, new Set<String>());
 
         System.Assert.isNull(builder.getLogEntryEvent().Locale__c);
         System.Assert.isNull(builder.getLogEntryEvent().LoggedById__c);
@@ -1253,7 +1268,7 @@ private class LogEntryEventBuilder_Tests {
     static void it_should_use_configured_log_entry_event_fields_for_debug_string() {
         // Don't bother testing stack trace logic when using a namespace prefix - there are
         // some platform limitations that prevent these tests from behaving as expected
-        if (String.isNotBlank(Logger.getNamespacePrefix()) == true) {
+        if (LogEntryEventBuilder.class.getName().contains('.') == true) {
             return;
         }
 
@@ -1262,7 +1277,9 @@ private class LogEntryEventBuilder_Tests {
         );
 
         DebugStringExample example = new DebugStringExample();
-        LogEntryEventBuilder builder = example.myMethod();
+        LoggerSettings__c userSettings = getUserSettings();
+        userSettings.IsApexSystemDebugLoggingEnabled__c = true;
+        LogEntryEventBuilder builder = example.myMethod(userSettings);
 
         System.Assert.areEqual(
             DebugStringExample.class.getName() +
@@ -1311,15 +1328,15 @@ private class LogEntryEventBuilder_Tests {
 
         public DebugStringExample() {
             this.stackTraceHandler = new System.DmlException();
-            Logger.debug('Logging in a constructor');
         }
 
         public String getStackTraceString() {
             return this.stackTraceHandler.getStackTraceString();
         }
 
-        public LogEntryEventBuilder myMethod() {
-            return Logger.debug(loggingString);
+        public LogEntryEventBuilder myMethod(LoggerSettings__c userSettings) {
+            return new LogEntryEventBuilder(userSettings, System.LoggingLevel.DEBUG, true, new Set<String>{ LogEntryEventBuilder.class.getName() })
+                .setMessage(loggingString);
         }
     }
 

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -808,8 +808,9 @@ private class Logger_Tests {
     @IsTest
     static void it_should_return_the_buffer_size() {
         System.Assert.areEqual(0, Logger.getBufferSize());
+        System.Assert.isTrue(Logger.isInfoEnabled());
 
-        Logger.debug('test log entry');
+        Logger.info('test log entry');
         Logger.warn('another test log entry');
 
         System.Assert.areEqual(2, Logger.getBufferSize());
@@ -1209,8 +1210,9 @@ private class Logger_Tests {
             )
         );
         List<LogEntryEvent__e> logEntryEvents = new List<LogEntryEvent__e>();
-        logEntryEvents.add(Logger.debug('test log entry').getLogEntryEvent());
-        logEntryEvents.add(Logger.debug('another test log entry').getLogEntryEvent());
+        System.Assert.isTrue(Logger.isInfoEnabled());
+        logEntryEvents.add(Logger.info('test log entry').getLogEntryEvent());
+        logEntryEvents.add(Logger.info('another test log entry').getLogEntryEvent());
         System.Test.startTest();
         System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
         System.Assert.areEqual(0, System.Limits.getQueueableJobs());
@@ -1261,8 +1263,8 @@ private class Logger_Tests {
             )
         );
         List<LogEntryEvent__e> logEntryEvents = new List<LogEntryEvent__e>();
-        logEntryEvents.add(Logger.debug('test log entry').getLogEntryEvent());
-        logEntryEvents.add(Logger.debug('another test log entry').getLogEntryEvent());
+        logEntryEvents.add(Logger.info('test log entry').getLogEntryEvent());
+        logEntryEvents.add(Logger.info('another test log entry').getLogEntryEvent());
         System.Test.startTest();
         System.Assert.areEqual(0, System.Limits.getPublishImmediateDml());
         System.Assert.areEqual(0, System.Limits.getQueueableJobs());
@@ -1303,8 +1305,8 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_flush_buffer() {
-        Logger.debug('test log entry');
-        Logger.debug('another test log entry');
+        Logger.info('test log entry');
+        Logger.info('another test log entry');
         System.Assert.areEqual(2, Logger.getBufferSize());
 
         Logger.flushBuffer();

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -28,18 +28,23 @@ private class Logger_Tests {
     @IsTest
     static void it_should_use_in_memory_default_settings_when_not_configured() {
         LoggerSettings__c expectedSettings = (LoggerSettings__c) LoggerSettings__c.SObjectType.newSObject(null, true);
+        if (LoggerEngineDataSelector.getInstance().getCachedOrganization()?.IsSandbox == true) {
+            expectedSettings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
+            expectedSettings.IsApexSystemDebugLoggingEnabled__c = true;
+            expectedSettings.IsJavaScriptConsoleLoggingEnabled__c = true;
+        }
         expectedSettings.SetupOwnerId = System.UserInfo.getUserId();
 
         LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
-        List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
-        System.Assert.areEqual(0, existingSettings.size(), 'LoggerSettings__c record should not have been saved');
         System.Assert.areEqual(expectedSettings, returnedSettings);
         System.Assert.isNull(returnedSettings.Id);
+        List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
+        System.Assert.areEqual(0, existingSettings.size(), 'LoggerSettings__c record should not have been saved');
     }
 
     @IsTest
-    static void it_should_default_settings_fields_when_organization_is_a_sandbox() {
+    static void it_should_settings_default_field_values_when_organization_is_a_sandbox() {
         Organization mockOrganization = (Schema.Organization) LoggerMockDataCreator.setReadOnlyField(new Organization(), Schema.Organization.IsSandbox, true);
         System.Assert.isTrue(mockOrganization.IsSandbox);
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
@@ -53,14 +58,14 @@ private class Logger_Tests {
 
         LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
-        List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
-        System.Assert.areEqual(0, existingSettings.size(), 'LoggerSettings__c record should not have been saved');
         System.Assert.areEqual(expectedSettings, returnedSettings);
         System.Assert.isNull(returnedSettings.Id);
+        List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
+        System.Assert.areEqual(0, existingSettings.size(), 'LoggerSettings__c record should not have been saved');
     }
 
     @IsTest
-    static void it_should_default_settings_fields_when_organization_is_not_a_sandbox() {
+    static void it_should_settings_default_field_values_when_organization_is_not_a_sandbox() {
         Organization mockOrganization = (Schema.Organization) LoggerMockDataCreator.setReadOnlyField(new Organization(), Schema.Organization.IsSandbox, false);
         System.Assert.isFalse(mockOrganization.IsSandbox);
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
@@ -74,17 +79,16 @@ private class Logger_Tests {
 
         LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
-        List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
-        System.Assert.areEqual(0, existingSettings.size(), 'LoggerSettings__c record should not have been saved');
         System.Assert.areEqual(expectedSettings, returnedSettings);
         System.Assert.isNull(returnedSettings.Id);
+        List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
+        System.Assert.areEqual(0, existingSettings.size(), 'LoggerSettings__c record should not have been saved');
     }
 
     @IsTest
-    static void it_should_default_settings_fields_when_organization_is_null() {
-        MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
-        mockSelector.setCachedOrganization(null);
-        LoggerEngineDataSelector.setMock(mockSelector);
+    static void it_should_settings_default_field_values_when_querying_organization_synchronously_is_disabled() {
+        LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryOrganizationDataSynchronously', Value__c = String.valueOf(false)));
+        System.Assert.isFalse(LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY);
         LoggerSettings__c expectedSettings = (LoggerSettings__c) LoggerSettings__c.SObjectType.newSObject(null, true);
         expectedSettings.LoggingLevel__c = System.LoggingLevel.INFO.name();
         expectedSettings.IsApexSystemDebugLoggingEnabled__c = false;
@@ -93,16 +97,16 @@ private class Logger_Tests {
 
         LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
-        List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
-        System.Assert.areEqual(0, existingSettings.size(), 'LoggerSettings__c record should not have been saved');
         System.Assert.areEqual(expectedSettings, returnedSettings);
         System.Assert.isNull(returnedSettings.Id);
+        List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
+        System.Assert.areEqual(0, existingSettings.size(), 'LoggerSettings__c record should not have been saved');
     }
 
     @IsTest
     static void it_should_use_org_default_settings_when_configured() {
         LoggerSettings__c expectedSettings = LoggerSettings__c.getOrgDefaults();
-        expectedSettings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
+        expectedSettings.LoggingLevel__c = System.LoggingLevel.FINE.name();
         insert expectedSettings;
         expectedSettings = LoggerSettings__c.getOrgDefaults();
         expectedSettings.Id = null;

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -39,6 +39,67 @@ private class Logger_Tests {
     }
 
     @IsTest
+    static void it_should_default_settings_fields_when_organization_is_a_sandbox() {
+        Organization mockOrganization = (Schema.Organization) LoggerMockDataCreator.setReadOnlyField(new Organization(), Schema.Organization.IsSandbox, true);
+        System.Assert.isTrue(mockOrganization.IsSandbox);
+        MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
+        mockSelector.setCachedOrganization(mockOrganization);
+        LoggerEngineDataSelector.setMock(mockSelector);
+        LoggerSettings__c expectedSettings = (LoggerSettings__c) LoggerSettings__c.SObjectType.newSObject(null, true);
+        expectedSettings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
+        expectedSettings.IsApexSystemDebugLoggingEnabled__c = true;
+        expectedSettings.IsJavaScriptConsoleLoggingEnabled__c = true;
+        expectedSettings.SetupOwnerId = System.UserInfo.getUserId();
+
+        LoggerSettings__c returnedSettings = Logger.getUserSettings();
+
+        List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
+        System.Assert.areEqual(0, existingSettings.size(), 'LoggerSettings__c record should not have been saved');
+        System.Assert.areEqual(expectedSettings, returnedSettings);
+        System.Assert.isNull(returnedSettings.Id);
+    }
+
+    @IsTest
+    static void it_should_default_settings_fields_when_organization_is_not_a_sandbox() {
+        Organization mockOrganization = (Schema.Organization) LoggerMockDataCreator.setReadOnlyField(new Organization(), Schema.Organization.IsSandbox, false);
+        System.Assert.isFalse(mockOrganization.IsSandbox);
+        MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
+        mockSelector.setCachedOrganization(mockOrganization);
+        LoggerEngineDataSelector.setMock(mockSelector);
+        LoggerSettings__c expectedSettings = (LoggerSettings__c) LoggerSettings__c.SObjectType.newSObject(null, true);
+        expectedSettings.LoggingLevel__c = System.LoggingLevel.INFO.name();
+        expectedSettings.IsApexSystemDebugLoggingEnabled__c = false;
+        expectedSettings.IsJavaScriptConsoleLoggingEnabled__c = false;
+        expectedSettings.SetupOwnerId = System.UserInfo.getUserId();
+
+        LoggerSettings__c returnedSettings = Logger.getUserSettings();
+
+        List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
+        System.Assert.areEqual(0, existingSettings.size(), 'LoggerSettings__c record should not have been saved');
+        System.Assert.areEqual(expectedSettings, returnedSettings);
+        System.Assert.isNull(returnedSettings.Id);
+    }
+
+    @IsTest
+    static void it_should_default_settings_fields_when_organization_is_null() {
+        MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
+        mockSelector.setCachedOrganization(null);
+        LoggerEngineDataSelector.setMock(mockSelector);
+        LoggerSettings__c expectedSettings = (LoggerSettings__c) LoggerSettings__c.SObjectType.newSObject(null, true);
+        expectedSettings.LoggingLevel__c = System.LoggingLevel.INFO.name();
+        expectedSettings.IsApexSystemDebugLoggingEnabled__c = false;
+        expectedSettings.IsJavaScriptConsoleLoggingEnabled__c = false;
+        expectedSettings.SetupOwnerId = System.UserInfo.getUserId();
+
+        LoggerSettings__c returnedSettings = Logger.getUserSettings();
+
+        List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];
+        System.Assert.areEqual(0, existingSettings.size(), 'LoggerSettings__c record should not have been saved');
+        System.Assert.areEqual(expectedSettings, returnedSettings);
+        System.Assert.isNull(returnedSettings.Id);
+    }
+
+    @IsTest
     static void it_should_use_org_default_settings_when_configured() {
         LoggerSettings__c expectedSettings = LoggerSettings__c.getOrgDefaults();
         expectedSettings.LoggingLevel__c = System.LoggingLevel.FINEST.name();
@@ -7000,6 +7061,18 @@ private class Logger_Tests {
     public class MockClassWithLogging {
         public LogEntryEventBuilder logSomething() {
             return Logger.info('Hello, world');
+        }
+    }
+
+    private class MockLoggerEngineDataSelector extends LoggerEngineDataSelector {
+        private Organization cachedOrganization;
+
+        public override Organization getCachedOrganization() {
+            return this.cachedOrganization;
+        }
+
+        public void setCachedOrganization(Schema.Organization organization) {
+            this.cachedOrganization = organization;
         }
     }
 

--- a/nebula-logger/extra-tests/classes/ExampleInboundEmailHandler.cls
+++ b/nebula-logger/extra-tests/classes/ExampleInboundEmailHandler.cls
@@ -27,9 +27,9 @@ global with sharing class ExampleInboundEmailHandler implements Messaging.Inboun
             Logger.error(logEntryMessage, apexException);
         } finally {
             result.success = true;
-            Logger.debug('Logger buffer size before save: ' + Logger.getBufferSize());
+            Logger.info('Logger buffer size before save: ' + Logger.getBufferSize());
             Logger.saveLog();
-            Logger.debug('Logger buffer size after save: ' + Logger.getBufferSize());
+            Logger.info('Logger buffer size after save: ' + Logger.getBufferSize());
         }
 
         return result;

--- a/nebula-logger/extra-tests/classes/FeatureManagement.cls
+++ b/nebula-logger/extra-tests/classes/FeatureManagement.cls
@@ -1,0 +1,10 @@
+//------------------------------------------------------------------------------------------------//
+// This file is part of the Nebula Logger project, released under the MIT License.                //
+// See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    //
+//------------------------------------------------------------------------------------------------//
+
+// This class intentionally does nothing - it's here to ensure that any references
+// in Nebula Logger's codebase use `System.FeatureManagement` instead of just `FeatureManagement`
+@SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
+public class FeatureManagement {
+}

--- a/nebula-logger/extra-tests/classes/FeatureManagement.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/FeatureManagement.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/nebula-logger/extra-tests/tests/LoggerSettingsController_Tests_Security.cls
+++ b/nebula-logger/extra-tests/tests/LoggerSettingsController_Tests_Security.cls
@@ -24,7 +24,10 @@ private class LoggerSettingsController_Tests_Security {
         insert new List<SObject>{ setupEntityAccess, permissionSetAssignment };
 
         System.runAs(standardUser) {
-            System.Assert.isTrue(FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME), JSON.serializePretty(permissionSetAssignment));
+            System.Assert.isTrue(
+                System.FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME),
+                JSON.serializePretty(permissionSetAssignment)
+            );
             System.Assert.isTrue(LoggerSettingsController.canUserModifyLoggerSettings());
         }
     }
@@ -36,7 +39,7 @@ private class LoggerSettingsController_Tests_Security {
         LoggerTestConfigurator.assignAdminPermissionSet(standardUser.Id);
 
         System.runAs(standardUser) {
-            System.Assert.isTrue(FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
+            System.Assert.isTrue(System.FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
             System.Assert.isTrue(LoggerSettingsController.canUserModifyLoggerSettings());
         }
     }
@@ -48,7 +51,7 @@ private class LoggerSettingsController_Tests_Security {
         LoggerTestConfigurator.assignLogViewerPermissionSet(standardUser.Id);
 
         System.runAs(standardUser) {
-            System.Assert.isFalse(FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
+            System.Assert.isFalse(System.FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
             System.Assert.isFalse(LoggerSettingsController.canUserModifyLoggerSettings());
         }
     }
@@ -60,7 +63,7 @@ private class LoggerSettingsController_Tests_Security {
         LoggerTestConfigurator.assignEndUserPermissionSet(standardUser.Id);
 
         System.runAs(standardUser) {
-            System.Assert.isFalse(FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
+            System.Assert.isFalse(System.FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
             System.Assert.isFalse(LoggerSettingsController.canUserModifyLoggerSettings());
         }
     }
@@ -72,7 +75,7 @@ private class LoggerSettingsController_Tests_Security {
         LoggerTestConfigurator.assignLogCreatorPermissionSet(standardUser.Id);
 
         System.runAs(standardUser) {
-            System.Assert.isFalse(FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
+            System.Assert.isFalse(System.FeatureManagement.checkPermission(CAN_MODIFY_LOGGER_SETTINGS_PERMISSION_NAME));
             System.Assert.isFalse(LoggerSettingsController.canUserModifyLoggerSettings());
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.9.5",
+    "version": "4.9.6",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -14,8 +14,8 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.9.5.NEXT",
-            "versionName": "Configurable Platform Cache Partition Name",
+            "versionNumber": "4.9.6.NEXT",
+            "versionName": "Environment-Aware Default Field Values For Logger Settings",
             "versionDescription": "Added new CMDT record LoggerParameter.PlatformCachePartitionName to control which platform cache partition is used for caching",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -149,6 +149,7 @@
         "Nebula Logger - Core@4.9.3-new-indicator-icons": "04t5Y0000023R7sQAE",
         "Nebula Logger - Core@4.9.4-new-indicator-icons": "04t5Y0000023R8WQAU",
         "Nebula Logger - Core@4.9.5-configurable-platform-cache-partition-name": "04t5Y0000023R9KQAU",
+        "Nebula Logger - Core@4.9.6-environment-aware-default-field-values-for-logger-settings": "04t5Y0000023R9eQAE",
         "Nebula Logger - Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
- Updated `LoggerSettings__c` fields `LoggingLevel__c`, `IsApexSystemDebugLoggingEnabled__c`, and `IsJavaScriptConsoleLoggingEnabled__c` to make the default values be the recommended values for production orgs
- Closes #364 by updating `Logger.getUserSettings()` to set some field values based on if the current org is a sandbox. This also applies when using the included 'Logger Settings' tab (which displays the LWC `loggerSettings`).
  - In production, the default field values are now:
    - `LoggingLevel__c` now defaults to 'INFO'
    - `IsApexSystemDebugLoggingEnabled__c` and `IsJavaScriptConsoleLoggingEnabled__c` default to `false`
  - In sandboxes & scratch orgs, the default field values are now:
    - `LoggingLevel__c` now defaults to 'FINEST'
    - `IsApexSystemDebugLoggingEnabled__c` and `IsJavaScriptConsoleLoggingEnabled__c` default to `true`
- Updated `LoggerEngineDataSelector` class to still leverage data cached in Platform Cache (if available), even if querying is disabled for a particular method
- Added the `System` namespace to all references to the `FeatureManagement` class
- Removed some lingering references to `Logger` in `LogEntryBuilder & LogEntryBuilder_Tests`, which finishes up some ongoing tech debt cleanup to make `LogEntryEventBuilder` independent/unaware of `Logger`
- Made test execution faster in the pipeline by updating `build.yml`  to skip unnecessary code coverage calculations for all test runs except for the final synchronous run in the Experience Cloud scratch org (when code coverage data is uploaded to [Codecov.io](https://about.codecov.io/)) 