### PR TITLE
Added new field Log__c.HasComments__c 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.9.7
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9eQAE)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9eQAE)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9yQAE)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9yQAE)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
 ## Managed Package - v4.9.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.9.6
+## Unlocked Package - v4.9.7
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9eQAE)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023R9eQAE)

--- a/nebula-logger/core/main/log-management/classes/LogHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogHandler.cls
@@ -29,6 +29,7 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
         this.logs = (List<Log__c>) triggerNew;
         this.loggerScenariosById = queryLoggerScenarios(this.logs);
 
+        this.setHasCommentsField();
         this.setClosedStatusFields();
         // The log OwnerId field should support being manually changed, so only auto-set it on insert
         this.setOwnerId();
@@ -41,6 +42,7 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
         this.logs = (List<Log__c>) triggerNewMap.values();
         this.oldLogsById = (Map<Id, Log__c>) triggerOldMap;
 
+        this.setHasCommentsField();
         this.setClosedStatusFields();
         // Priority logic relies on roll-up fields, so only run on update (after log entries are inserted)
         this.setPriority();
@@ -50,6 +52,12 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
         this.logs = (List<Log__c>) triggerNewMap.values();
 
         this.shareLogsWithLoggingUsers();
+    }
+
+    private void setHasCommentsField() {
+        for (Log__c log : this.logs) {
+            log.HasComments__c = String.isNotBlank(log.Comments__c);
+        }
     }
 
     private void setClosedStatusFields() {

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/HasComments__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/HasComments__c.field-meta.xml
@@ -7,8 +7,8 @@
     <externalId>false</externalId>
     <label>Has Comments</label>
     <securityClassification>Confidential</securityClassification>
-    <trackFeedHistory>true</trackFeedHistory>
-    <trackHistory>true</trackHistory>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
     <type>Checkbox</type>
 </CustomField>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/HasComments__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/HasComments__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HasComments__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Has Comments</label>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>true</trackFeedHistory>
+    <trackHistory>true</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -786,6 +786,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.HasComments__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.ImpersonatedByUsernameLink__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -710,6 +710,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.HasComments__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.ImpersonatedByUsernameLink__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.9.6';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.9.7';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final Set<String> IGNORED_APEX_CLASSES = initializeIgnoredApexClasses();
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();

--- a/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls
@@ -74,14 +74,13 @@ private class LogHandler_Tests {
     @IsTest
     static void it_should_set_hasComments_field_on_update_when_comments_field_is_null() {
         setupConfigurations();
-        setupConfigurations();
         String exampleComment = 'some comment';
         Log__c log = new Log__c(Comments__c = exampleComment, TransactionId__c = '1234');
         LoggerDataStore.getDatabase().insertRecord(log);
         log = [SELECT Id, Comments__c, HasComments__c FROM Log__c WHERE Id = :log.Id];
         System.Assert.areEqual(exampleComment, log.Comments__c);
         System.Assert.isTrue(log.HasComments__c);
-        log.Comments__c = exampleComment;
+        log.Comments__c = null;
 
         LoggerDataStore.getDatabase().updateRecord(log);
 

--- a/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls
@@ -37,6 +37,88 @@ private class LogHandler_Tests {
     }
 
     @IsTest
+    static void it_should_set_hasComments_field_on_insert_when_comments_field_is_null() {
+        setupConfigurations();
+        Log__c log = new Log__c(Comments__c = null, TransactionId__c = '1234');
+
+        LoggerDataStore.getDatabase().insertRecord(log);
+
+        System.Assert.areEqual(
+            2,
+            LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
+            'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
+        );
+        log = [SELECT Id, Comments__c, HasComments__c FROM Log__c WHERE Id = :log.Id];
+        System.Assert.isNull(log.Comments__c);
+        System.Assert.isFalse(log.HasComments__c);
+    }
+
+    @IsTest
+    static void it_should_set_hasComments_field_on_insert_when_comments_field_is_not_null() {
+        setupConfigurations();
+        String exampleComment = 'some comment';
+        Log__c log = new Log__c(Comments__c = exampleComment, TransactionId__c = '1234');
+
+        LoggerDataStore.getDatabase().insertRecord(log);
+
+        System.Assert.areEqual(
+            2,
+            LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
+            'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
+        );
+        log = [SELECT Id, Comments__c, HasComments__c FROM Log__c WHERE Id = :log.Id];
+        System.Assert.areEqual(exampleComment, log.Comments__c);
+        System.Assert.isTrue(log.HasComments__c);
+    }
+
+    @IsTest
+    static void it_should_set_hasComments_field_on_update_when_comments_field_is_null() {
+        setupConfigurations();
+        setupConfigurations();
+        String exampleComment = 'some comment';
+        Log__c log = new Log__c(Comments__c = exampleComment, TransactionId__c = '1234');
+        LoggerDataStore.getDatabase().insertRecord(log);
+        log = [SELECT Id, Comments__c, HasComments__c FROM Log__c WHERE Id = :log.Id];
+        System.Assert.areEqual(exampleComment, log.Comments__c);
+        System.Assert.isTrue(log.HasComments__c);
+        log.Comments__c = exampleComment;
+
+        LoggerDataStore.getDatabase().updateRecord(log);
+
+        System.Assert.areEqual(
+            4,
+            LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
+            'Handler class should have executed four times - once for BEFORE_INSERT, AFTER_INSERT, BEFORE_UPDATE, and AFTER_UPDATE'
+        );
+        log = [SELECT Id, Comments__c, HasComments__c FROM Log__c WHERE Id = :log.Id];
+        System.Assert.isNull(log.Comments__c);
+        System.Assert.isFalse(log.HasComments__c);
+    }
+
+    @IsTest
+    static void it_should_set_hasComments_field_on_update_when_comments_field_is_not_null() {
+        setupConfigurations();
+        Log__c log = new Log__c(Comments__c = null, TransactionId__c = '1234');
+        LoggerDataStore.getDatabase().insertRecord(log);
+        log = [SELECT Id, Comments__c, HasComments__c FROM Log__c WHERE Id = :log.Id];
+        System.Assert.isNull(log.Comments__c);
+        System.Assert.isFalse(log.HasComments__c);
+        String exampleComment = 'some comment';
+        log.Comments__c = exampleComment;
+
+        LoggerDataStore.getDatabase().updateRecord(log);
+
+        System.Assert.areEqual(
+            4,
+            LoggerSObjectHandler.getExecutedHandlers().get(Schema.Log__c.SObjectType).size(),
+            'Handler class should have executed four times - once for BEFORE_INSERT, AFTER_INSERT, BEFORE_UPDATE, and AFTER_UPDATE'
+        );
+        log = [SELECT Id, Comments__c, HasComments__c FROM Log__c WHERE Id = :log.Id];
+        System.Assert.areEqual(exampleComment, log.Comments__c);
+        System.Assert.isTrue(log.HasComments__c);
+    }
+
+    @IsTest
     static void it_should_clear_closed_status_fields_when_open() {
         setupConfigurations();
         Log__c log = new Log__c(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.9.6",
+    "version": "4.9.7",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -14,9 +14,9 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.9.6.NEXT",
-            "versionName": "Environment-Aware Default Field Values For Logger Settings",
-            "versionDescription": "Added new CMDT record LoggerParameter.PlatformCachePartitionName to control which platform cache partition is used for caching",
+            "versionNumber": "4.9.7.NEXT",
+            "versionName": "New Log Field HasComments",
+            "versionDescription": "Added new field Log__c.HasComments__c to make it easier to filter on Log__c records that have a value populated in the long textarea field Log__c.Comments__c",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -150,6 +150,7 @@
         "Nebula Logger - Core@4.9.4-new-indicator-icons": "04t5Y0000023R8WQAU",
         "Nebula Logger - Core@4.9.5-configurable-platform-cache-partition-name": "04t5Y0000023R9KQAU",
         "Nebula Logger - Core@4.9.6-environment-aware-default-field-values-for-logger-settings": "04t5Y0000023R9eQAE",
+        "Nebula Logger - Core@4.9.7-new-log-field-hascomments": "04t5Y0000023R9yQAE",
         "Nebula Logger - Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
Since the field `Log__c.Comments__c` is a long textarea field, it can't be filter in SOQL, list views, etc. which makes it very difficult to find log records where someone has entered comments.

To help identify `Log__c` records that have a value populated `Log__c.Comments__c`, the new Boolean field `Log__c.HasComments__c` can be used for filtering - it's now set `BEFORE_INSERT` and `BEFORE_UPDATE` via the class `LogHandler`