### PR TITLE
Customized search layout fields for all custom objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.9.9
+## Unlocked Package - v4.9.10
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023RBpQAM)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023RBpQAM)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.9.10
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023RBpQAM)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023RBpQAM)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015mv8QAA)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015mv8QAA)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
 ## Managed Package - v4.9.0

--- a/nebula-logger/core/main/log-management/objects/LogEntryTag__c/LogEntryTag__c.object-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntryTag__c/LogEntryTag__c.object-meta.xml
@@ -149,6 +149,8 @@
     <allowInChatterGroups>true</allowInChatterGroups>
     <compactLayoutAssignment>SYSTEM</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
+    <description
+    >Used by Nebula Logger as a junction object to represent a unique relationship between a LogEntry__c record and a LoggerTag__c record</description>
     <enableActivities>true</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>true</enableFeeds>
@@ -172,8 +174,8 @@
         <customTabListAdditionalFields>LogEntry__c</customTabListAdditionalFields>
         <customTabListAdditionalFields>Tag__c</customTabListAdditionalFields>
         <excludedStandardButtons>Accept</excludedStandardButtons>
-        <excludedStandardButtons>Import</excludedStandardButtons>
         <excludedStandardButtons>PrintableListView</excludedStandardButtons>
+        <excludedStandardButtons>Import</excludedStandardButtons>
         <lookupDialogsAdditionalFields>LogEntry__c</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>Tag__c</lookupDialogsAdditionalFields>
         <lookupPhoneDialogsAdditionalFields>LogEntry__c</lookupPhoneDialogsAdditionalFields>
@@ -181,6 +183,12 @@
         <searchFilterFields>NAME</searchFilterFields>
         <searchFilterFields>LogEntry__c</searchFilterFields>
         <searchFilterFields>Tag__c</searchFilterFields>
+        <searchResultsAdditionalFields>LoggedByUsernameLink__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>LogLink__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>LogEntryTimestamp__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>LogEntry__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>LogEntryOrigin__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>Tag__c</searchResultsAdditionalFields>
     </searchLayouts>
     <sharingModel>ControlledByParent</sharingModel>
     <visibility>Public</visibility>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/LogEntry__c.object-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/LogEntry__c.object-meta.xml
@@ -149,6 +149,8 @@
     <allowInChatterGroups>true</allowInChatterGroups>
     <compactLayoutAssignment>LogEntryCompactLayout</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
+    <description
+    >Used by Nebula Logger to represent a single log message within a transaction - log entries can be generated via Apex, Flow, Process Builder, Lighting Web Components, and Aura Components.</description>
     <enableActivities>true</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>true</enableFeeds>
@@ -169,10 +171,10 @@
     <searchLayouts>
         <excludedStandardButtons>New</excludedStandardButtons>
         <excludedStandardButtons>Accept</excludedStandardButtons>
-        <excludedStandardButtons>PrintableListView</excludedStandardButtons>
+        <excludedStandardButtons>ChangeOwner</excludedStandardButtons>
         <excludedStandardButtons>Import</excludedStandardButtons>
         <excludedStandardButtons>MassChangeOwner</excludedStandardButtons>
-        <excludedStandardButtons>ChangeOwner</excludedStandardButtons>
+        <excludedStandardButtons>PrintableListView</excludedStandardButtons>
         <lookupDialogsAdditionalFields>Log__c</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>Timestamp__c</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>LoggingLevelWithImage__c</lookupDialogsAdditionalFields>
@@ -181,6 +183,13 @@
         <lookupPhoneDialogsAdditionalFields>Timestamp__c</lookupPhoneDialogsAdditionalFields>
         <lookupPhoneDialogsAdditionalFields>LoggingLevelWithImage__c</lookupPhoneDialogsAdditionalFields>
         <lookupPhoneDialogsAdditionalFields>Message__c</lookupPhoneDialogsAdditionalFields>
+        <searchResultsAdditionalFields>LoggedByUsernameLink__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>Timestamp__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>Log__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>LoggingLevelWithImage__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>Message__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>OriginType__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>OriginLocation__c</searchResultsAdditionalFields>
     </searchLayouts>
     <sharingModel>ControlledByParent</sharingModel>
     <visibility>Public</visibility>

--- a/nebula-logger/core/main/log-management/objects/Log__c/Log__c.object-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/Log__c.object-meta.xml
@@ -149,6 +149,7 @@
     <allowInChatterGroups>true</allowInChatterGroups>
     <compactLayoutAssignment>LogCompactLayout</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
+    <description>Used by Nebula Logger to unify all log entries generated in a single transaction</description>
     <enableActivities>true</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>true</enableFeeds>

--- a/nebula-logger/core/main/log-management/objects/LoggerScenario__c/LoggerScenario__c.object-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LoggerScenario__c/LoggerScenario__c.object-meta.xml
@@ -149,6 +149,8 @@
     <allowInChatterGroups>true</allowInChatterGroups>
     <compactLayoutAssignment>LoggerScenarioCompactLayout</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
+    <description
+    >Used by Nebula Logger to store unique scenarios (text/String) that can be used to identify Log__c and LogEntry__c records via the lookup fields Log__c.TransactionScenario__c and LogEntry__c.EntryScenario__c</description>
     <enableActivities>true</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>true</enableFeeds>
@@ -169,8 +171,8 @@
     <pluralLabel>Logger Scenarios</pluralLabel>
     <searchLayouts>
         <excludedStandardButtons>Accept</excludedStandardButtons>
-        <excludedStandardButtons>PrintableListView</excludedStandardButtons>
         <excludedStandardButtons>Import</excludedStandardButtons>
+        <excludedStandardButtons>PrintableListView</excludedStandardButtons>
         <searchResultsAdditionalFields>UniqueId__c</searchResultsAdditionalFields>
         <searchResultsAdditionalFields>OWNER.ALIAS</searchResultsAdditionalFields>
         <searchResultsAdditionalFields>CREATED_DATE</searchResultsAdditionalFields>

--- a/nebula-logger/core/main/log-management/objects/LoggerTag__c/LoggerTag__c.object-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LoggerTag__c/LoggerTag__c.object-meta.xml
@@ -149,7 +149,8 @@
     <allowInChatterGroups>true</allowInChatterGroups>
     <compactLayoutAssignment>LoggerTagCompactLayout</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
-    <description>Custom tags used by Logger for tagging Log__c and LogEntry__c records</description>
+    <description
+    >Used by Nebula Logger for storing unique tags (text/String) that can be associated with LogEntry__c records via the junction object LogEntryTag__c</description>
     <enableActivities>true</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>true</enableFeeds>
@@ -172,8 +173,8 @@
         <customTabListAdditionalFields>OWNER.ALIAS</customTabListAdditionalFields>
         <customTabListAdditionalFields>TotalLogEntries__c</customTabListAdditionalFields>
         <excludedStandardButtons>Accept</excludedStandardButtons>
-        <excludedStandardButtons>Import</excludedStandardButtons>
         <excludedStandardButtons>PrintableListView</excludedStandardButtons>
+        <excludedStandardButtons>Import</excludedStandardButtons>
         <lookupDialogsAdditionalFields>OWNER.ALIAS</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>TotalLogEntries__c</lookupDialogsAdditionalFields>
         <lookupPhoneDialogsAdditionalFields>OWNER.ALIAS</lookupPhoneDialogsAdditionalFields>
@@ -181,6 +182,11 @@
         <searchFilterFields>NAME</searchFilterFields>
         <searchFilterFields>OWNER.ALIAS</searchFilterFields>
         <searchFilterFields>TotalLogEntries__c</searchFilterFields>
+        <searchResultsAdditionalFields>TotalLogEntries__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>UniqueId__c</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>OWNER.ALIAS</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>CREATED_DATE</searchResultsAdditionalFields>
+        <searchResultsAdditionalFields>LAST_UPDATE</searchResultsAdditionalFields>
     </searchLayouts>
     <sharingModel>Read</sharingModel>
     <visibility>Public</visibility>

--- a/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
@@ -331,7 +331,7 @@ private class LoggerSettingsController_Tests {
     @IsTest
     static void it_should_return_user_search_results_list_when_matches_found() {
         // Using lastName (required field) instead of the optional field firstName
-        String searchTerm = '%' + System.UserInfo.getLastName() + '%'; 
+        String searchTerm = '%' + System.UserInfo.getLastName() + '%';
         Map<Id, User> expectedResultsById = new Map<Id, User>(
             [SELECT Id, Name, Username, SmallPhotoUrl FROM User WHERE Name LIKE :searchTerm OR Username LIKE :searchTerm]
         );

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -44,7 +44,7 @@ private class Logger_Tests {
     }
 
     @IsTest
-    static void it_should_settings_default_field_values_when_organization_is_a_sandbox() {
+    static void it_should_properly_set_default_field_values_for_settings_when_organization_is_a_sandbox() {
         Organization mockOrganization = (Schema.Organization) LoggerMockDataCreator.setReadOnlyField(new Organization(), Schema.Organization.IsSandbox, true);
         System.Assert.isTrue(mockOrganization.IsSandbox);
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
@@ -65,7 +65,7 @@ private class Logger_Tests {
     }
 
     @IsTest
-    static void it_should_settings_default_field_values_when_organization_is_not_a_sandbox() {
+    static void it_should_properly_set_default_field_values_for_settings_when_organization_is_not_a_sandbox() {
         Organization mockOrganization = (Schema.Organization) LoggerMockDataCreator.setReadOnlyField(new Organization(), Schema.Organization.IsSandbox, false);
         System.Assert.isFalse(mockOrganization.IsSandbox);
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
@@ -86,7 +86,7 @@ private class Logger_Tests {
     }
 
     @IsTest
-    static void it_should_settings_default_field_values_when_querying_organization_synchronously_is_disabled() {
+    static void it_should_properly_set_default_field_values_for_settings_when_querying_organization_synchronously_is_disabled() {
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryOrganizationDataSynchronously', Value__c = String.valueOf(false)));
         System.Assert.isFalse(LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY);
         LoggerSettings__c expectedSettings = (LoggerSettings__c) LoggerSettings__c.SObjectType.newSObject(null, true);
@@ -97,6 +97,7 @@ private class Logger_Tests {
 
         LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
+        System.Assert.areEqual(0, System.Limits.getQueries());
         System.Assert.areEqual(expectedSettings, returnedSettings);
         System.Assert.isNull(returnedSettings.Id);
         List<LoggerSettings__c> existingSettings = [SELECT Id FROM LoggerSettings__c];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.9.9",
+    "version": "4.9.10",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -153,6 +153,7 @@
         "Nebula Logger - Core@4.9.7-new-log-field-hascomments": "04t5Y0000023R9yQAE",
         "Nebula Logger - Core@4.9.8-test-coverage-improvements": "04t5Y0000023RBBQA2",
         "Nebula Logger - Core@4.9.9-scenario-and-tag-storage-configurations": "04t5Y0000023RBpQAM",
+        "Nebula Logger - Core@4.9.10-added-search-result-fields-for-all-custom-objects": "04t5Y0000015mv8QAA",
         "Nebula Logger - Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -14,9 +14,9 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.9.9.NEXT",
-            "versionName": "Scenario and Tag Storage Configurations",
-            "versionDescription": "Added new CMDT records LoggerParameter__mdt.NormalizeScenarioData and LoggerParameter__mdt.NormalizeTagData to control if scenarios & tags are stored in custom objects (default) or text fields (denormalized data)",
+            "versionNumber": "4.9.10.NEXT",
+            "versionName": "Added search result fields for all custom objects",
+            "versionDescription": "Added meaningful fields to each of the included objects' search results layouts - previously, several objects were only showing the Name field. Descriptions have also been added to all custom objects.",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"


### PR DESCRIPTION
### Core Unlocked Package Changes
- Closed #443 (reported by @solo-1234) by updating all custom objects to have relevant fields on the search results layouts
  - `Log__c` search results now display the fields `Name`, `LoggedByUsernameLink__c`, `StartTime__c`, `OWNER`, `Priority__c`, `Status__c`, `TransactionId__c`, `TotalLogEntries__c`, `TotalERRORLogEntries__c`, `TotalWARNLogEntries__c`
  
  ![image](https://user-images.githubusercontent.com/1267157/214132868-d6e97780-9f29-46b0-b00b-5fbc922043e4.png)

  - `LogEntry__c` search results now display the fields `Name`, `LoggedByUsernameLink__c`, `Timestamp__c`, `Log__c`, `LoggingLevelWithImage__c`, `Message__c`, `OriginType__c`, `OriginLocation__c`
    
    ![image](https://user-images.githubusercontent.com/1267157/214132410-8958e676-6f75-408b-87be-362155400023.png)
    
  - `LogEntryTag__c` search results now display the fields `Name`, `LoggedByUsernameLink__c`, `LogLink__c`, `LogEntryTimestamp__c`, `LogEntry__c`, `LogEntryOrigin__c`, `Tag__c`
  
    ![image](https://user-images.githubusercontent.com/1267157/214133190-a032b579-6066-40ea-b5e1-669552481a64.png)

  - `LoggerTag__c` search results now display the fields `Name`, `TotalLogEntries__c`, `UniqueId__c`, `OWNER`, `CREATED_DATE`, `LAST_UPDATE`
  
    ![image](https://user-images.githubusercontent.com/1267157/214133690-12dc6780-fdca-426f-818a-f0172ca98acc.png)

  - `LoggerScenario__c` search results now display the fields `Name`, `UniqueId__c`, `OWNER`, `CREATED_DATE`, `LAST_UPDATE`
  
    ![image](https://user-images.githubusercontent.com/1267157/214135129-5627daaa-43d4-4fa8-bbd0-83aaeaeed70e.png)

- Also added descriptions to all of the custom objects

  ![image](https://user-images.githubusercontent.com/1267157/214132984-94c19ee8-57b6-4009-9dad-4c65b4665711.png)