### PR TITLE
Summer '23 Release (API v58.0) - v4.11.0

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -4,6 +4,7 @@
 
 nebula-logger/managed-package/sfdx-project.json
 nebula-logger/managed-package/**/*.animationRule-meta.xml
+nebula-logger/managed-package/**/*.indx-meta.xml
 nebula-logger/managed-package/**/*.testSuite-meta.xml
 /**/Admin.profile-meta.xml
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -362,7 +362,7 @@ jobs:
                   npx sfdx bummer:package:aliases:sort
                   npx prettier --write ./sfdx-project.json
                   git add ./sfdx-project.json
-                  git commit -m "Created new package version"
+                  git commit -m "Created new core unlocked package version"
                   git push
 
     promote-package-versions:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.10.6
+## Unlocked Package - v4.11.0
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SCqQAM)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SCqQAM)

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.11.0
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SDUQA2)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SDUQA2)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SI6QAM)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SI6QAM)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sfdx package install --wait 20 --security-type AdminsOnly --package 04t5Y0000023SDUQA2`
+`sfdx package install --wait 20 --security-type AdminsOnly --package 04t5Y0000023SI6QAM`
 
 ## Managed Package - v4.10.0
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,21 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SI6QAM)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sfdx package install --wait 20 --security-type AdminsOnly --package 04t5Y0000023SI6QAM`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000023SI6QAM`
 
-## Managed Package - v4.10.0
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000023SI6QAM`
 
-[![Install Managed Package in a Sandbox](./images/btn-install-managed-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?mgd=true&p0=04t5Y0000015nWeQAI)
-[![Install Managed Package in Production](./images/btn-install-managed-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?mgd=true&p0=04t5Y0000015nWeQAI)
-[![View Milestone](./images/btn-view-managed-package-milestone.png)](https://github.com/jongpie/NebulaLogger/milestone/10?closed=1)
+---
 
-`sfdx package install --wait 30 --security-type AdminsOnly --package 04t5Y0000015nWeQAI`
+## Managed Package - v4.11.0
+
+[![Install Managed Package in a Sandbox](./images/btn-install-managed-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?mgd=true&p0=04t5Y0000023SI1QAM)
+[![Install Managed Package in Production](./images/btn-install-managed-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?mgd=true&p0=04t5Y0000023SI1QAM)
+[![View Milestone](./images/btn-view-managed-package-milestone.png)](https://github.com/jongpie/NebulaLogger/milestone/11?closed=1)
+
+`sf package install --wait 30 --security-type AdminsOnly --package 04t5Y0000023SI1QAM`
+
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000023SI1QAM`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.11.0
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SCqQAM)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SCqQAM)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SDUQA2)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000023SDUQA2)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sfdx package install --wait 20 --security-type AdminsOnly --package 04t5Y0000023SCqQAM`
+`sfdx package install --wait 20 --security-type AdminsOnly --package 04t5Y0000023SDUQA2`
 
 ## Managed Package - v4.10.0
 

--- a/config/experience-cloud/classes/ChangePasswordController.cls-meta.xml
+++ b/config/experience-cloud/classes/ChangePasswordController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/config/experience-cloud/classes/ChangePasswordControllerTest.cls-meta.xml
+++ b/config/experience-cloud/classes/ChangePasswordControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/config/experience-cloud/classes/ForgotPasswordController.cls-meta.xml
+++ b/config/experience-cloud/classes/ForgotPasswordController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/config/experience-cloud/classes/ForgotPasswordControllerTest.cls-meta.xml
+++ b/config/experience-cloud/classes/ForgotPasswordControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/config/experience-cloud/classes/MicrobatchSelfRegController.cls-meta.xml
+++ b/config/experience-cloud/classes/MicrobatchSelfRegController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/config/experience-cloud/classes/MicrobatchSelfRegControllerTest.cls-meta.xml
+++ b/config/experience-cloud/classes/MicrobatchSelfRegControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/config/experience-cloud/classes/MyProfilePageController.cls-meta.xml
+++ b/config/experience-cloud/classes/MyProfilePageController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/config/experience-cloud/classes/MyProfilePageControllerTest.cls-meta.xml
+++ b/config/experience-cloud/classes/MyProfilePageControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/config/experience-cloud/classes/SiteLoginController.cls-meta.xml
+++ b/config/experience-cloud/classes/SiteLoginController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/config/experience-cloud/classes/SiteLoginControllerTest.cls-meta.xml
+++ b/config/experience-cloud/classes/SiteLoginControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/config/experience-cloud/classes/SiteRegisterController.cls-meta.xml
+++ b/config/experience-cloud/classes/SiteRegisterController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/config/experience-cloud/classes/SiteRegisterControllerTest.cls-meta.xml
+++ b/config/experience-cloud/classes/SiteRegisterControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/config/experience-cloud/pages/BandwidthExceeded.page-meta.xml
+++ b/config/experience-cloud/pages/BandwidthExceeded.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <description>Página predeterminada de límite superado de Plataforma Lightning</description>

--- a/config/experience-cloud/pages/ChangePassword.page-meta.xml
+++ b/config/experience-cloud/pages/ChangePassword.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <description>Página de cambio de contraseña predeterminada de Sitios de Salesforce</description>

--- a/config/experience-cloud/pages/CommunitiesLanding.page-meta.xml
+++ b/config/experience-cloud/pages/CommunitiesLanding.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <description>Página de inicio de experiencias predeterminadas</description>

--- a/config/experience-cloud/pages/CommunitiesLogin.page-meta.xml
+++ b/config/experience-cloud/pages/CommunitiesLogin.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <description>Página de inicio de sesión para experiencias predeterminadas</description>

--- a/config/experience-cloud/pages/CommunitiesSelfReg.page-meta.xml
+++ b/config/experience-cloud/pages/CommunitiesSelfReg.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <description>Página de inscripción automática de experiencias predeterminadas</description>

--- a/config/experience-cloud/pages/CommunitiesSelfRegConfirm.page-meta.xml
+++ b/config/experience-cloud/pages/CommunitiesSelfRegConfirm.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <description>Página de confirmación de registro de experiencias predeterminadas</description>

--- a/config/experience-cloud/pages/Exception.page-meta.xml
+++ b/config/experience-cloud/pages/Exception.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <description>Página predeterminada de Plataforma Lightning para errores post-autenticación</description>

--- a/config/experience-cloud/pages/FileNotFound.page-meta.xml
+++ b/config/experience-cloud/pages/FileNotFound.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <description>Página predeterminada de página/datos no encontrados de Plataforma Lightning</description>

--- a/config/experience-cloud/pages/ForgotPasswordConfirm.page-meta.xml
+++ b/config/experience-cloud/pages/ForgotPasswordConfirm.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <description>Página Contraseña olvidada predeterminada de Sitios de Salesforce</description>

--- a/config/experience-cloud/pages/InMaintenance.page-meta.xml
+++ b/config/experience-cloud/pages/InMaintenance.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <description>Página predeterminada de Plataforma Lightning en mantenimiento</description>

--- a/config/experience-cloud/pages/SiteRegisterConfirm.page-meta.xml
+++ b/config/experience-cloud/pages/SiteRegisterConfirm.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <description>Página Confirmación de registro de usuario predeterminada de Sitios de Salesforce</description>

--- a/config/linters/lint-staged.config.js
+++ b/config/linters/lint-staged.config.js
@@ -4,7 +4,9 @@ module.exports = {
     },
     '*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}': filenames => filenames.map(filename => `prettier --write '${filename}'`),
     '**/lwc/**': filenames => {
-        return [`eslint --config ./config/linters/.eslintrc.json ${filenames.join(' ')} --fix`, `npm run test:lwc`];
+        return [`eslint --config ./config/linters/.eslintrc.json ${filenames.join(' ')} --fix`];
+        // FIXME this command should only run tests for the changed LWCs (instead of running tests for all LWCs)
+        // return [`eslint --config ./config/linters/.eslintrc.json ${filenames.join(' ')} --fix`, `npm run test:lwc`];
     }
     // FIXME this command should only scan the changed Apex files (instead of scanning all Apex files)
     // '*.{cls,trigger}': () => {

--- a/config/linters/lint-staged.config.js
+++ b/config/linters/lint-staged.config.js
@@ -2,7 +2,7 @@ module.exports = {
     'sfdx-project.json': () => {
         return `npm run package:version:number:fix`;
     },
-    '*.{cls,cmp,component,css,html,js,json,md,page,trigger,yaml,yml}': filenames => filenames.map(filename => `prettier --write '${filename}'`),
+    '*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}': filenames => filenames.map(filename => `prettier --write '${filename}'`),
     '**/lwc/**': filenames => {
         return [`eslint --config ./config/linters/.eslintrc.json ${filenames.join(' ')} --fix`, `npm run test:lwc`];
     }

--- a/docs/apex/Configuration/LoggerParameter.md
+++ b/docs/apex/Configuration/LoggerParameter.md
@@ -14,6 +14,10 @@ Provides a centralized way to load parameters for SObject handlers &amp; plugins
 
 Indicates if Nebula Logger will make an async callout to `https://api.status.salesforce.com` to get additional details about the current org, which is then stored on the Log\_\_c record. Controlled by the custom metadata record `LoggerParameter.CallStatusApi`, or `false` as the default
 
+#### `ENABLE_LOG_ENTRY_EVENT_STREAM` → `Boolean`
+
+Indicates if Nebula Logger&apos;s LWC `logEntryEventStream` is enabled. The component uses the Emp API, which counts towards orgs&apos; daily delivery allocations for platform events. To help reduce usage of the daily allocation limit, orgs can disable the LWC. Controlled by the custom metadata record `LoggerParameter.EnableLogEntryEventStream`, or `true` as the default
+
 #### `ENABLE_STACK_TRACE_PARSING` → `Boolean`
 
 Indicates if Nebula Logger will parse a stack trace for each log entry, which is then used to populate fields like `LogEntry__c.StackTrace__c` and `LogEntry__c.OriginLocation__c`. Controlled by the custom metadata record `LoggerParameter.EnableStackTraceParsing`, or `true` as the default

--- a/docs/apex/Configuration/LoggerPlugin.md
+++ b/docs/apex/Configuration/LoggerPlugin.md
@@ -41,6 +41,20 @@ List&lt;LoggerPlugin_t&gt;
 
 The list of matching `LoggerPlugin_t` records
 
+#### `getPluginConfigurations()` → `List<LoggerPlugin_t>`
+
+Returns all enabled `LoggerPlugin_t` records, based on `IsEnabled__c == true`
+
+##### Return
+
+**Type**
+
+List&lt;LoggerPlugin_t&gt;
+
+**Description**
+
+The list of enabled `LoggerPlugin_t` records
+
 #### `newBatchableInstance(String apexClassTypeName)` → `Batchable`
 
 Creates an instance of the class `LoggerPlugin.Batchable` based on the provided `LoggerPlugin_t` configuration

--- a/docs/apex/Log-Management/LogEntryEventStreamController.md
+++ b/docs/apex/Log-Management/LogEntryEventStreamController.md
@@ -24,4 +24,18 @@ List&lt;String&gt;
 
 The instance of `List&lt;String&gt;`, containing the list of columns to be displayed in
 
+#### `isEnabled()` → `Boolean`
+
+Indicates if the LWC `logEntryEventStream` has been enabled (default) or disabled
+
+##### Return
+
+**Type**
+
+Boolean
+
+**Description**
+
+The `Boolean` value of the `LoggerParameter_t` record `LoggerParameter.EnableLogEntryEventStream`
+
 ---

--- a/docs/apex/Log-Management/LoggerHomeHeaderController.md
+++ b/docs/apex/Log-Management/LoggerHomeHeaderController.md
@@ -44,8 +44,6 @@ An instance of `LoggerHomeHeaderController.Environment`
 
 ###### `organizationDomainUrl` → `String`
 
-###### `organizationEnvironment` → `String`
-
 ###### `organizationFormattedCreatedDate` → `String`
 
 ###### `organizationId` → `String`
@@ -63,8 +61,6 @@ An instance of `LoggerHomeHeaderController.Environment`
 ###### `organizationReleaseNumber` → `String`
 
 ###### `organizationReleaseVersion` → `String`
-
-###### `organizationStatus` → `String`
 
 ###### `organizationType` → `String`
 

--- a/docs/apex/Log-Management/LoggerHomeHeaderController.md
+++ b/docs/apex/Log-Management/LoggerHomeHeaderController.md
@@ -34,6 +34,10 @@ An instance of `LoggerHomeHeaderController.Environment`
 
 ##### Properties
 
+###### `loggerEnabledPlugins` → `String`
+
+###### `loggerEnabledPluginsCount` → `Integer`
+
 ###### `loggerNamespacePrefix` → `String`
 
 ###### `loggerVersionNumber` → `String`

--- a/docs/apex/Logger-Engine/Logger.md
+++ b/docs/apex/Logger-Engine/Logger.md
@@ -26,7 +26,7 @@ Enum used to control how LogEntryEvent\_\_e records are inserted
 
 #### `callStatusApi()` → `StatusApiResponse`
 
-**This is only intended to be used internally by Nebula Logger, and is subject to change.** Calls Salesforce&apos;s API endpoint https://api.status.salesforce.com/v1/instances/ to get more details about the current org, including the org&apos;s release number and release version
+**This is only intended to be used internally by Nebula Logger, and is subject to change.** Calls Salesforce&apos;s API endpoint https://api.status.salesforce.com/v1/instances/ to get more details about the current org, including the org&apos;s release number and release version. Trust API docs available at https://api.status.salesforce.com/v1/docs/
 
 ##### Return
 

--- a/nebula-logger/core/main/configuration/classes/LoggerBatchableContext.cls-meta.xml
+++ b/nebula-logger/core/main/configuration/classes/LoggerBatchableContext.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/configuration/classes/LoggerCache.cls-meta.xml
+++ b/nebula-logger/core/main/configuration/classes/LoggerCache.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
@@ -31,9 +31,11 @@ public class LoggerParameter {
     }
 
     /**
-     * @description Indicates if Nebula Logger will parse a stack trace for each log entry, which is then used to populate
-     *              fields like `LogEntry__c.StackTrace__c` and `LogEntry__c.OriginLocation__c`.
-     *              Controlled by the custom metadata record `LoggerParameter.EnableStackTraceParsing`, or `true` as the default
+     * @description Indicates if Nebula Logger's LWC `logEntryEventStream` is enabled. The component uses
+     *              the Emp API, which counts towards orgs' daily delivery allocations for platform events.
+     *              To help reduce usage of the daily allocation limit, orgs can disable the LWC.
+     *              Controlled by the custom metadata record `LoggerParameter.EnableLogEntryEventStream`,
+     *              or `true` as the default
      */
     public static final Boolean ENABLE_LOG_ENTRY_EVENT_STREAM {
         get {

--- a/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
@@ -35,6 +35,21 @@ public class LoggerParameter {
      *              fields like `LogEntry__c.StackTrace__c` and `LogEntry__c.OriginLocation__c`.
      *              Controlled by the custom metadata record `LoggerParameter.EnableStackTraceParsing`, or `true` as the default
      */
+    public static final Boolean ENABLE_LOG_ENTRY_EVENT_STREAM {
+        get {
+            if (ENABLE_LOG_ENTRY_EVENT_STREAM == null) {
+                ENABLE_LOG_ENTRY_EVENT_STREAM = getBoolean('EnableLogEntryEventStream', true);
+            }
+            return ENABLE_LOG_ENTRY_EVENT_STREAM;
+        }
+        private set;
+    }
+
+    /**
+     * @description Indicates if Nebula Logger will parse a stack trace for each log entry, which is then used to populate
+     *              fields like `LogEntry__c.StackTrace__c` and `LogEntry__c.OriginLocation__c`.
+     *              Controlled by the custom metadata record `LoggerParameter.EnableStackTraceParsing`, or `true` as the default
+     */
     public static final Boolean ENABLE_STACK_TRACE_PARSING {
         get {
             if (ENABLE_STACK_TRACE_PARSING == null) {

--- a/nebula-logger/core/main/configuration/classes/LoggerParameter.cls-meta.xml
+++ b/nebula-logger/core/main/configuration/classes/LoggerParameter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/configuration/classes/LoggerPlugin.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerPlugin.cls
@@ -9,7 +9,7 @@
  *              based on configurations stored in the custom metadata type `LoggerPlugin__mdt`
  */
 public without sharing class LoggerPlugin {
-    private static final Map<String, LoggerPlugin__mdt> DEVELOPER_NAME_TO_RECORD = loadRecords();
+    private static final Map<String, LoggerPlugin__mdt> DEVELOPER_NAME_TO_RECORD = loadEnabledRecords();
 
     /**
      * @description Interface used to create plugins that can be used within Logger's batch job `LogBatchPurger`
@@ -27,6 +27,14 @@ public without sharing class LoggerPlugin {
     @SuppressWarnings('PMD.ApexDoc')
     public interface Triggerable {
         void execute(LoggerPlugin__mdt configuration, LoggerTriggerableContext input);
+    }
+
+    /**
+     * @description Returns all enabled `LoggerPlugin__mdt` records, based on `IsEnabled__c == true`
+     * @return      The list of enabled `LoggerPlugin__mdt` records
+     */
+    public static List<LoggerPlugin__mdt> getPluginConfigurations() {
+        return DEVELOPER_NAME_TO_RECORD.values();
     }
 
     /**
@@ -94,12 +102,17 @@ public without sharing class LoggerPlugin {
         return System.Type.forName(apexClassTypeName)?.newInstance();
     }
 
-    private static Map<String, LoggerPlugin__mdt> loadRecords() {
-        Map<String, LoggerPlugin__mdt> pluginConfigurations = LoggerPlugin__mdt.getAll().clone();
-        if (System.Test.isRunningTest() == true) {
-            pluginConfigurations.clear();
+    private static Map<String, LoggerPlugin__mdt> loadEnabledRecords() {
+        Map<String, LoggerPlugin__mdt> pluginDeveloperNameToConfiguration = new Map<String, LoggerPlugin__mdt>();
+        for (LoggerPlugin__mdt pluginConfiguration : LoggerPlugin__mdt.getAll().values()) {
+            if (pluginConfiguration.IsEnabled__c == true) {
+                pluginDeveloperNameToConfiguration.put(pluginConfiguration.DeveloperName, pluginConfiguration);
+            }
         }
-        return pluginConfigurations;
+        if (System.Test.isRunningTest() == true) {
+            pluginDeveloperNameToConfiguration.clear();
+        }
+        return pluginDeveloperNameToConfiguration;
     }
 
     @TestVisible

--- a/nebula-logger/core/main/configuration/classes/LoggerPlugin.cls-meta.xml
+++ b/nebula-logger/core/main/configuration/classes/LoggerPlugin.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/configuration/classes/LoggerScenarioRule.cls-meta.xml
+++ b/nebula-logger/core/main/configuration/classes/LoggerScenarioRule.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/configuration/classes/LoggerTriggerableContext.cls-meta.xml
+++ b/nebula-logger/core/main/configuration/classes/LoggerTriggerableContext.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableLogEntryEventStream.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableLogEntryEventStream.md-meta.xml
@@ -8,7 +8,9 @@
     <protected>false</protected>
     <values>
         <field>Description__c</field>
-        <value xsi:type="xsd:string">When set to &apos;true&apos; (default), the LWC logEntryEventStream is enabled &amp; subscribes to LogEntryEvent__e records, using the Emp API. Using the Emp API counts towards your org's event delivery allocations, so the LWC can be disabled if the allocation needs to be conserved. See this page for more details may be generated that contain additional details about the logging system - https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_event_limits.htm</value>
+        <value
+            xsi:type="xsd:string"
+        >When set to &apos;true&apos; (default), the LWC logEntryEventStream is enabled &amp; subscribes to LogEntryEvent__e records, using the Emp API. Using the Emp API counts towards your org's event delivery allocations, so the LWC can be disabled if the allocation needs to be conserved. See this page for more details may be generated that contain additional details about the logging system - https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_event_limits.htm</value>
     </values>
     <values>
         <field>Value__c</field>

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableLogEntryEventStream.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableLogEntryEventStream.md-meta.xml
@@ -14,6 +14,6 @@
     </values>
     <values>
         <field>Value__c</field>
-        <value xsi:type="xsd:string">false</value>
+        <value xsi:type="xsd:string">true</value>
     </values>
 </CustomMetadata>

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableLogEntryEventStream.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableLogEntryEventStream.md-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomMetadata
+    xmlns="http://soap.sforce.com/2006/04/metadata"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+>
+    <label>Enable Log Entry Event Stream</label>
+    <protected>false</protected>
+    <values>
+        <field>Description__c</field>
+        <value xsi:type="xsd:string">When set to &apos;true&apos; (default), the LWC logEntryEventStream is enabled &amp; subscribes to LogEntryEvent__e records, using the Emp API. Using the Emp API counts towards your org's event delivery allocations, so the LWC can be disabled if the allocation needs to be conserved. See this page for more details may be generated that contain additional details about the logging system - https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_event_limits.htm</value>
+    </values>
+    <values>
+        <field>Value__c</field>
+        <value xsi:type="xsd:string">false</value>
+    </values>
+</CustomMetadata>

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultLogOwner__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultLogOwner__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>DefaultLogOwner__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <inlineHelpText
     >Specifies the default owner for new Log__c records. This can be a user ID, a username, a queue ID, or a queue&apos;s developer name.</inlineHelpText>

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultLogPurgeAction__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultLogPurgeAction__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>DefaultLogPurgeAction__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <defaultValue>&apos;Delete&apos;</defaultValue>
     <externalId>false</externalId>
     <inlineHelpText

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultLogShareAccessLevel__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultLogShareAccessLevel__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>DefaultLogShareAccessLevel__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <defaultValue>&apos;Read&apos;</defaultValue>
     <description
     >Uses Apex managed sharing to grants users read or edit access to their log records (on insert only). When no access level is specified, no Apex sharing logic is executed. This only gives record-level access - users will still need to be granted access to the Log__c object using permission sets or profiles.</description>

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultNumberOfDaysToRetainLogs__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultNumberOfDaysToRetainLogs__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>DefaultNumberOfDaysToRetainLogs__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <defaultValue>14</defaultValue>
     <description
     >This value is used to set the field Log__c.LogRetentionDate__c,  which is then used by LogBatchPurger to delete old logs. To keep  logs indefinitely, set this field to blank (null).</description>

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultPlatformEventStorageLocation__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultPlatformEventStorageLocation__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>DefaultPlatformEventStorageLocation__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <defaultValue>&apos;CUSTOM_OBJECTS&apos;</defaultValue>
     <description
     >Defaults to CUSTOM_OBJECTS. This controls the default location where LogEntryEvent__e records are stored - when null, LogEntryEvent__e records will not be stored.</description>

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultSaveMethod__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultSaveMethod__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>DefaultSaveMethod__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <defaultValue>&apos;EVENT_BUS&apos;</defaultValue>
     <description
     >Defaults to EVENT_BUS. This controls the default save method used by Logger when calling saveLog(). In most situations, EVENT_BUS should be used.</description>

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultScenario__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/DefaultScenario__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>DefaultScenario__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <description>Sets a default scenario for the transaction</description>
     <externalId>false</externalId>
     <inlineHelpText>Sets a default scenario for the transaction</inlineHelpText>

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/EndTime__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/EndTime__c.field-meta.xml
@@ -5,5 +5,6 @@
     <inlineHelpText>Optional - when set, the LoggerSettings__c record is only used when EndTime__c &gt;= System.now()</inlineHelpText>
     <label>End Time</label>
     <required>false</required>
+    <trackTrending>false</trackTrending>
     <type>DateTime</type>
 </CustomField>

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsAnonymousModeEnabled__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsAnonymousModeEnabled__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>IsAnonymousModeEnabled__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <defaultValue>false</defaultValue>
     <externalId>false</externalId>
     <inlineHelpText

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsApexSystemDebugLoggingEnabled__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsApexSystemDebugLoggingEnabled__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>IsApexSystemDebugLoggingEnabled__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <defaultValue>true</defaultValue>
     <externalId>false</externalId>
     <inlineHelpText

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsDataMaskingEnabled__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsDataMaskingEnabled__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>IsDataMaskingEnabled__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <defaultValue>true</defaultValue>
     <externalId>false</externalId>
     <inlineHelpText

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsEnabled__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsEnabled__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>IsEnabled__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <defaultValue>true</defaultValue>
     <externalId>false</externalId>
     <inlineHelpText>Controls if Logger is enabled for the specified level (organization, profile, or user)</inlineHelpText>

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsJavaScriptConsoleLoggingEnabled__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsJavaScriptConsoleLoggingEnabled__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>IsJavaScriptConsoleLoggingEnabled__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <defaultValue>true</defaultValue>
     <externalId>false</externalId>
     <inlineHelpText

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsRecordFieldStrippingEnabled__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsRecordFieldStrippingEnabled__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>IsRecordFieldStrippingEnabled__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <defaultValue>false</defaultValue>
     <externalId>false</externalId>
     <inlineHelpText

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsSavingEnabled__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/IsSavingEnabled__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>IsSavingEnabled__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <defaultValue>true</defaultValue>
     <description>Controls if saving is enabled - when disabled, any calls to saveLog() are ignored.</description>
     <externalId>false</externalId>

--- a/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/LoggingLevel__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerSettings__c/fields/LoggingLevel__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggingLevel__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <defaultValue>&apos;FINEST&apos;</defaultValue>
     <externalId>false</externalId>
     <label>Logging Level</label>

--- a/nebula-logger/core/main/log-management/animationRules/LogStatus.animationRule-meta.xml
+++ b/nebula-logger/core/main/log-management/animationRules/LogStatus.animationRule-meta.xml
@@ -3,7 +3,7 @@
     <animationFrequency>always</animationFrequency>
     <developerName>LogStatus</developerName>
     <isActive>true</isActive>
-    <masterLabel>Log Status</masterLabel>
+    <masterLabel>Nebula Logger: Log Status</masterLabel>
     <recordTypeContext>Master</recordTypeContext>
     <recordTypeName>__MASTER__</recordTypeName>
     <sobjectType>Log__c</sobjectType>

--- a/nebula-logger/core/main/log-management/applications/LoggerConsole.app-meta.xml
+++ b/nebula-logger/core/main/log-management/applications/LoggerConsole.app-meta.xml
@@ -26,6 +26,7 @@
     <tabs>LogEntry__c</tabs>
     <tabs>LogEntryTag__c</tabs>
     <tabs>LoggerTag__c</tabs>
+    <tabs>standard-WaveHomeLightning</tabs>
     <tabs>standard-report</tabs>
     <tabs>standard-Dashboard</tabs>
     <uiType>Lightning</uiType>
@@ -50,6 +51,9 @@
         </mappings>
         <mappings>
             <tab>standard-Dashboard</tab>
+        </mappings>
+        <mappings>
+            <tab>standard-WaveHomeLightning</tab>
         </mappings>
         <mappings>
             <tab>standard-home</tab>

--- a/nebula-logger/core/main/log-management/applications/LoggerConsole.app-meta.xml
+++ b/nebula-logger/core/main/log-management/applications/LoggerConsole.app-meta.xml
@@ -26,7 +26,6 @@
     <tabs>LogEntry__c</tabs>
     <tabs>LogEntryTag__c</tabs>
     <tabs>LoggerTag__c</tabs>
-    <tabs>standard-WaveHomeLightning</tabs>
     <tabs>standard-report</tabs>
     <tabs>standard-Dashboard</tabs>
     <uiType>Lightning</uiType>
@@ -51,9 +50,6 @@
         </mappings>
         <mappings>
             <tab>standard-Dashboard</tab>
-        </mappings>
-        <mappings>
-            <tab>standard-WaveHomeLightning</tab>
         </mappings>
         <mappings>
             <tab>standard-home</tab>

--- a/nebula-logger/core/main/log-management/classes/LogBatchPurgeController.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LogBatchPurgeController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LogBatchPurgeScheduler.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LogBatchPurgeScheduler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LogBatchPurger.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LogBatchPurger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventStreamController.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventStreamController.cls
@@ -19,6 +19,16 @@ public with sharing class LogEntryEventStreamController {
         Schema.LogEntryEvent__e.LoggingLevel__c.getDescribe().getLocalName(),
         Schema.LogEntryEvent__e.Message__c.getDescribe().getLocalName()
     };
+
+    /**
+     * @description Indicates if the LWC `logEntryEventStream` has been enabled (default) or disabled
+     * @return   The `Boolean` value of the `LoggerParameter__mdt` record `LoggerParameter.EnableLogEntryEventStream`
+     */
+    @AuraEnabled
+    public static Boolean isEnabled() {
+        return LoggerParameter.ENABLE_LOG_ENTRY_EVENT_STREAM;
+    }
+
     /**
      * @description Returns the list of columns to be displayed in LogEntryEventStream datatable.
      *              The fields are configured in the custom metadata record LoggerParameter__mdt.LogEntryEventStreamDisplayFields.

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventStreamController.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventStreamController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LogEntryFieldSetPicklist.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LogEntryFieldSetPicklist.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LogEntryHandler.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LogEntryHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LogEntryTagHandler.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LogEntryTagHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LogHandler.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LogHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LogManagementDataSelector.cls
+++ b/nebula-logger/core/main/log-management/classes/LogManagementDataSelector.cls
@@ -31,7 +31,7 @@ public without sharing virtual class LogManagementDataSelector {
      * @return             `List<SObject>` containing any records in the specified `SObjectType`
      */
     public virtual List<SObject> getAll(Schema.SObjectType sobjectType, Set<String> fieldNames) {
-        String query = String.format('SELECT {0} FROM {1}', new List<Object>{ String.join(new List<String>(fieldNames), ', '), sobjectType });
+        String query = String.format('SELECT {0} FROM {1}', new List<Object>{ String.join(fieldNames, ', '), sobjectType });
         return Database.query(String.escapeSingleQuotes(query));
     }
 
@@ -44,10 +44,7 @@ public without sharing virtual class LogManagementDataSelector {
      * @return             `List<SObject>` containing any matching records in the specified `SObjectType`
      */
     public virtual List<SObject> getById(Schema.SObjectType sobjectType, Set<String> fieldNames, List<Id> recordIds) {
-        String query = String.format(
-            'SELECT {0} FROM {1} WHERE Id IN :recordIds',
-            new List<Object>{ String.join(new List<String>(fieldNames), ', '), sobjectType }
-        );
+        String query = String.format('SELECT {0} FROM {1} WHERE Id IN :recordIds', new List<Object>{ String.join(fieldNames, ', '), sobjectType });
         return Database.query(String.escapeSingleQuotes(query));
     }
 

--- a/nebula-logger/core/main/log-management/classes/LogManagementDataSelector.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LogManagementDataSelector.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LogMassDeleteExtension.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LogMassDeleteExtension.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LogViewerController.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LogViewerController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LoggerEmailSender.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LoggerEmailSender.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LoggerHomeHeaderController.cls
+++ b/nebula-logger/core/main/log-management/classes/LoggerHomeHeaderController.cls
@@ -35,15 +35,15 @@ public without sharing class LoggerHomeHeaderController {
     }
 
     private static void setPluginDetails(Environment environment) {
-        List<LoggerPlugin__mdt> enabledplugins = LoggerPlugin.getPluginConfigurations();
-        environment.loggerEnabledPluginsCount = enabledplugins.size();
+        List<LoggerPlugin__mdt> enabledPlugins = LoggerPlugin.getPluginConfigurations();
+        environment.loggerEnabledPluginsCount = enabledPlugins.size();
         if (environment.loggerEnabledPluginsCount == 0) {
             environment.loggerEnabledPlugins = null;
             return;
         }
 
         List<String> pluginLabels = new List<String>();
-        for (LoggerPlugin__mdt plugin : enabledplugins) {
+        for (LoggerPlugin__mdt plugin : enabledPlugins) {
             pluginLabels.add(plugin.Label);
         }
         pluginLabels.sort();

--- a/nebula-logger/core/main/log-management/classes/LoggerHomeHeaderController.cls
+++ b/nebula-logger/core/main/log-management/classes/LoggerHomeHeaderController.cls
@@ -28,6 +28,29 @@ public without sharing class LoggerHomeHeaderController {
         environment.organizationName = System.UserInfo.getOrganizationName();
         environment.organizationType = organization.OrganizationType;
 
+        setPluginDetails(environment);
+        setStatusApiResponseDetails(environment);
+
+        return environment;
+    }
+
+    private static void setPluginDetails(Environment environment) {
+        List<LoggerPlugin__mdt> enabledplugins = LoggerPlugin.getPluginConfigurations();
+        environment.loggerEnabledPluginsCount = enabledplugins.size();
+        if (environment.loggerEnabledPluginsCount == 0) {
+            environment.loggerEnabledPlugins = null;
+            return;
+        }
+
+        List<String> pluginLabels = new List<String>();
+        for (LoggerPlugin__mdt plugin : enabledplugins) {
+            pluginLabels.add(plugin.Label);
+        }
+        pluginLabels.sort();
+        environment.loggerEnabledPlugins = String.join(pluginLabels, ', ');
+    }
+
+    private static void setStatusApiResponseDetails(Environment environment) {
         Logger.StatusApiResponse statusApiResponse = Logger.callStatusApi();
         if (statusApiResponse != null) {
             environment.organizationInstanceLocation = statusApiResponse.location;
@@ -39,8 +62,6 @@ public without sharing class LoggerHomeHeaderController {
                 environment.organizationInstanceProducts = getInstanceProductNames(statusApiResponse);
             }
         }
-
-        return environment;
     }
 
     private static String getInstanceProductNames(Logger.StatusApiResponse statusApiResponse) {
@@ -53,6 +74,10 @@ public without sharing class LoggerHomeHeaderController {
 
     @SuppressWarnings('PMD.ApexDoc, PMD.TooManyFields')
     public class Environment {
+        @AuraEnabled
+        public Integer loggerEnabledPluginsCount;
+        @AuraEnabled
+        public String loggerEnabledPlugins = 'Unknown';
         @AuraEnabled
         public String loggerNamespacePrefix = 'Unknown';
         @AuraEnabled

--- a/nebula-logger/core/main/log-management/classes/LoggerHomeHeaderController.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LoggerHomeHeaderController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LoggerSObjectMetadata.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LoggerSObjectMetadata.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LoggerScenarioHandler.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LoggerScenarioHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LoggerSettingsController.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LoggerSettingsController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/LoggerTagHandler.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/LoggerTagHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/classes/RelatedLogEntriesController.cls-meta.xml
+++ b/nebula-logger/core/main/log-management/classes/RelatedLogEntriesController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/log-management/customPermissions/CanExecuteLogBatchPurger.customPermission-meta.xml
+++ b/nebula-logger/core/main/log-management/customPermissions/CanExecuteLogBatchPurger.customPermission-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomPermission xmlns="http://soap.sforce.com/2006/04/metadata">
     <isLicensed>false</isLicensed>
-    <label>Can Execute Log Batch Purger</label>
+    <label>Nebula Logger: Can Execute Log Batch Purger</label>
 </CustomPermission>

--- a/nebula-logger/core/main/log-management/customPermissions/CanModifyLoggerSettings.customPermission-meta.xml
+++ b/nebula-logger/core/main/log-management/customPermissions/CanModifyLoggerSettings.customPermission-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomPermission xmlns="http://soap.sforce.com/2006/04/metadata">
     <isLicensed>false</isLicensed>
-    <label>Can Modify Logger Settings</label>
+    <label>Nebula Logger: Can Modify Logger Settings</label>
 </CustomPermission>

--- a/nebula-logger/core/main/log-management/dashboards/LogDashboards.dashboardFolder-meta.xml
+++ b/nebula-logger/core/main/log-management/dashboards/LogDashboards.dashboardFolder-meta.xml
@@ -6,5 +6,5 @@
         <sharedTo>AllInternalUsers</sharedTo>
         <sharedToType>Organization</sharedToType>
     </folderShares>
-    <name>Log Dashboards</name>
+    <name>Nebula Logger: Log Dashboards</name>
 </DashboardFolder>

--- a/nebula-logger/core/main/log-management/dashboards/LogDashboards/LoggerAdmin.dashboard-meta.xml
+++ b/nebula-logger/core/main/log-management/dashboards/LogDashboards/LoggerAdmin.dashboard-meta.xml
@@ -335,7 +335,6 @@
     </dashboardGridLayout>
     <dashboardType>SpecifiedUser</dashboardType>
     <isGridLayout>true</isGridLayout>
-    <runningUser>test-triqc8kt7jj0@example.com</runningUser>
     <textColor>#000000</textColor>
     <title>Logger Admin Dashboard</title>
     <titleColor>#000000</titleColor>

--- a/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
@@ -1547,7 +1547,7 @@
         <name>sidebar</name>
         <type>Region</type>
     </flexiPageRegions>
-    <masterLabel>Log Entry Record Page</masterLabel>
+    <masterLabel>Nebula Logger: Log Entry Record Page</masterLabel>
     <sobjectType>LogEntry__c</sobjectType>
     <template>
         <name>flexipage:recordHomeTemplateDesktop</name>

--- a/nebula-logger/core/main/log-management/flexipages/LogEntryTagRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LogEntryTagRecordPage.flexipage-meta.xml
@@ -54,7 +54,7 @@
         <name>sidebar</name>
         <type>Region</type>
     </flexiPageRegions>
-    <masterLabel>Log Entry Tag Record Page</masterLabel>
+    <masterLabel>Nebula Logger: Log Entry Tag Record Page</masterLabel>
     <sobjectType>LogEntryTag__c</sobjectType>
     <template>
         <name>flexipage:recordHomeTemplateDesktop</name>

--- a/nebula-logger/core/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
@@ -1207,7 +1207,7 @@
         <name>main</name>
         <type>Region</type>
     </flexiPageRegions>
-    <masterLabel>Log Record Page</masterLabel>
+    <masterLabel>Nebula Logger: Log Record Page</masterLabel>
     <sobjectType>Log__c</sobjectType>
     <template>
         <name>flexipage:recordHomeSimpleViewTemplate</name>

--- a/nebula-logger/core/main/log-management/flexipages/LoggerConsoleUtilityBar.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LoggerConsoleUtilityBar.flexipage-meta.xml
@@ -54,7 +54,7 @@
         <name>backgroundComponents</name>
         <type>Background</type>
     </flexiPageRegions>
-    <masterLabel>Logger Console Utility Bar</masterLabel>
+    <masterLabel>Nebula Logger: Logger Console Utility Bar</masterLabel>
     <template>
         <name>one:utilityBarTemplateDesktop</name>
         <properties>

--- a/nebula-logger/core/main/log-management/flexipages/LoggerHomePage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LoggerHomePage.flexipage-meta.xml
@@ -132,7 +132,7 @@
         <name>main</name>
         <type>Region</type>
     </flexiPageRegions>
-    <masterLabel>Logger Home Page</masterLabel>
+    <masterLabel>Nebula Logger: Logger Home Page</masterLabel>
     <template>
         <name>runtime_commerce_oci:homeTemplateOneRegion</name>
     </template>

--- a/nebula-logger/core/main/log-management/flexipages/LoggerHomePage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LoggerHomePage.flexipage-meta.xml
@@ -9,7 +9,7 @@
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>hideOnError</name>
-                    <value>true</value>
+                    <value>false</value>
                 </componentInstanceProperties>
                 <componentName>desktopDashboards:embeddedDashboard</componentName>
                 <identifier>desktopDashboards_embeddedDashboard</identifier>
@@ -70,6 +70,10 @@
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
+                    <name>active</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>body</name>
                     <value>Facet-dce32d29-eac4-4969-a853-889e1276ac4e</value>
                 </componentInstanceProperties>
@@ -84,6 +88,10 @@
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
+                    <name>active</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>body</name>
                     <value>Facet-7c15c775-623e-411d-99c9-040fac6a118a</value>
                 </componentInstanceProperties>
@@ -97,6 +105,10 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
+                <componentInstanceProperties>
+                    <name>active</name>
+                    <value>false</value>
+                </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>body</name>
                     <value>Facet-flyklawwy3t</value>

--- a/nebula-logger/core/main/log-management/flexipages/LoggerScenarioRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LoggerScenarioRecordPage.flexipage-meta.xml
@@ -212,7 +212,7 @@
         <name>main</name>
         <type>Region</type>
     </flexiPageRegions>
-    <masterLabel>Log Scenario Record Page</masterLabel>
+    <masterLabel>Nebula Logger: Log Scenario Record Page</masterLabel>
     <sobjectType>LoggerScenario__c</sobjectType>
     <template>
         <name>flexipage:recordHomeSingleColTemplateDesktop</name>

--- a/nebula-logger/core/main/log-management/flexipages/LoggerTagRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LoggerTagRecordPage.flexipage-meta.xml
@@ -124,7 +124,7 @@
         <name>main</name>
         <type>Region</type>
     </flexiPageRegions>
-    <masterLabel>Logger Tag Record Page</masterLabel>
+    <masterLabel>Nebula Logger: Logger Tag Record Page</masterLabel>
     <sobjectType>LoggerTag__c</sobjectType>
     <template>
         <name>flexipage:recordHomeSingleColTemplateDesktop</name>

--- a/nebula-logger/core/main/log-management/globalValueSets/LoggingLevel.globalValueSet-meta.xml
+++ b/nebula-logger/core/main/log-management/globalValueSets/LoggingLevel.globalValueSet-meta.xml
@@ -38,6 +38,6 @@
         <default>false</default>
         <label>FINEST</label>
     </customValue>
-    <masterLabel>Logging Level</masterLabel>
+    <masterLabel>Nebula Logger: Logging Level</masterLabel>
     <sorted>false</sorted>
 </GlobalValueSet>

--- a/nebula-logger/core/main/log-management/lwc/logBatchPurge/logBatchPurge.js-meta.xml
+++ b/nebula-logger/core/main/log-management/lwc/logBatchPurge/logBatchPurge.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
-    <masterLabel>Log Batch Purge</masterLabel>
+    <masterLabel>Nebula Logger: Log Batch Purge</masterLabel>
     <targets>
         <target>lightning__HomePage</target>
         <target>lightning__Tab</target>

--- a/nebula-logger/core/main/log-management/lwc/logBatchPurge/logBatchPurge.js-meta.xml
+++ b/nebula-logger/core/main/log-management/lwc/logBatchPurge/logBatchPurge.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Log Batch Purge</masterLabel>
     <targets>

--- a/nebula-logger/core/main/log-management/lwc/logEntryEventStream/__tests__/logEntryEventStream.test.js
+++ b/nebula-logger/core/main/log-management/lwc/logEntryEventStream/__tests__/logEntryEventStream.test.js
@@ -61,6 +61,7 @@ jest.mock(
 const flushPromises = () => new Promise(process.nextTick);
 
 async function createStreamElement(namespace) {
+    isEnabled.mockResolvedValue(true);
     getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
     const mockLogEntryEventSchema = generateLogEntryEventSchema(namespace);
     getSchemaForName.mockResolvedValue(mockLogEntryEventSchema);
@@ -133,6 +134,7 @@ describe('LogEntryEventStream tests', () => {
         while (document.body.firstChild) {
             document.body.removeChild(document.body.firstChild);
         }
+        jest.clearAllMocks();
     });
 
     const namespaces = ['', 'SomeNamespace'];
@@ -193,6 +195,7 @@ describe('LogEntryEventStream tests', () => {
             })
         );
     });
+
     it('clears stream when clear button clicked', async () => {
         await Promise.all(
             namespaces.map(async namespace => {
@@ -214,6 +217,7 @@ describe('LogEntryEventStream tests', () => {
             })
         );
     });
+
     it('includes matching log entry event for logging level filter', async () => {
         await Promise.all(
             namespaces.map(async namespace => {
@@ -237,6 +241,7 @@ describe('LogEntryEventStream tests', () => {
             })
         );
     });
+
     it('excludes non-matching log entry event for logging level filter', async () => {
         await Promise.all(
             namespaces.map(async namespace => {
@@ -259,10 +264,11 @@ describe('LogEntryEventStream tests', () => {
             })
         );
     });
+
     it('includes matching log entry event for origin type filter', async () => {
+        isEnabled.mockResolvedValue(true);
         getSchemaForName.mockResolvedValue(mockLogEntryEventSchemaTemplate);
         getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
-
         const element = createElement('log-entry-event-stream', {
             is: LogEntryEventStream
         });
@@ -286,7 +292,9 @@ describe('LogEntryEventStream tests', () => {
         const eventStreamDiv = element.shadowRoot.querySelector('.event-stream');
         expect(eventStreamDiv.textContent).toBe(expectedStreamText);
     });
+
     it('excludes non-matching log entry event for origin type filter', async () => {
+        isEnabled.mockResolvedValue(true);
         getSchemaForName.mockResolvedValue(mockLogEntryEventSchemaTemplate);
         getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
         const element = createElement('log-entry-event-stream', {
@@ -297,7 +305,6 @@ describe('LogEntryEventStream tests', () => {
         const originTypeFilterDropdown = element.shadowRoot.querySelector('lightning-combobox[data-id="originTypeFilter"]');
         originTypeFilterDropdown.value = 'Flow';
         originTypeFilterDropdown.dispatchEvent(new CustomEvent('change'));
-
         await flushPromises();
 
         const nonMatchingLogEntryEvent = { ...mockLogEntryEventTemplate };
@@ -308,11 +315,12 @@ describe('LogEntryEventStream tests', () => {
                 payload: nonMatchingLogEntryEvent
             }
         });
-
         const eventStreamDiv = element.shadowRoot.querySelector('.event-stream');
         expect(eventStreamDiv.textContent).toBeFalsy();
     });
+
     it('includes matching log entry event for origin location filter', async () => {
+        isEnabled.mockResolvedValue(true);
         getSchemaForName.mockResolvedValue(mockLogEntryEventSchemaTemplate);
         getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
         const element = createElement('log-entry-event-stream', {
@@ -338,10 +346,11 @@ describe('LogEntryEventStream tests', () => {
         const eventStreamDiv = element.shadowRoot.querySelector('.event-stream');
         expect(eventStreamDiv.textContent).toBe(expectedStreamText);
     });
+
     it('excludes non-matching log entry event for origin location filter', async () => {
+        isEnabled.mockResolvedValue(true);
         getSchemaForName.mockResolvedValue(mockLogEntryEventSchemaTemplate);
         getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
-
         const element = createElement('log-entry-event-stream', {
             is: LogEntryEventStream
         });
@@ -350,7 +359,6 @@ describe('LogEntryEventStream tests', () => {
         const originLocationFilterDropdown = element.shadowRoot.querySelector('lightning-input[data-id="originLocationFilter"]');
         originLocationFilterDropdown.value = 'SomeClass.someMethod';
         originLocationFilterDropdown.dispatchEvent(new CustomEvent('change'));
-
         await flushPromises();
 
         const nonMatchingLogEntryEvent = { ...mockLogEntryEventTemplate };
@@ -365,10 +373,11 @@ describe('LogEntryEventStream tests', () => {
         const eventStreamDiv = element.shadowRoot.querySelector('.event-stream');
         expect(eventStreamDiv.textContent).toBeFalsy();
     });
+
     it('includes matching log entry event for logged by filter', async () => {
+        isEnabled.mockResolvedValue(true);
         getSchemaForName.mockResolvedValue(mockLogEntryEventSchemaTemplate);
         getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
-
         const element = createElement('log-entry-event-stream', {
             is: LogEntryEventStream
         });
@@ -387,15 +396,15 @@ describe('LogEntryEventStream tests', () => {
                 payload: matchingLogEntryEvent
             }
         });
-
         const expectedStreamText = getPlatformEventText(matchingLogEntryEvent);
         const eventStreamDiv = element.shadowRoot.querySelector('.event-stream');
         expect(eventStreamDiv.textContent).toBe(expectedStreamText);
     });
+
     it('excludes non-matching log entry event for logged by filter', async () => {
+        isEnabled.mockResolvedValue(true);
         getSchemaForName.mockResolvedValue(mockLogEntryEventSchemaTemplate);
         getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
-
         const element = createElement('log-entry-event-stream', {
             is: LogEntryEventStream
         });
@@ -418,7 +427,9 @@ describe('LogEntryEventStream tests', () => {
         const eventStreamDiv = element.shadowRoot.querySelector('.event-stream');
         expect(eventStreamDiv.textContent).toBeFalsy();
     });
+
     it('includes matching log entry event using string for message filter', async () => {
+        isEnabled.mockResolvedValue(true);
         getSchemaForName.mockResolvedValue(mockLogEntryEventSchemaTemplate);
         getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
         const element = createElement('log-entry-event-stream', {
@@ -444,10 +455,11 @@ describe('LogEntryEventStream tests', () => {
         const eventStreamDiv = element.shadowRoot.querySelector('.event-stream');
         expect(eventStreamDiv.textContent).toBe(expectedStreamText);
     });
+
     it('excludes non-matching log entry event for message filter', async () => {
+        isEnabled.mockResolvedValue(true);
         getSchemaForName.mockResolvedValue(mockLogEntryEventSchemaTemplate);
         getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
-
         const element = createElement('log-entry-event-stream', {
             is: LogEntryEventStream
         });
@@ -472,9 +484,9 @@ describe('LogEntryEventStream tests', () => {
     });
 
     it('includes matching log entry event using regex for message filter', async () => {
+        isEnabled.mockResolvedValue(true);
         getSchemaForName.mockResolvedValue(mockLogEntryEventSchemaTemplate);
         getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
-
         const element = createElement('log-entry-event-stream', {
             is: LogEntryEventStream
         });
@@ -499,10 +511,10 @@ describe('LogEntryEventStream tests', () => {
         expect(eventStreamDiv.textContent).toBe(expectedStreamText);
     });
 
-    it('it should show the splitview as expanded by default', async () => {
+    it('shows the splitview as expanded by default', async () => {
+        isEnabled.mockResolvedValue(true);
         getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
         getSchemaForName.mockResolvedValue(mockLogEntryEventSchemaTemplate);
-
         const element = createElement('log-entry-event-stream', {
             is: LogEntryEventStream
         });
@@ -516,15 +528,19 @@ describe('LogEntryEventStream tests', () => {
         document.body.appendChild(element);
         await flushPromises();
 
-        const splitViewContainer = element.shadowRoot.querySelector('[data-id="split-view-container"]');
+        let splitViewContainer = element.shadowRoot.querySelector('[data-id="split-view-container"]');
         expect(splitViewContainer.className).toContain('slds-is-open');
 
         const toggleSplitViewButton = element.shadowRoot.querySelector('[data-id="split-view-button"]');
         expect(toggleSplitViewButton.className).toContain('slds-is-open');
+        toggleSplitViewButton.click();
+        await flushPromises();
 
-        const eventStreamDiv = element.shadowRoot.querySelector('.event-stream');
+        splitViewContainer = element.shadowRoot.querySelector('[data-id="split-view-container"]');
+        expect(splitViewContainer.className).toContain('slds-is-closed');
     });
-    it('it should colapse the split view when user click on the splitview panel button', async () => {
+
+    it('collapses the split view when user click on the splitview panel button', async () => {
         getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
         getSchemaForName.mockResolvedValue(mockLogEntryEventSchemaTemplate);
 
@@ -552,10 +568,10 @@ describe('LogEntryEventStream tests', () => {
         const eventStreamDiv = element.shadowRoot.querySelector('.event-stream');
     });
 
-    it('it should expand the console when user click on the expand button', async () => {
+    it('expands the console when user click on the expand button', async () => {
+        isEnabled.mockResolvedValue(true);
         getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
         getSchemaForName.mockResolvedValue(mockLogEntryEventSchemaTemplate);
-
         const element = createElement('log-entry-event-stream', {
             is: LogEntryEventStream
         });
@@ -577,10 +593,10 @@ describe('LogEntryEventStream tests', () => {
         expect(consoleBlock.className).toContain('expanded');
     });
 
-    it('it should exit full screen mode when user click on the contract button', async () => {
+    it('exits full screen mode when user click on the contract button', async () => {
+        isEnabled.mockResolvedValue(true);
         getDatatableDisplayFields.mockResolvedValue(mockTableViewDisplayFields);
         getSchemaForName.mockResolvedValue(mockLogEntryEventSchemaTemplate);
-
         const element = createElement('log-entry-event-stream', {
             is: LogEntryEventStream
         });
@@ -603,7 +619,7 @@ describe('LogEntryEventStream tests', () => {
         expect(consoleBlock.className).not.toContain('expanded');
     });
 
-    it('it should show log entries in console when user select console view ', async () => {
+    it('shows log entries in console when user selects console view ', async () => {
         await Promise.all(
             namespaces.map(async namespace => {
                 const element = await createStreamElement(namespace);
@@ -623,7 +639,7 @@ describe('LogEntryEventStream tests', () => {
         );
     });
 
-    it('it should show log entries in datatable when user select tabular view ', async () => {
+    it('shows log entries in datatable when user select tabular view ', async () => {
         await Promise.all(
             namespaces.map(async namespace => {
                 const element = await createStreamElement(namespace);

--- a/nebula-logger/core/main/log-management/lwc/logEntryEventStream/logEntryEventStream.html
+++ b/nebula-logger/core/main/log-management/lwc/logEntryEventStream/logEntryEventStream.html
@@ -39,12 +39,21 @@
                 <div class="slds-panel__body">
                     <div class="slds-p-horizontal_small">
                         <lightning-input
-                            label="Max Number of Events to Display"
                             disabled={isDisabled}
-                            onchange={handleMaxEventsChange}
+                            field-level-help={maxEventsToStreamHelp}
+                            label="Max Number of Events to Stream"
+                            onchange={handleMaxEventsStreamedChange}
+                            placeholder="Specify Max Events To Stream"
+                            type="number"
+                            value={maxEventsToStream}
+                        ></lightning-input>
+                        <lightning-input
+                            disabled={isDisabled}
+                            label="Max Number of Events to Display"
+                            onchange={handleMaxEventsToDisplayChange}
                             placeholder="Specify Max Events"
                             type="number"
-                            value={maxEvents}
+                            value={maxEventsToDisplay}
                         ></lightning-input>
                         <lightning-combobox
                             data-id="loggingLevelFilter"
@@ -100,16 +109,23 @@
                 </div>
             </div>
         </div>
-        <div class="slds-grow slds-m-horizontal_medium event-stream-container">
+        <div class="slds-grow slds-m-left_small event-stream-container" style="max-height: 65vh">
             <article style="height: 100%; width: 95%" data-id="event-stream-console" class="slds-card">
                 <div class="slds-card__header slds-grid">
                     <header class="slds-media slds-media_center slds-has-flexi-truncate">
                         <div class="slds-media__body">
-                            <h2 class="slds-card__header-title">
+                            <h2 class="slds-card__header-title slds-m-left_medium">
                                 <span>{title}</span>
                             </h2>
                         </div>
                         <template if:true={isEnabled}>
+                            <lightning-progress-ring
+                                class="slds-m-right_medium"
+                                title={eventDeliveryUsageSummary}
+                                value={eventDeliveryPercent}
+                                variant={eventDeliveryProgressVariant}
+                            >
+                            </lightning-progress-ring>
                             <div class="slds-no-flex">
                                 <lightning-button-group>
                                     <lightning-button-stateful

--- a/nebula-logger/core/main/log-management/lwc/logEntryEventStream/logEntryEventStream.html
+++ b/nebula-logger/core/main/log-management/lwc/logEntryEventStream/logEntryEventStream.html
@@ -4,6 +4,16 @@
  **********************************************************************************************-->
 
 <template>
+    <template if:false={isEnabled}>
+        <div class="disabled-warning-message slds-card slds-theme_shade">
+            <div class="slds-card__header slds-grid">
+                <div class="slds-notify slds-notify_alert slds-alert_warning" role="alert">
+                    <lightning-icon icon-name="utility:warning" size="x-small"></lightning-icon>
+                    <div class="slds-text-heading_medium">{disabledWarningMessage}</div>
+                </div>
+            </div>
+        </div>
+    </template>
     <div class="main-container height-full slds-p-around_none">
         <div class="slds-is-relative height-full">
             <button
@@ -30,6 +40,7 @@
                     <div class="slds-p-horizontal_small">
                         <lightning-input
                             label="Max Number of Events to Display"
+                            disabled={isDisabled}
                             onchange={handleMaxEventsChange}
                             placeholder="Specify Max Events"
                             type="number"
@@ -37,6 +48,7 @@
                         ></lightning-input>
                         <lightning-combobox
                             data-id="loggingLevelFilter"
+                            disabled={isDisabled}
                             label="Minimum Logging Level"
                             onchange={handleFilterChange}
                             options={loggingLevelOptions}
@@ -45,6 +57,7 @@
                         ></lightning-combobox>
                         <lightning-combobox
                             data-id="originTypeFilter"
+                            disabled={isDisabled}
                             label="Origin Type"
                             onchange={handleFilterChange}
                             options={originTypeOptions}
@@ -53,6 +66,7 @@
                         ></lightning-combobox>
                         <lightning-input
                             data-id="originLocationFilter"
+                            disabled={isDisabled}
                             label="Origin Location"
                             onchange={handleFilterChange}
                             placeholder="Specify Origin Location"
@@ -60,6 +74,7 @@
                         ></lightning-input>
                         <lightning-input
                             data-id="scenarioFilter"
+                            disabled={isDisabled}
                             label="Scenario"
                             onchange={handleFilterChange}
                             placeholder="Specify Scenario"
@@ -67,6 +82,7 @@
                         ></lightning-input>
                         <lightning-input
                             data-id="loggedByFilter"
+                            disabled={isDisabled}
                             label="Logged By"
                             onchange={handleFilterChange}
                             placeholder="Specify Username"
@@ -74,6 +90,7 @@
                         ></lightning-input>
                         <lightning-textarea
                             data-id="messageFilter"
+                            disabled={isDisabled}
                             label="Message"
                             onchange={handleFilterChange}
                             placeholder="Message Contains"
@@ -92,65 +109,67 @@
                                 <span>{title}</span>
                             </h2>
                         </div>
-                        <div class="slds-no-flex">
-                            <lightning-button-group>
-                                <lightning-button-stateful
-                                    data-id="toggle-stream"
-                                    icon-name-when-hover="utility:close"
-                                    icon-name-when-off="utility:pause_alt"
-                                    icon-name-when-on="utility:play"
-                                    label-when-hover="  Pause  "
-                                    label-when-off="Paused"
-                                    label-when-on="Streaming"
-                                    onclick={onToggleStream}
-                                    selected={isStreamEnabled}
-                                    variant={streamButtonVariant}
-                                >
-                                </lightning-button-stateful>
-                                <lightning-button
-                                    data-id="clear"
-                                    label="Clear"
-                                    icon-name="utility:delete"
-                                    name="clear"
-                                    onclick={onClear}
-                                    variant="destructive"
-                                ></lightning-button>
-                                <lightning-button-stateful
-                                    data-id="expand-toggle"
-                                    icon-name-when-off="utility:expand"
-                                    icon-name-when-on="utility:contract"
-                                    label-when-off="Expand"
-                                    label-when-on="Contract"
-                                    onclick={onToggleExpand}
-                                    selected={isExpanded}
-                                    variant="brand"
-                                >
-                                </lightning-button-stateful>
-                            </lightning-button-group>
-                        </div>
-                        <lightning-button-menu
-                            data-id="select-view-button"
-                            class="slds-p-left_x-small"
-                            icon-name={selectViewMenuIcon}
-                            alternative-text="view as"
-                            onselect={onSelectView}
-                            variant="base"
-                            menu-alignment="auto"
-                        >
-                            <lightning-menu-subheader label="Display As"></lightning-menu-subheader>
-                            <template for:each={selectViewMenuOptions} for:item="action">
-                                <lightning-menu-item
-                                    icon-name={action.iconName}
-                                    id={action.id}
-                                    data-id={action.id}
-                                    label={action.label}
-                                    value={action.value}
-                                    key={action.label}
-                                    checked={action.checked}
-                                >
-                                </lightning-menu-item
-                            ></template>
-                        </lightning-button-menu>
+                        <template if:true={isEnabled}>
+                            <div class="slds-no-flex">
+                                <lightning-button-group>
+                                    <lightning-button-stateful
+                                        data-id="toggle-stream"
+                                        icon-name-when-hover="utility:close"
+                                        icon-name-when-off="utility:pause_alt"
+                                        icon-name-when-on="utility:play"
+                                        label-when-hover="  Pause  "
+                                        label-when-off="Paused"
+                                        label-when-on="Streaming"
+                                        onclick={onToggleStream}
+                                        selected={isStreamEnabled}
+                                        variant={streamButtonVariant}
+                                    >
+                                    </lightning-button-stateful>
+                                    <lightning-button
+                                        data-id="clear"
+                                        label="Clear"
+                                        icon-name="utility:delete"
+                                        name="clear"
+                                        onclick={onClear}
+                                        variant="destructive"
+                                    ></lightning-button>
+                                    <lightning-button-stateful
+                                        data-id="expand-toggle"
+                                        icon-name-when-off="utility:expand"
+                                        icon-name-when-on="utility:contract"
+                                        label-when-off="Expand"
+                                        label-when-on="Contract"
+                                        onclick={onToggleExpand}
+                                        selected={isExpanded}
+                                        variant="brand"
+                                    >
+                                    </lightning-button-stateful>
+                                </lightning-button-group>
+                            </div>
+                            <lightning-button-menu
+                                class="slds-p-left_x-small"
+                                data-id="select-view-button"
+                                icon-name={selectViewMenuIcon}
+                                alternative-text="view as"
+                                onselect={onSelectView}
+                                variant="base"
+                                menu-alignment="auto"
+                            >
+                                <lightning-menu-subheader label="Display As"></lightning-menu-subheader>
+                                <template for:each={selectViewMenuOptions} for:item="action">
+                                    <lightning-menu-item
+                                        icon-name={action.iconName}
+                                        id={action.id}
+                                        data-id={action.id}
+                                        label={action.label}
+                                        value={action.value}
+                                        key={action.label}
+                                        checked={action.checked}
+                                    >
+                                    </lightning-menu-item
+                                ></template>
+                            </lightning-button-menu>
+                        </template>
                     </header>
                 </div>
                 <div class="slds-p-around_small card-body">

--- a/nebula-logger/core/main/log-management/lwc/logEntryEventStream/logEntryEventStream.js
+++ b/nebula-logger/core/main/log-management/lwc/logEntryEventStream/logEntryEventStream.js
@@ -108,9 +108,8 @@ export default class LogEntryEventStream extends LightningElement {
             return 'base';
         } else if (this.eventDeliveryPercent >= 50 && this.eventDeliveryPercent < 75) {
             return 'warning';
-        } 
-            return 'expired';
-        
+        }
+        return 'expired';
     }
 
     get maxEventsToStreamHelp() {

--- a/nebula-logger/core/main/log-management/lwc/logEntryEventStream/logEntryEventStream.js-meta.xml
+++ b/nebula-logger/core/main/log-management/lwc/logEntryEventStream/logEntryEventStream.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
-    <masterLabel>Log Entry Event Stream</masterLabel>
+    <masterLabel>Nebula Logger: Log Entry Event Stream</masterLabel>
     <targets>
         <target>lightning__HomePage</target>
         <target>lightning__Tab</target>

--- a/nebula-logger/core/main/log-management/lwc/logEntryEventStream/logEntryEventStream.js-meta.xml
+++ b/nebula-logger/core/main/log-management/lwc/logEntryEventStream/logEntryEventStream.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Log Entry Event Stream</masterLabel>
     <targets>

--- a/nebula-logger/core/main/log-management/lwc/logViewer/logViewer.js-meta.xml
+++ b/nebula-logger/core/main/log-management/lwc/logViewer/logViewer.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__RecordAction</target>

--- a/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/__tests__/loggerHomeHeader.test.js
+++ b/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/__tests__/loggerHomeHeader.test.js
@@ -4,6 +4,8 @@ import getEnvironmentDetails from '@salesforce/apex/LoggerHomeHeaderController.g
 
 const MOCK_ENVIRONMENT_DETAILS = {
     loggerNamespacePrefix: '(none)',
+    loggerEnabledPluginsCount: 3,
+    loggerEnabledPlugins: 'A Plugin, My Other Plugin, Some Other Plugin',
     loggerVersionNumber: 'v4.10.4',
     organizationApiVersion: 'v57.0',
     organizationCreatedByUsername: 'some.username@test.com',
@@ -50,6 +52,9 @@ describe('c-logger-home-header', () => {
         const headerTitleElement = element.shadowRoot.querySelector('[data-id="header-title"]');
         expect(headerTitleElement).toBeTruthy();
         expect(headerTitleElement.innerHTML).toBe(`Nebula Logger ${MOCK_ENVIRONMENT_DETAILS.loggerVersionNumber}`);
+        const pluginsSummaryElement = element.shadowRoot.querySelector('[data-id="enabled-plugins-summary"]');
+        expect(pluginsSummaryElement).toBeTruthy();
+        expect(pluginsSummaryElement.innerHTML).toBe(MOCK_ENVIRONMENT_DETAILS.loggerEnabledPluginsCount + ' Enabled Plugins');
         const environmentDetailsButton = element.shadowRoot.querySelector('lightning-button[data-id="environment-details-button"]');
         expect(environmentDetailsButton.label).toBe('View Environment Details');
         const releaseNotesButton = element.shadowRoot.querySelector('lightning-button[data-id="release-notes-button"]');
@@ -71,6 +76,7 @@ describe('c-logger-home-header', () => {
         const modalTitleElement = element.shadowRoot.querySelector('[data-id="environment-details-modal-title"]');
         expect(modalTitleElement.innerHTML).toBe('Environment Details');
         const dataIdToEnvironmentProperty = {
+            'environment-loggerEnabledPlugins': MOCK_ENVIRONMENT_DETAILS.loggerEnabledPlugins,
             'environment-loggerVersionNumber': MOCK_ENVIRONMENT_DETAILS.loggerVersionNumber,
             'environment-loggerNamespacePrefix': MOCK_ENVIRONMENT_DETAILS.loggerNamespacePrefix,
             'environment-organizationId': MOCK_ENVIRONMENT_DETAILS.organizationId,

--- a/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/__tests__/loggerHomeHeader.test.js
+++ b/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/__tests__/loggerHomeHeader.test.js
@@ -114,6 +114,20 @@ describe('c-logger-home-header', () => {
         expect(modalElement).toBeFalsy();
     });
 
+    it('hides the "View Release Notes" button when version number is not available', async () => {
+        const element = createElement('c-logger-home-header', {
+            is: LoggerHomeHeader
+        });
+        document.body.appendChild(element);
+        getEnvironmentDetails.emit({ ...MOCK_ENVIRONMENT_DETAILS, ...{ loggerVersionNumber: null } });
+        await Promise.resolve('Resolve getEnvironmentDetails()');
+        const navigationHandler = jest.fn();
+        element.addEventListener('navigate', navigationHandler);
+
+        const button = element.shadowRoot.querySelector('lightning-button[data-id="release-notes-button"]');
+        expect(button).toBeFalsy();
+    });
+
     it('displays github release notes url when "View Release Notes" button is clicked', async () => {
         const element = createElement('c-logger-home-header', {
             is: LoggerHomeHeader

--- a/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.html
+++ b/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.html
@@ -27,12 +27,14 @@
                                 label={environmentDetailsButtonLabel}
                                 onclick={handleViewEnvironmentDetails}
                             ></lightning-button>
-                            <lightning-button
-                                data-id="release-notes-button"
-                                icon-name="utility:announcement"
-                                label={releaseNotesButtonLabel}
-                                onclick={handleViewReleaseNotes}
-                            ></lightning-button>
+                            <template if:true={showReleaseNotesButton}>
+                                <lightning-button
+                                    data-id="release-notes-button"
+                                    icon-name="utility:announcement"
+                                    label={releaseNotesButtonLabel}
+                                    onclick={handleViewReleaseNotes}
+                                ></lightning-button>
+                            </template>
                         </lightning-button-group>
                     </div>
                 </div>

--- a/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.html
+++ b/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.html
@@ -12,6 +12,9 @@
                                 <h1>
                                     <span class="slds-page-header__title slds-p-top_xx-small" data-id="header-title" title={title}>{title}</span>
                                 </h1>
+                                <template if:true={enabledPluginsSummary}>
+                                    <p data-id="enabled-plugins-summary">{enabledPluginsSummary}</p>
+                                </template>
                             </div>
                         </div>
                     </div>
@@ -65,7 +68,7 @@
                         <h3 class="slds-section__title slds-theme_shade">
                             <span class="slds-truncate slds-p-horizontal_small" title="Nebula Logger">Nebula Logger</span>
                         </h3>
-                        <lightning-layout>
+                        <lightning-layout class="slds-p-around_small">
                             <lightning-layout-item size="12">
                                 <lightning-input
                                     data-id="environment-loggerVersionNumber"
@@ -83,6 +86,18 @@
                                     value={environment.loggerNamespacePrefix}
                                     variant="label-inline"
                                 ></lightning-input>
+                                <template if:true={environment.loggerEnabledPlugins}>
+                                    <div class="slds-form-element slds-form-element_horizontal">
+                                        <label class="slds-form-element__label" for="logger-enabled-plugins-output">Enabled Plugins</label>
+                                        <div class="slds-form-element__control">
+                                            <lightning-formatted-rich-text
+                                                data-id="environment-loggerEnabledPlugins"
+                                                id="logger-enabled-plugins-output"
+                                                value={environment.loggerEnabledPlugins}
+                                            ></lightning-formatted-rich-text>
+                                        </div>
+                                    </div>
+                                </template>
                             </lightning-layout-item>
                         </lightning-layout>
                     </div>
@@ -92,7 +107,7 @@
                         <h3 class="slds-section__title slds-theme_shade">
                             <span class="slds-truncate slds-p-horizontal_small" title="Organization">Organization</span>
                         </h3>
-                        <lightning-layout>
+                        <lightning-layout class="slds-p-around_small">
                             <lightning-layout-item size="12">
                                 <lightning-input
                                     data-id="environment-organizationId"
@@ -126,14 +141,16 @@
                                     value={environment.organizationInstanceName}
                                     variant="label-inline"
                                 ></lightning-input>
-                                <lightning-input
-                                    data-id="environment-organizationInstanceProducts"
-                                    label="Instance Products"
-                                    read-only
-                                    type="url"
-                                    value={environment.organizationInstanceProducts}
-                                    variant="label-inline"
-                                ></lightning-input>
+                                <div class="slds-form-element slds-form-element_horizontal">
+                                    <label class="slds-form-element__label" for="organization-instance-products-output">Instance Products</label>
+                                    <div class="slds-form-element__control">
+                                        <lightning-formatted-rich-text
+                                            data-id="environment-organizationInstanceProducts"
+                                            id="organization-instance-products-output"
+                                            value={environment.organizationInstanceProducts}
+                                        ></lightning-formatted-rich-text>
+                                    </div>
+                                </div>
                                 <lightning-input
                                     data-id="environment-organizationInstanceLocation"
                                     label="Instance Location"
@@ -210,6 +227,7 @@
                         label="Open Status Site"
                         onclick={handleViewStatusSite}
                         title="Open Status Site"
+                        variant="brand"
                     ></lightning-button>
                 </footer>
             </div>

--- a/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.js
+++ b/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.js
@@ -24,6 +24,14 @@ export default class LoggerHomeHeader extends NavigationMixin(LightningElement) 
         return titleText;
     }
 
+    get enabledPluginsSummary() {
+        if (!this.environment.loggerEnabledPlugins) {
+            return undefined;
+        }
+
+        return this.environment.loggerEnabledPluginsCount + ' Enabled Plugins';
+    }
+
     get environmentDetailsButtonLabel() {
         return `View Environment Details`;
     }

--- a/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.js
+++ b/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.js
@@ -28,6 +28,10 @@ export default class LoggerHomeHeader extends NavigationMixin(LightningElement) 
         return `View Environment Details`;
     }
 
+    get showReleaseNotesButton() {
+        return !!this.environment?.loggerVersionNumber;
+    }
+
     get releaseNotesButtonLabel() {
         return `View ${this.environment.loggerVersionNumber} Release Notes`;
     }

--- a/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.js-meta.xml
+++ b/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
-    <masterLabel>Logger Home Header</masterLabel>
+    <masterLabel>Nebula Logger: Logger Home Header</masterLabel>
     <description
     >Header component used on the Logger Console home page. This provides access to resources for configuring &amp; using Nebula Logger</description>
     <targets>

--- a/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.js-meta.xml
+++ b/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Logger Home Header</masterLabel>
     <description

--- a/nebula-logger/core/main/log-management/lwc/loggerSettings/loggerSettings.js-meta.xml
+++ b/nebula-logger/core/main/log-management/lwc/loggerSettings/loggerSettings.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Logger Settings</masterLabel>
     <targets>

--- a/nebula-logger/core/main/log-management/lwc/loggerSettings/loggerSettings.js-meta.xml
+++ b/nebula-logger/core/main/log-management/lwc/loggerSettings/loggerSettings.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
-    <masterLabel>Logger Settings</masterLabel>
+    <masterLabel>Nebula Logger: Logger Settings</masterLabel>
     <targets>
         <target>lightning__HomePage</target>
         <target>lightning__Tab</target>

--- a/nebula-logger/core/main/log-management/lwc/relatedLogEntries/relatedLogEntries.js-meta.xml
+++ b/nebula-logger/core/main/log-management/lwc/relatedLogEntries/relatedLogEntries.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <masterLabel>Related Log Entries</masterLabel>
+    <masterLabel>Nebula Logger: Related Log Entries</masterLabel>
     <description>Displays a related list of log entries for the current record.</description>
     <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>

--- a/nebula-logger/core/main/log-management/lwc/relatedLogEntries/relatedLogEntries.js-meta.xml
+++ b/nebula-logger/core/main/log-management/lwc/relatedLogEntries/relatedLogEntries.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <masterLabel>Related Log Entries</masterLabel>
     <description>Displays a related list of log entries for the current record.</description>
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__RecordPage</target>

--- a/nebula-logger/core/main/log-management/objects/LogEntryTag__c/LogEntryTag__c.object-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntryTag__c/LogEntryTag__c.object-meta.xml
@@ -174,8 +174,8 @@
         <customTabListAdditionalFields>LogEntry__c</customTabListAdditionalFields>
         <customTabListAdditionalFields>Tag__c</customTabListAdditionalFields>
         <excludedStandardButtons>Accept</excludedStandardButtons>
-        <excludedStandardButtons>PrintableListView</excludedStandardButtons>
         <excludedStandardButtons>Import</excludedStandardButtons>
+        <excludedStandardButtons>PrintableListView</excludedStandardButtons>
         <lookupDialogsAdditionalFields>LogEntry__c</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>Tag__c</lookupDialogsAdditionalFields>
         <lookupPhoneDialogsAdditionalFields>LogEntry__c</lookupPhoneDialogsAdditionalFields>

--- a/nebula-logger/core/main/log-management/objects/LogEntryTag__c/fields/LoggedByUsernameLink__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntryTag__c/fields/LoggedByUsernameLink__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggedByUsernameLink__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <formula>LogEntry__r.LoggedByUsernameLink__c</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/ApexClassApiVersion__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/ApexClassApiVersion__c.field-meta.xml
@@ -19,12 +19,12 @@
             <value>
                 <fullName>v58.0</fullName>
                 <default>false</default>
-                <label>v58.0 - Summer &apos;23 Release</label>
+                <label>v59.0 - Winter &apos;24 Release</label>
             </value>
             <value>
-                <fullName>v57.0</fullName>
+                <fullName>v58.0</fullName>
                 <default>false</default>
-                <label>v57.0 - Spring &apos;23 Release</label>
+                <label>v58.0 - Summer &apos;23 Release</label>
             </value>
         </valueSetDefinition>
     </valueSet>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/ApexClassApiVersion__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/ApexClassApiVersion__c.field-meta.xml
@@ -17,7 +17,7 @@
         <valueSetDefinition>
             <sorted>false</sorted>
             <value>
-                <fullName>v58.0</fullName>
+                <fullName>v59.0</fullName>
                 <default>false</default>
                 <label>v59.0 - Winter &apos;24 Release</label>
             </value>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/ApexClassLastModifiedDate__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/ApexClassLastModifiedDate__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ApexClassLastModifiedDate__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Apex Class Last Modified Date</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/FlowVersionApiVersionRuntime__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/FlowVersionApiVersionRuntime__c.field-meta.xml
@@ -18,7 +18,7 @@
         <valueSetDefinition>
             <sorted>false</sorted>
             <value>
-                <fullName>v58.0</fullName>
+                <fullName>v59.0</fullName>
                 <default>false</default>
                 <label>v59.0 - Winter &apos;24 Release</label>
             </value>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/FlowVersionApiVersionRuntime__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/FlowVersionApiVersionRuntime__c.field-meta.xml
@@ -20,12 +20,12 @@
             <value>
                 <fullName>v58.0</fullName>
                 <default>false</default>
-                <label>v58.0 - Summer &apos;23 Release</label>
+                <label>v59.0 - Winter &apos;24 Release</label>
             </value>
             <value>
-                <fullName>v57.0</fullName>
+                <fullName>v58.0</fullName>
                 <default>false</default>
-                <label>v57.0 - Spring &apos;23 Release</label>
+                <label>v58.0 - Summer &apos;23 Release</label>
             </value>
         </valueSetDefinition>
     </valueSet>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsAggregateQueries__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LimitsAggregateQueries__c.field-meta.xml
@@ -13,7 +13,7 @@
             &quot;✅&quot;
         )
     )
-    + &apos; &apos; + IF(LimitsAggregateQueriesMax__c = 0, '100', TEXT(ROUND(LimitsAggregateQueriesUsed__c / LimitsAggregateQueriesMax__c * 100, 2))) + &apos;% (&apos;
+    + &apos; &apos; + IF(LimitsAggregateQueriesMax__c = 0, &apos;100&apos;, TEXT(ROUND(LimitsAggregateQueriesUsed__c / LimitsAggregateQueriesMax__c * 100, 2))) + &apos;% (&apos;
     + TEXT(LimitsAggregateQueriesUsed__c) + &apos; / &apos; + TEXT(LimitsAggregateQueriesMax__c) + &apos;)&apos;</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <inlineHelpText>✅ when 80% or less of the limit is used, ⚠️ when 80.1-89.9% is used, or ⛔ when 90% or more is used</inlineHelpText>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LoggedByUsernameLink__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LoggedByUsernameLink__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggedByUsernameLink__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <formula>Log__r.LoggedByUsernameLink__c</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LoggingLevelOrdinal__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LoggingLevelOrdinal__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggingLevelOrdinal__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Logging Level Ordinal</label>
     <precision>2</precision>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LoggingLevelWithImage__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LoggingLevelWithImage__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggingLevelWithImage__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <formula>CASE(
     TEXT(LoggingLevel__c),

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LoggingLevel__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/LoggingLevel__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggingLevel__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Logging Level</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/ApiVersion__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/ApiVersion__c.field-meta.xml
@@ -19,12 +19,12 @@
             <value>
                 <fullName>v58.0</fullName>
                 <default>false</default>
-                <label>v58.0 - Summer &apos;23 Release</label>
+                <label>v59.0 - Winter &apos;24 Release</label>
             </value>
             <value>
-                <fullName>v57.0</fullName>
+                <fullName>v58.0</fullName>
                 <default>false</default>
-                <label>v57.0 - Spring &apos;23 Release</label>
+                <label>v58.0 - Summer &apos;23 Release</label>
             </value>
         </valueSetDefinition>
     </valueSet>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/ApiVersion__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/ApiVersion__c.field-meta.xml
@@ -17,7 +17,7 @@
         <valueSetDefinition>
             <sorted>false</sorted>
             <value>
-                <fullName>v58.0</fullName>
+                <fullName>v59.0</fullName>
                 <default>false</default>
                 <label>v59.0 - Winter &apos;24 Release</label>
             </value>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/ClosedBy__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/ClosedBy__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ClosedBy__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <deleteConstraint>SetNull</deleteConstraint>
     <externalId>false</externalId>
     <label>Closed By</label>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/ImpersonatedByUsernameLink__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/ImpersonatedByUsernameLink__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ImpersonatedByUsernameLink__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <formula>IF(
     ISBLANK(ImpersonatedBy__c),

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/ImpersonatedBy__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/ImpersonatedBy__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ImpersonatedBy__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <deleteConstraint>SetNull</deleteConstraint>
     <externalId>false</externalId>
     <label>Impersonated By</label>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/Locale__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/Locale__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Locale__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Locale</label>
     <length>255</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/LoggedByUsernameLink__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/LoggedByUsernameLink__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggedByUsernameLink__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <formula>IF(
     ISBLANK(LoggedBy__c),

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/LoggedByUsername__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/LoggedByUsername__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggedByUsername__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Username</label>
     <length>255</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/LoggedBy__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/LoggedBy__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggedBy__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <deleteConstraint>SetNull</deleteConstraint>
     <externalId>false</externalId>
     <label>Logged By</label>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/LoginApplication__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/LoginApplication__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoginApplication__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Login Application</label>
     <length>255</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/LoginBrowser__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/LoginBrowser__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoginBrowser__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Login Browser</label>
     <length>255</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/LoginDomain__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/LoginDomain__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoginDomain__c</fullName>
     <businessStatus>DeprecateCandidate</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>DEPRECATED: Login Domain</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/LoginHistoryId__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/LoginHistoryId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoginHistoryId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Login History ID</label>
     <length>18</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/LoginPlatform__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/LoginPlatform__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoginPlatform__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Login Platform</label>
     <length>255</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/LoginType__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/LoginType__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoginType__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Login Type</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/NetworkId__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/NetworkId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <description>The Network ID of the Community user&apos;s site. Set with Network.getNetworkId()</description>
     <externalId>true</externalId>
     <inlineHelpText>The Network ID of the user&apos;s Community site.</inlineHelpText>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/NetworkLoginUrl__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/NetworkLoginUrl__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkLoginUrl__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Site Login URL</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/NetworkLogoutUrl__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/NetworkLogoutUrl__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkLogoutUrl__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Site Logout URL</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/NetworkName__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/NetworkName__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkName__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <description>The name of the user&apos;s Community site (based on NetworkId).</description>
     <externalId>false</externalId>
     <inlineHelpText>The name of the user&apos;s Community site (based on NetworkId).</inlineHelpText>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/NetworkSelfRegistrationUrl__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/NetworkSelfRegistrationUrl__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkSelfRegistrationUrl__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Site Self Registration URL</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/NetworkUrlPathPrefix__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/NetworkUrlPathPrefix__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkUrlPathPrefix__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <description
     >The UrlPathPrefix is a unique string at the end of the URL for this community. For example, in the community URL CommunitiesSubdomainName.force.com/customers, customers is the UrlPathPrefix.</description>
     <externalId>false</externalId>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/OrganizationApiVersion__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/OrganizationApiVersion__c.field-meta.xml
@@ -19,12 +19,12 @@
             <value>
                 <fullName>v58.0</fullName>
                 <default>false</default>
-                <label>v58.0 - Summer &apos;23 Release</label>
+                <label>v59.0 - Winter &apos;24 Release</label>
             </value>
             <value>
-                <fullName>v57.0</fullName>
+                <fullName>v58.0</fullName>
                 <default>false</default>
-                <label>v57.0 - Spring &apos;23 Release</label>
+                <label>v58.0 - Summer &apos;23 Release</label>
             </value>
         </valueSetDefinition>
     </valueSet>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/OrganizationApiVersion__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/OrganizationApiVersion__c.field-meta.xml
@@ -17,7 +17,7 @@
         <valueSetDefinition>
             <sorted>false</sorted>
             <value>
-                <fullName>v58.0</fullName>
+                <fullName>v59.0</fullName>
                 <default>false</default>
                 <label>v59.0 - Winter &apos;24 Release</label>
             </value>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/ParentLogLink__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/ParentLogLink__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ParentLogLink__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <formula>IF(
     NOT(ISBLANK(ParentLog__c)),

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/ParentLogTransactionId__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/ParentLogTransactionId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ParentLogTransactionId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Parent Log Transaction ID</label>
     <length>36</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/ParentLog__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/ParentLog__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ParentLog__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <deleteConstraint>SetNull</deleteConstraint>
     <description
     >The log from the original transaction that initiated a child log - for example, batch jobs have start, execute and finish methods. All 3 are considered separate transactions. By using the parent log, logs from all 3 transactions can be linked together.</description>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/ProfileId__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/ProfileId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ProfileId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Profile ID</label>
     <length>18</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/ProfileLink__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/ProfileLink__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ProfileLink__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <formula>HYPERLINK(&apos;/&apos; + ProfileId__c, ProfileName__c, &apos;_top&apos;)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/ProfileName__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/ProfileName__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ProfileName__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Profile Name</label>
     <length>255</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/Scenario__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/Scenario__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Scenario__c</fullName>
     <businessStatus>DeprecateCandidate</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>true</externalId>
     <label>DEPRECATED: Scenario</label>
     <length>255</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/SessionId__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/SessionId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>SessionId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Session ID</label>
     <length>120</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/SessionSecurityLevel__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/SessionSecurityLevel__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>SessionSecurityLevel__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Session Security Level</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/SessionType__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/SessionType__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>SessionType__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Session Type</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/SourceIp__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/SourceIp__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>SourceIp__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Source IP</label>
     <length>255</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/TimeZoneId__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/TimeZoneId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>TimeZoneId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Time Zone ID</label>
     <length>255</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/TimeZoneName__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/TimeZoneName__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>TimeZoneName__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Time Zone Name</label>
     <length>255</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/TransactionScenario__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/TransactionScenario__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>TransactionScenario__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <deleteConstraint>SetNull</deleteConstraint>
     <externalId>false</externalId>
     <label>Transaction Scenario</label>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/UserLicenseDefinitionKey__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/UserLicenseDefinitionKey__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserLicenseDefinitionKey__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <description>https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_userlicense.htm</description>
     <externalId>false</externalId>
     <label>User License Definition Key</label>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/UserLicenseId__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/UserLicenseId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserLicenseId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>User License ID</label>
     <length>18</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/UserLicenseName__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/UserLicenseName__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserLicenseName__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>User License Name</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/UserLoggingLevelOrdinal__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/UserLoggingLevelOrdinal__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserLoggingLevelOrdinal__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>User Logging Level Ordinal</label>
     <precision>2</precision>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/UserLoggingLevel__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/UserLoggingLevel__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserLoggingLevel__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>User Logging Level</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/UserRoleId__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/UserRoleId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserRoleId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>User Role ID</label>
     <length>18</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/UserRoleLink__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/UserRoleLink__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserRoleLink__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <formula>HYPERLINK(&apos;/&apos; + UserRoleId__c, UserRoleName__c, &apos;_top&apos;)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/UserRoleName__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/UserRoleName__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserRoleName__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>User Role Name</label>
     <length>255</length>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/UserType__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/UserType__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserType__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>User Type</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/WasLoggedByCurrentUser__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/WasLoggedByCurrentUser__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>WasLoggedByCurrentUser__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <formula>$User.Id ==  LoggedBy__c</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>

--- a/nebula-logger/core/main/log-management/objects/LoggerTag__c/LoggerTag__c.object-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LoggerTag__c/LoggerTag__c.object-meta.xml
@@ -173,8 +173,8 @@
         <customTabListAdditionalFields>OWNER.ALIAS</customTabListAdditionalFields>
         <customTabListAdditionalFields>TotalLogEntries__c</customTabListAdditionalFields>
         <excludedStandardButtons>Accept</excludedStandardButtons>
-        <excludedStandardButtons>PrintableListView</excludedStandardButtons>
         <excludedStandardButtons>Import</excludedStandardButtons>
+        <excludedStandardButtons>PrintableListView</excludedStandardButtons>
         <lookupDialogsAdditionalFields>OWNER.ALIAS</lookupDialogsAdditionalFields>
         <lookupDialogsAdditionalFields>TotalLogEntries__c</lookupDialogsAdditionalFields>
         <lookupPhoneDialogsAdditionalFields>OWNER.ALIAS</lookupPhoneDialogsAdditionalFields>

--- a/nebula-logger/core/main/log-management/pages/LogMassDelete.page-meta.xml
+++ b/nebula-logger/core/main/log-management/pages/LogMassDelete.page-meta.xml
@@ -3,5 +3,5 @@
     <apiVersion>58.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
-    <label>Log Mass Delete</label>
+    <label>Nebula Logger: Log Mass Delete</label>
 </ApexPage>

--- a/nebula-logger/core/main/log-management/pages/LogMassDelete.page-meta.xml
+++ b/nebula-logger/core/main/log-management/pages/LogMassDelete.page-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <availableInTouch>false</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>Log Mass Delete</label>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -61,6 +61,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>LoggerHomeHeaderController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>LoggerParameter</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -1270,7 +1270,7 @@
         <readable>true</readable>
     </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
-    <label>Logger: Admin</label>
+    <label>Nebula Logger: Admin</label>
     <objectPermissions>
         <allowCreate>false</allowCreate>
         <allowDelete>false</allowDelete>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -989,7 +989,7 @@
         <readable>true</readable>
     </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
-    <label>Logger: End User</label>
+    <label>Nebula Logger: End User</label>
     <objectPermissions>
         <allowCreate>true</allowCreate>
         <allowDelete>false</allowDelete>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -21,6 +21,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>LoggerHomeHeaderController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>LoggerSObjectMetadata</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -1199,7 +1199,7 @@
         <readable>true</readable>
     </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
-    <label>Logger: Log Viewer</label>
+    <label>Nebula Logger: Log Viewer</label>
     <objectPermissions>
         <allowCreate>false</allowCreate>
         <allowDelete>false</allowDelete>

--- a/nebula-logger/core/main/log-management/reports/LogReports.reportFolder-meta.xml
+++ b/nebula-logger/core/main/log-management/reports/LogReports.reportFolder-meta.xml
@@ -6,5 +6,5 @@
         <sharedTo>AllInternalUsers</sharedTo>
         <sharedToType>Organization</sharedToType>
     </folderShares>
-    <name>Log Reports</name>
+    <name>Nebula Logger: Log Reports</name>
 </ReportFolder>

--- a/nebula-logger/core/main/log-management/triggers/Log.trigger-meta.xml
+++ b/nebula-logger/core/main/log-management/triggers/Log.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/nebula-logger/core/main/log-management/triggers/LogEntry.trigger-meta.xml
+++ b/nebula-logger/core/main/log-management/triggers/LogEntry.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/nebula-logger/core/main/log-management/triggers/LogEntryEvent.trigger-meta.xml
+++ b/nebula-logger/core/main/log-management/triggers/LogEntryEvent.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/nebula-logger/core/main/log-management/triggers/LogEntryTag.trigger-meta.xml
+++ b/nebula-logger/core/main/log-management/triggers/LogEntryTag.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/nebula-logger/core/main/log-management/triggers/LoggerScenario.trigger-meta.xml
+++ b/nebula-logger/core/main/log-management/triggers/LoggerScenario.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/nebula-logger/core/main/log-management/triggers/LoggerTag.trigger-meta.xml
+++ b/nebula-logger/core/main/log-management/triggers/LoggerTag.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/nebula-logger/core/main/logger-engine/classes/ComponentLogger.cls-meta.xml
+++ b/nebula-logger/core/main/logger-engine/classes/ComponentLogger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/logger-engine/classes/FlowCollectionLogEntry.cls-meta.xml
+++ b/nebula-logger/core/main/logger-engine/classes/FlowCollectionLogEntry.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/logger-engine/classes/FlowLogEntry.cls-meta.xml
+++ b/nebula-logger/core/main/logger-engine/classes/FlowLogEntry.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/logger-engine/classes/FlowLogger.cls-meta.xml
+++ b/nebula-logger/core/main/logger-engine/classes/FlowLogger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/logger-engine/classes/FlowRecordLogEntry.cls-meta.xml
+++ b/nebula-logger/core/main/logger-engine/classes/FlowRecordLogEntry.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls-meta.xml
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/logger-engine/classes/LogMessage.cls-meta.xml
+++ b/nebula-logger/core/main/logger-engine/classes/LogMessage.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.10.6';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.11.0';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final Set<String> IGNORED_APEX_CLASSES = initializeIgnoredApexClasses();
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -3123,7 +3123,8 @@ global with sharing class Logger {
     /**
      * @description **This is only intended to be used internally by Nebula Logger, and is subject to change.**
      *              Calls Salesforce's API endpoint https://api.status.salesforce.com/v1/instances/
-     *              to get more details about the current org, including the org's release number and release version
+     *              to get more details about the current org, including the org's release number and release version.
+     *              Trust API docs available at https://api.status.salesforce.com/v1/docs/
      * @return      Instance of `Logger.StatusApiResponse`, a data transfer object (DTO) that maps to the JSON returned
      *              by the status API endpoint.
      */

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls-meta.xml
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/logger-engine/classes/LoggerDataStore.cls-meta.xml
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerDataStore.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/logger-engine/classes/LoggerEngineDataSelector.cls-meta.xml
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerEngineDataSelector.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/logger-engine/classes/LoggerSObjectHandler.cls-meta.xml
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerSObjectHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/logger-engine/classes/LoggerSObjectProxy.cls-meta.xml
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerSObjectProxy.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
@@ -6,7 +6,7 @@
 import { LightningElement, api } from 'lwc';
 import { createLoggerService } from './loggerService';
 
-const CURRENT_VERSION_NUMBER = 'v4.10.6';
+const CURRENT_VERSION_NUMBER = 'v4.11.0';
 
 export default class Logger extends LightningElement {
     #loggerService = createLoggerService();

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logger.js-meta.xml
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logger.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logger.js-meta.xml
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logger.js-meta.xml
@@ -2,4 +2,5 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>58.0</apiVersion>
     <isExposed>false</isExposed>
+    <masterLabel>Nebula Logger: Logger for Lightning Components</masterLabel>
 </LightningComponentBundle>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/EntryScenario__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/EntryScenario__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>EntryScenario__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/ImpersonatedById__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/ImpersonatedById__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ImpersonatedById__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/Locale__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/Locale__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Locale__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoggedById__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoggedById__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggedById__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoggedByUsername__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoggedByUsername__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggedByUsername__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoggingLevelOrdinal__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoggingLevelOrdinal__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggingLevelOrdinal__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoggingLevel__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoggingLevel__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoggingLevel__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoginApplication__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoginApplication__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoginApplication__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoginBrowser__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoginBrowser__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoginBrowser__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoginDomain__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoginDomain__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoginDomain__c</fullName>
     <businessStatus>DeprecateCandidate</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoginHistoryId__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoginHistoryId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoginHistoryId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoginPlatform__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoginPlatform__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoginPlatform__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoginType__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/LoginType__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>LoginType__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkId__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkLoginUrl__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkLoginUrl__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkLoginUrl__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkLogoutUrl__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkLogoutUrl__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkLogoutUrl__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkName__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkName__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkName__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <description>The name of the user&apos;s Community site (based on NetworkId).</description>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkSelfRegistrationUrl__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkSelfRegistrationUrl__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkSelfRegistrationUrl__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkUrlPathPrefix__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/NetworkUrlPathPrefix__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>NetworkUrlPathPrefix__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <description
     >The UrlPathPrefix is a unique string at the end of the URL for this community. For example, in the community URL CommunitiesSubdomainName.force.com/customers, customers is the UrlPathPrefix.</description>
     <externalId>false</externalId>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/ParentLogTransactionId__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/ParentLogTransactionId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ParentLogTransactionId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/ProfileId__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/ProfileId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ProfileId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/ProfileName__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/ProfileName__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>ProfileName__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/Scenario__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/Scenario__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Scenario__c</fullName>
     <businessStatus>DeprecateCandidate</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/SessionId__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/SessionId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>SessionId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/SessionSecurityLevel__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/SessionSecurityLevel__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>SessionSecurityLevel__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/SessionType__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/SessionType__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>SessionType__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/SourceIp__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/SourceIp__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>SourceIp__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/TimeZoneId__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/TimeZoneId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>TimeZoneId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/TimeZoneName__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/TimeZoneName__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>TimeZoneName__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/TransactionScenario__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/TransactionScenario__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>TransactionScenario__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserLicenseDefinitionKey__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserLicenseDefinitionKey__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserLicenseDefinitionKey__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <description>https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_userlicense.htm</description>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserLicenseId__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserLicenseId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserLicenseId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserLicenseName__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserLicenseName__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserLicenseName__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserLoggingLevelOrdinal__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserLoggingLevelOrdinal__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserLoggingLevelOrdinal__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserLoggingLevel__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserLoggingLevel__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserLoggingLevel__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserRoleId__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserRoleId__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserRoleId__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserRoleName__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserRoleName__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserRoleName__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserType__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/UserType__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>UserType__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>CCPA;GDPR;PII</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/permissionsets/LoggerLogCreator.permissionset-meta.xml
+++ b/nebula-logger/core/main/logger-engine/permissionsets/LoggerLogCreator.permissionset-meta.xml
@@ -31,7 +31,7 @@
     <description
     >Provides access to generate log entries via Apex, Lightning Components, Flow and Process Builder. This is currently optional, but required if/when Salesforce activates the release update called &quot;Require User Access to Apex Classes Invoked by Flow&quot;.</description>
     <hasActivationRequired>false</hasActivationRequired>
-    <label>Logger: Log Creator</label>
+    <label>Nebula Logger: Log Creator</label>
     <objectPermissions>
         <allowCreate>true</allowCreate>
         <allowDelete>false</allowDelete>

--- a/nebula-logger/core/tests/configuration/classes/LoggerCache_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/configuration/classes/LoggerCache_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
@@ -47,6 +47,17 @@ private class LoggerParameter_Tests {
     }
 
     @IsTest
+    static void it_should_return_constant_value_for_enable_log_entry_event_stream() {
+        Boolean mockValue = false;
+        LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'EnableLogEntryEventStream', Value__c = JSON.serialize(mockValue));
+        LoggerParameter.setMock(mockParameter);
+
+        Boolean returnedValue = LoggerParameter.ENABLE_LOG_ENTRY_EVENT_STREAM;
+
+        System.Assert.areEqual(mockValue, returnedValue);
+    }
+
+    @IsTest
     static void it_should_return_constant_value_for_enable_system_messages() {
         Boolean mockValue = false;
         LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'EnableLoggerSystemMessages', Value__c = JSON.serialize(mockValue));

--- a/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/configuration/classes/LoggerPlugin_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerPlugin_Tests.cls
@@ -9,6 +9,22 @@ private class LoggerPlugin_Tests {
     private static final String PLUGIN_LOG_STATUS = 'On Hold';
 
     @IsTest
+    static void it_should_returned_all_enabled_plugin_configurations() {
+        LoggerPlugin__mdt firstMockPluginConfiguration = createMockPluginConfiguration('Some_Mock_Plugin_Configuration');
+        LoggerPlugin.setMock(firstMockPluginConfiguration);
+        LoggerPlugin__mdt secondMockPluginConfiguration = createMockPluginConfiguration('Another_Mock_Plugin_Configuration');
+        LoggerPlugin.setMock(secondMockPluginConfiguration);
+        List<LoggerPlugin__mdt> expectedPluginConfigurations = new List<LoggerPlugin__mdt>{ firstMockPluginConfiguration, secondMockPluginConfiguration };
+
+        List<LoggerPlugin__mdt> returnedPluginConfigurations = LoggerPlugin.getPluginConfigurations();
+
+        expectedPluginConfigurations.sort();
+        returnedPluginConfigurations.sort();
+        System.Assert.areEqual(expectedPluginConfigurations.size(), returnedPluginConfigurations.size());
+        System.Assert.areEqual(expectedPluginConfigurations, returnedPluginConfigurations);
+    }
+
+    @IsTest
     static void it_should_returned_filtered_plugin_configurations_in_sorted_order() {
         // The mock LoggerPlugin__mdt records are purposeful being added to LoggerPlugin.setMock()
         // in an order that's different from the order when sorting on SObjectHandlerExecutionOrder__c.

--- a/nebula-logger/core/tests/configuration/classes/LoggerPlugin_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/configuration/classes/LoggerPlugin_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/configuration/classes/LoggerScenarioRule_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/configuration/classes/LoggerScenarioRule_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls-meta.xml
+++ b/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LogBatchPurgeController_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LogBatchPurgeController_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LogBatchPurgeScheduler_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LogBatchPurgeScheduler_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LogBatchPurger_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LogBatchPurger_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventStreamController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventStreamController_Tests.cls
@@ -7,6 +7,17 @@
 @IsTest
 private class LogEntryEventStreamController_Tests {
     @IsTest
+    static void it_should_return_is_enabled_parameter() {
+        Boolean mockValue = false;
+        LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'EnableLogEntryEventStream', Value__c = JSON.serialize(mockValue));
+        LoggerParameter.setMock(mockParameter);
+
+        Boolean returnedValue = LogEntryEventStreamController.isEnabled();
+
+        System.Assert.areEqual(mockValue, returnedValue);
+    }
+
+    @IsTest
     static void it_should_return_list_of_fields_configured_in_logger_parameters() {
         String fields = '["Timestamp__c", "LoggedByUsername__c", "OriginLocation__c"]';
         LoggerTestConfigurator.setMock(

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventStreamController_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventStreamController_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LogEntryFieldSetPicklist_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryFieldSetPicklist_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LogEntryTagHandler_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryTagHandler_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LogManagementDataSelector_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogManagementDataSelector_Tests.cls
@@ -14,6 +14,7 @@ private class LogManagementDataSelector_Tests {
 
         List<SObject> returnedResults = LogManagementDataSelector.getInstance().getAll(targetSObjectType, targetFieldNames);
 
+        System.Assert.areEqual(1, returnedResults.size());
         System.Assert.areEqual(expectedResults, returnedResults);
     }
 
@@ -363,6 +364,18 @@ private class LogManagementDataSelector_Tests {
     }
 
     @IsTest
+    static void it_returns_empty_list_without_querying_when_specified_search_term_is_blank() {
+        String blankSearchTerm = '    \t \n \r    ';
+        System.Assert.isTrue(String.isBlank(blankSearchTerm));
+        List<User> expectedResults = new List<User>();
+
+        List<User> returnedResults = LogManagementDataSelector.getInstance().getUsersByNameSearch(blankSearchTerm);
+
+        System.Assert.areEqual(expectedResults, returnedResults);
+        System.Assert.areEqual(0, System.Limits.getQueries());
+    }
+
+    @IsTest
     static void it_returns_user_for_specified_search_term() {
         String searchTerm = System.UserInfo.getLastName();
         List<User> expectedResults = [SELECT Id, Name, Username, SmallPhotoUrl FROM User WHERE Name LIKE :searchTerm OR Username LIKE :searchTerm];
@@ -372,6 +385,7 @@ private class LogManagementDataSelector_Tests {
         expectedResults.sort();
         returnedResults.sort();
         System.Assert.areEqual(expectedResults, returnedResults);
+        System.Assert.areEqual(2, System.Limits.getQueries());
     }
 
     @IsTest
@@ -387,6 +401,7 @@ private class LogManagementDataSelector_Tests {
         expectedResults.sort();
         returnedResults.sort();
         System.Assert.areEqual(expectedResults, returnedResults);
+        System.Assert.areEqual(2, System.Limits.getQueries());
     }
 
     @IsTest

--- a/nebula-logger/core/tests/log-management/classes/LogManagementDataSelector_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogManagementDataSelector_Tests.cls
@@ -10,7 +10,7 @@ private class LogManagementDataSelector_Tests {
     static void it_dynamically_queries_all_records_for_specified_sobject_type_and_fields() {
         Schema.SObjectType targetSObjectType = Schema.Organization.SObjectType;
         Set<String> targetFieldNames = new Set<String>{ Schema.Organization.Id.getDescribe().getName(), Schema.Organization.Name.getDescribe().getName() };
-        List<Organization> expectedResults = Database.query('SELECT ' + String.join(new List<String>(targetFieldNames), ', ') + ' FROM ' + targetSObjectType);
+        List<Organization> expectedResults = Database.query('SELECT ' + String.join(targetFieldNames, ', ') + ' FROM ' + targetSObjectType);
 
         List<SObject> returnedResults = LogManagementDataSelector.getInstance().getAll(targetSObjectType, targetFieldNames);
 
@@ -22,9 +22,7 @@ private class LogManagementDataSelector_Tests {
         Schema.SObjectType targetSObjectType = Schema.User.SObjectType;
         Set<String> targetFieldNames = new Set<String>{ Schema.User.Id.getDescribe().getName(), Schema.User.Name.getDescribe().getName() };
         List<Id> targetIds = new List<Id>(new Map<Id, User>([SELECT Id FROM User LIMIT 3]).keySet());
-        List<User> expectedResults = Database.query(
-            'SELECT ' + String.join(new List<String>(targetFieldNames), ', ') + ' FROM ' + targetSObjectType + ' WHERE Id IN :targetIds'
-        );
+        List<User> expectedResults = Database.query('SELECT ' + String.join(targetFieldNames, ', ') + ' FROM ' + targetSObjectType + ' WHERE Id IN :targetIds');
 
         List<SObject> returnedResults = LogManagementDataSelector.getInstance().getById(targetSObjectType, targetFieldNames, targetIds);
 

--- a/nebula-logger/core/tests/log-management/classes/LogManagementDataSelector_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LogManagementDataSelector_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LogMassDeleteExtension_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LogMassDeleteExtension_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LogViewerController_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LogViewerController_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LoggerBatchableContext_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LoggerBatchableContext_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LoggerEmailSender_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LoggerEmailSender_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LoggerHomeHeaderController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerHomeHeaderController_Tests.cls
@@ -23,6 +23,8 @@ private class LoggerHomeHeaderController_Tests {
         LoggerHomeHeaderController.Environment returnedEnvironment = LoggerHomeHeaderController.getEnvironmentDetails();
 
         Organization organization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
+        System.Assert.isNull(returnedEnvironment.loggerEnabledPluginsCount);
+        System.Assert.isNull(returnedEnvironment.loggerEnabledPlugins);
         System.Assert.areEqual(
             String.isNotBlank(Logger.getNamespacePrefix()) == true ? Logger.getNamespacePrefix() : '(none)',
             returnedEnvironment.loggerNamespacePrefix
@@ -56,6 +58,8 @@ private class LoggerHomeHeaderController_Tests {
         LoggerHomeHeaderController.Environment returnedEnvironment = LoggerHomeHeaderController.getEnvironmentDetails();
 
         Organization organization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
+        System.Assert.isNull(returnedEnvironment.loggerEnabledPluginsCount);
+        System.Assert.isNull(returnedEnvironment.loggerEnabledPlugins);
         System.Assert.areEqual(
             String.isNotBlank(Logger.getNamespacePrefix()) == true ? Logger.getNamespacePrefix() : '(none)',
             returnedEnvironment.loggerNamespacePrefix
@@ -83,6 +87,8 @@ private class LoggerHomeHeaderController_Tests {
         LoggerHomeHeaderController.Environment returnedEnvironment = LoggerHomeHeaderController.getEnvironmentDetails();
 
         Organization organization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
+        System.Assert.isNull(returnedEnvironment.loggerEnabledPluginsCount);
+        System.Assert.isNull(returnedEnvironment.loggerEnabledPlugins);
         System.Assert.areEqual(
             String.isNotBlank(Logger.getNamespacePrefix()) == true ? Logger.getNamespacePrefix() : '(none)',
             returnedEnvironment.loggerNamespacePrefix
@@ -101,6 +107,31 @@ private class LoggerHomeHeaderController_Tests {
         System.Assert.areEqual('Unknown', returnedEnvironment.organizationReleaseNumber);
         System.Assert.areEqual('Unknown', returnedEnvironment.organizationReleaseVersion);
         System.Assert.areEqual(organization.OrganizationType, returnedEnvironment.organizationType);
+    }
+
+    @IsTest
+    public static void it_returns_environment_details_when_plugins_are_installed() {
+        LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'CallStatusApi', Value__c = System.JSON.serialize(false)));
+        LoggerPlugin__mdt firstMockPluginConfiguration = createMockPluginConfiguration('Some_Mock_Plugin_Configuration');
+        LoggerPlugin.setMock(firstMockPluginConfiguration);
+        LoggerPlugin__mdt secondMockPluginConfiguration = createMockPluginConfiguration('Another_Mock_Plugin_Configuration');
+        LoggerPlugin.setMock(secondMockPluginConfiguration);
+        List<LoggerPlugin__mdt> expectedPluginConfigurations = LoggerPlugin.getPluginConfigurations();
+        System.Assert.areEqual(2, expectedPluginConfigurations.size());
+
+        LoggerHomeHeaderController.Environment returnedEnvironment = LoggerHomeHeaderController.getEnvironmentDetails();
+
+        List<String> pluginLabels = new List<String>();
+        for (LoggerPlugin__mdt pluginConfiguration : expectedPluginConfigurations) {
+            pluginLabels.add(pluginConfiguration.Label);
+        }
+        pluginLabels.sort();
+        System.Assert.areEqual(pluginLabels.size(), returnedEnvironment.loggerEnabledPluginsCount);
+        System.Assert.areEqual(String.join(pluginLabels, ', '), returnedEnvironment.loggerEnabledPlugins);
+    }
+
+    private static LoggerPlugin__mdt createMockPluginConfiguration(String developerName) {
+        return new LoggerPlugin__mdt(DeveloperName = developerName, IsEnabled__c = true);
     }
 
     private static Logger.StatusApiResponse createMockStatusApiResponse() {

--- a/nebula-logger/core/tests/log-management/classes/LoggerHomeHeaderController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerHomeHeaderController_Tests.cls
@@ -23,7 +23,7 @@ private class LoggerHomeHeaderController_Tests {
         LoggerHomeHeaderController.Environment returnedEnvironment = LoggerHomeHeaderController.getEnvironmentDetails();
 
         Organization organization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
-        System.Assert.isNull(returnedEnvironment.loggerEnabledPluginsCount);
+        System.Assert.areEqual(0, returnedEnvironment.loggerEnabledPluginsCount);
         System.Assert.isNull(returnedEnvironment.loggerEnabledPlugins);
         System.Assert.areEqual(
             String.isNotBlank(Logger.getNamespacePrefix()) == true ? Logger.getNamespacePrefix() : '(none)',
@@ -58,7 +58,7 @@ private class LoggerHomeHeaderController_Tests {
         LoggerHomeHeaderController.Environment returnedEnvironment = LoggerHomeHeaderController.getEnvironmentDetails();
 
         Organization organization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
-        System.Assert.isNull(returnedEnvironment.loggerEnabledPluginsCount);
+        System.Assert.areEqual(0, returnedEnvironment.loggerEnabledPluginsCount);
         System.Assert.isNull(returnedEnvironment.loggerEnabledPlugins);
         System.Assert.areEqual(
             String.isNotBlank(Logger.getNamespacePrefix()) == true ? Logger.getNamespacePrefix() : '(none)',
@@ -87,7 +87,7 @@ private class LoggerHomeHeaderController_Tests {
         LoggerHomeHeaderController.Environment returnedEnvironment = LoggerHomeHeaderController.getEnvironmentDetails();
 
         Organization organization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
-        System.Assert.isNull(returnedEnvironment.loggerEnabledPluginsCount);
+        System.Assert.areEqual(0, returnedEnvironment.loggerEnabledPluginsCount);
         System.Assert.isNull(returnedEnvironment.loggerEnabledPlugins);
         System.Assert.areEqual(
             String.isNotBlank(Logger.getNamespacePrefix()) == true ? Logger.getNamespacePrefix() : '(none)',

--- a/nebula-logger/core/tests/log-management/classes/LoggerHomeHeaderController_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LoggerHomeHeaderController_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LoggerSObjectMetadata_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LoggerSObjectMetadata_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LoggerScenarioHandler_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LoggerScenarioHandler_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/LoggerTagHandler_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/LoggerTagHandler_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/classes/RelatedLogEntriesController_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/classes/RelatedLogEntriesController_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/log-management/utilities/LoggerTestConfigurator.cls-meta.xml
+++ b/nebula-logger/core/tests/log-management/utilities/LoggerTestConfigurator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/classes/ComponentLogger_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/classes/ComponentLogger_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/classes/FlowCollectionLogEntry_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowCollectionLogEntry_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/classes/FlowLogEntry_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowLogEntry_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/classes/FlowLogger_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowLogger_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/classes/FlowRecordLogEntry_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowRecordLogEntry_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/classes/LogMessage_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/classes/LogMessage_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerDataStore_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerDataStore_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerEngineDataSelector_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerEngineDataSelector_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerSObjectHandler_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerSObjectHandler_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerSObjectProxy_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerSObjectProxy_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerTriggerableContext_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerTriggerableContext_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/core/tests/logger-engine/utilities/LoggerMockDataStore.cls-meta.xml
+++ b/nebula-logger/core/tests/logger-engine/utilities/LoggerMockDataStore.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/AccessType.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/AccessType.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/Assert.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/Assert.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/AuraHandledException.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/AuraHandledException.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/CalloutException.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/CalloutException.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/DmlException.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/DmlException.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/ExampleInboundEmailHandler.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/ExampleInboundEmailHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/FeatureManagement.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/FeatureManagement.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/FieldSet.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/FieldSet.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/FieldSetMember.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/FieldSetMember.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/Http.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/Http.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/HttpCalloutMock.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/HttpCalloutMock.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/HttpRequest.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/HttpRequest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/HttpResponse.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/HttpResponse.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/IllegalArgumentException.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/IllegalArgumentException.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/Limits.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/Limits.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/LoggingLevel.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/LoggingLevel.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/NebulaLogger_E2E_Tests.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/NebulaLogger_E2E_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/Network.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/Network.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/SObjectAccessDecision.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/SObjectAccessDecision.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/SObjectField.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/SObjectField.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/SObjectType.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/SObjectType.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/Security.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/Security.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/Test.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/Test.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/Type.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/Type.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/classes/UserInfo.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/UserInfo.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/flows/LogEntryHandler_Screen_Tests_for_Flow.flow-meta.xml
+++ b/nebula-logger/extra-tests/flows/LogEntryHandler_Screen_Tests_for_Flow.flow-meta.xml
@@ -87,7 +87,7 @@
         </inputParameters>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <description>A screen Flow used to help test the Apex class LogEntryHandler</description>
     <interviewLabel>LogEntryHandler Screen Tests for Flow {!$Flow.CurrentDateTime}</interviewLabel>
     <label>LogEntryHandler Screen Tests for Flow</label>

--- a/nebula-logger/extra-tests/flows/LogEntryHandler_Tests_Flow.flow-meta.xml
+++ b/nebula-logger/extra-tests/flows/LogEntryHandler_Tests_Flow.flow-meta.xml
@@ -50,7 +50,7 @@
         </inputParameters>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <description>An auto-launched Flow used to help test the Apex class LogEntryHandler</description>
     <interviewLabel>LogEntryHandler_Tests_Flow {!$Flow.CurrentDateTime}</interviewLabel>
     <label>LogEntryHandler Tests for Flow</label>

--- a/nebula-logger/extra-tests/flows/LogEntryHandler_Tests_Scheduled_Flow.flow-meta.xml
+++ b/nebula-logger/extra-tests/flows/LogEntryHandler_Tests_Scheduled_Flow.flow-meta.xml
@@ -50,7 +50,7 @@
         </inputParameters>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <description>A scheduled Flow used in tests to verify that LogEntryHandler automatically logs details about the Flow (metadata data)</description>
     <interviewLabel>LogEntryHandler_Tests_Scheduled_Flow {!$Flow.CurrentDateTime}</interviewLabel>
     <label>LogEntryHandler_Tests_Scheduled_Flow</label>

--- a/nebula-logger/extra-tests/flows/MockLogBatchPurgerPlugin.flow-meta.xml
+++ b/nebula-logger/extra-tests/flows/MockLogBatchPurgerPlugin.flow-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <assignments>
         <name>Assign_example_value_0</name>
         <label>Assign example value</label>

--- a/nebula-logger/extra-tests/flows/MockLoggerSObjectHandlerPlugin.flow-meta.xml
+++ b/nebula-logger/extra-tests/flows/MockLoggerSObjectHandlerPlugin.flow-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <assignments>
         <name>Assign_example_value_0</name>
         <label>Assign example value</label>

--- a/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Database.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Database.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Flow.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Flow.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Network.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Network.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Security.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/LogEntryEventBuilder_Tests_Security.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/tests/LogEntryHandler_Tests_EmailMessage.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/LogEntryHandler_Tests_EmailMessage.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/tests/LogEntryHandler_Tests_Flow.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/LogEntryHandler_Tests_Flow.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/tests/LogManagementDataSelector_Tests_Flow.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/LogManagementDataSelector_Tests_Flow.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/tests/LoggerCache_Tests_PlatformCache.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/LoggerCache_Tests_PlatformCache.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/tests/LoggerEngineDataSelector_Tests_Network.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/LoggerEngineDataSelector_Tests_Network.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/tests/LoggerSObjectHandler_Tests_Flow.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/LoggerSObjectHandler_Tests_Flow.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/tests/LoggerSettingsController_Tests_Security.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/LoggerSettingsController_Tests_Security.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/tests/Logger_Tests_InboundEmailHandler.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/Logger_Tests_InboundEmailHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/tests/Logger_Tests_MergeResult.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/Logger_Tests_MergeResult.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/extra-tests/tests/Logger_Tests_Network.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/Logger_Tests_Network.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/managed-package/core/main/configuration/classes/LoggerInstallHandler.cls-meta.xml
+++ b/nebula-logger/managed-package/core/main/configuration/classes/LoggerInstallHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/managed-package/core/main/configuration/classes/LoggerInstallHandler_Tests.cls-meta.xml
+++ b/nebula-logger/managed-package/core/main/configuration/classes/LoggerInstallHandler_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/managed-package/core/main/deprecated/aura/logJSONViewer/logJSONViewer.cmp-meta.xml
+++ b/nebula-logger/managed-package/core/main/deprecated/aura/logJSONViewer/logJSONViewer.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <description>View a log and its entries in JSON format</description>
 </AuraDefinitionBundle>

--- a/nebula-logger/managed-package/core/main/deprecated/classes/LoggerEmailUtils.cls-meta.xml
+++ b/nebula-logger/managed-package/core/main/deprecated/classes/LoggerEmailUtils.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/managed-package/core/main/deprecated/classes/LoggerEmailUtils_Tests.cls-meta.xml
+++ b/nebula-logger/managed-package/core/main/deprecated/classes/LoggerEmailUtils_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/managed-package/core/main/deprecated/classes/LoggerSObjectHandlerPlugin.cls-meta.xml
+++ b/nebula-logger/managed-package/core/main/deprecated/classes/LoggerSObjectHandlerPlugin.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/managed-package/core/main/deprecated/classes/LoggerSObjectHandlerPlugin_Tests.cls-meta.xml
+++ b/nebula-logger/managed-package/core/main/deprecated/classes/LoggerSObjectHandlerPlugin_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/managed-package/core/main/deprecated/classes/LoggerTestUtils.cls-meta.xml
+++ b/nebula-logger/managed-package/core/main/deprecated/classes/LoggerTestUtils.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/managed-package/sfdx-project.json
+++ b/nebula-logger/managed-package/sfdx-project.json
@@ -1,7 +1,7 @@
 {
     "namespace": "Nebula",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "57.0",
+    "sourceApiVersion": "58.0",
     "packageDirectories": [
         {
             "package": "Nebula Logger - Managed Package",

--- a/nebula-logger/managed-package/sfdx-project.json
+++ b/nebula-logger/managed-package/sfdx-project.json
@@ -27,6 +27,6 @@
         "Nebula Logger - Managed Package@4.7.0-spring-22-release": "04t5Y0000015lXNQAY",
         "Nebula Logger - Managed Package@4.8.0-summer-22-release": "04t5Y0000015lsgQAA",
         "Nebula Logger - Managed Package@4.9.0-winter-23-release": "04t5Y0000023R28QAE",
-        "Nebula Logger - Managed Package@4.10.0-spring-23-release": "04t5Y0000015nWeQAI"
+        "Nebula Logger - Managed Package@4.10.0-spring-23-release": "04t5Y0000023SI1QAM"
     }
 }

--- a/nebula-logger/managed-package/sfdx-project.json
+++ b/nebula-logger/managed-package/sfdx-project.json
@@ -13,7 +13,7 @@
             "versionNumber": "4.11.0.NEXT",
             "versionName": "Summer '23 Release",
             "versionDescription": "View the v4.11.0 milestone in GitHub for the list of changes - https://github.com/jongpie/NebulaLogger/milestone/11?closed=1",
-            "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases"
+            "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases/tag/v4.11.0"
         }
     ],
     "packageAliases": {

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogBatchApexErrorEventHandler.cls-meta.xml
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogBatchApexErrorEventHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogBatchApexErrorEventHandler_Tests.cls-meta.xml
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogBatchApexErrorEventHandler_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFinalizer.cls-meta.xml
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFinalizer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFinalizer_Tests.cls-meta.xml
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFinalizer_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFlowExecutionErrorEventHandler.cls-meta.xml
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFlowExecutionErrorEventHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFlowExecutionErrorEventHandler_Tests.cls-meta.xml
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFlowExecutionErrorEventHandler_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/async-failure-additions/plugin/flows/LoggerFlowExecutionErrorEventHandling.flow-meta.xml
+++ b/nebula-logger/plugins/async-failure-additions/plugin/flows/LoggerFlowExecutionErrorEventHandling.flow-meta.xml
@@ -15,7 +15,7 @@
             </value>
         </inputParameters>
     </actionCalls>
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <description
     >`FlowExecutionErrorEvent` messages are created and fired by the platform when Screen Flows have unhandled errors, but Apex can&apos;t subscribe to them, so we use this platform event-driven Flow to call an Apex action to log errors. Subscribers can enable this functionality using a Logger Parameter: &quot;Is FlowExecutionErrorEvent Handled?&quot;</description>
     <interviewLabel>Nebula Logger: Flow {!$Flow.CurrentDateTime}</interviewLabel>

--- a/nebula-logger/plugins/async-failure-additions/plugin/triggers/LogBatchApexErrorEventTrigger.trigger-meta.xml
+++ b/nebula-logger/plugins/async-failure-additions/plugin/triggers/LogBatchApexErrorEventTrigger.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveBuilder.cls-meta.xml
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveBuilder.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveBuilder_Tests.cls-meta.xml
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveBuilder_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveController.cls-meta.xml
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveController_Tests.cls-meta.xml
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveController_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchivePlugin.cls-meta.xml
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchivePlugin.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchivePlugin_Tests.cls-meta.xml
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchivePlugin_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/big-object-archiving/plugin/lwc/logEntryArchives/logEntryArchives.js-meta.xml
+++ b/nebula-logger/plugins/big-object-archiving/plugin/lwc/logEntryArchives/logEntryArchives.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <isExposed>false</isExposed>
     <masterLabel>Log Entry Archives</masterLabel>
     <targets>

--- a/nebula-logger/plugins/big-object-archiving/plugin/lwc/logEntryArchives/logEntryArchives.js-meta.xml
+++ b/nebula-logger/plugins/big-object-archiving/plugin/lwc/logEntryArchives/logEntryArchives.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>58.0</apiVersion>
     <isExposed>false</isExposed>
-    <masterLabel>Log Entry Archives</masterLabel>
+    <masterLabel>Nebula Logger: Log Entry Archives</masterLabel>
     <targets>
         <target>lightning__Tab</target>
     </targets>

--- a/nebula-logger/plugins/big-object-archiving/plugin/permissionsets/LoggerLogEntryArchiveAdmin.permissionset-meta.xml
+++ b/nebula-logger/plugins/big-object-archiving/plugin/permissionsets/LoggerLogEntryArchiveAdmin.permissionset-meta.xml
@@ -657,7 +657,7 @@
         <readable>true</readable>
     </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
-    <label>Logger: Log Entry Archive Admin</label>
+    <label>Nebula Logger: Log Entry Archive Admin</label>
     <objectPermissions>
         <allowCreate>true</allowCreate>
         <allowDelete>true</allowDelete>

--- a/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter.cls-meta.xml
+++ b/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter_Tests.cls-meta.xml
+++ b/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionRulesPlugin.cls-meta.xml
+++ b/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionRulesPlugin.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionRulesPlugin_Tests.cls-meta.xml
+++ b/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionRulesPlugin_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin.cls-meta.xml
+++ b/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin_Tests.cls-meta.xml
+++ b/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin_Tests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/plugins/slack/plugin/slack/permissionsets/LoggerSlackPluginAdmin.permissionset-meta.xml
+++ b/nebula-logger/plugins/slack/plugin/slack/permissionsets/LoggerSlackPluginAdmin.permissionset-meta.xml
@@ -16,5 +16,5 @@
         <readable>true</readable>
     </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
-    <label>Logger: Slack Plugin Admin</label>
+    <label>Nebula Logger: Slack Plugin Admin</label>
 </PermissionSet>

--- a/nebula-logger/recipes/aura/loggerAuraDemo/loggerAuraDemo.cmp-meta.xml
+++ b/nebula-logger/recipes/aura/loggerAuraDemo/loggerAuraDemo.cmp-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <description>A Lightning Component Bundle</description>
 </AuraDefinitionBundle>

--- a/nebula-logger/recipes/classes/Account_Batch_Logger_Example.cls-meta.xml
+++ b/nebula-logger/recipes/classes/Account_Batch_Logger_Example.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/recipes/classes/Account_Queueable_Logger_Example.cls-meta.xml
+++ b/nebula-logger/recipes/classes/Account_Queueable_Logger_Example.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/recipes/classes/ExampleBigObjectDataGenerator.cls-meta.xml
+++ b/nebula-logger/recipes/classes/ExampleBigObjectDataGenerator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/recipes/classes/ExampleClassWithLogging.cls-meta.xml
+++ b/nebula-logger/recipes/classes/ExampleClassWithLogging.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/recipes/classes/LoggerLWCDemoController.cls-meta.xml
+++ b/nebula-logger/recipes/classes/LoggerLWCDemoController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/nebula-logger/recipes/flexipages/Logger_Recipes_UtilityBar.flexipage-meta.xml
+++ b/nebula-logger/recipes/flexipages/Logger_Recipes_UtilityBar.flexipage-meta.xml
@@ -8,7 +8,7 @@
         <name>backgroundComponents</name>
         <type>Background</type>
     </flexiPageRegions>
-    <masterLabel>Logger Recipes UtilityBar</masterLabel>
+    <masterLabel>Nebula Logger: Logger Recipes UtilityBar</masterLabel>
     <template>
         <name>one:utilityBarTemplateDesktop</name>
         <properties>

--- a/nebula-logger/recipes/flows/Account_Flow_Logger_Example.flow-meta.xml
+++ b/nebula-logger/recipes/flows/Account_Flow_Logger_Example.flow-meta.xml
@@ -81,7 +81,7 @@
         </inputParameters>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <assignments>
         <description>An example field update</description>
         <name>Update_Account</name>

--- a/nebula-logger/recipes/flows/Account_Process_Logger_Example.flow-meta.xml
+++ b/nebula-logger/recipes/flows/Account_Process_Logger_Example.flow-meta.xml
@@ -354,7 +354,7 @@
             </value>
         </inputParameters>
     </actionCalls>
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <decisions>
         <processMetadataValues>
             <name>index</name>

--- a/nebula-logger/recipes/flows/Account_Record_Launched_Flow_Example.flow-meta.xml
+++ b/nebula-logger/recipes/flows/Account_Record_Launched_Flow_Example.flow-meta.xml
@@ -50,7 +50,7 @@
         </inputParameters>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </actionCalls>
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <interviewLabel>Account_Record_Launched_Flow_Example {!$Flow.CurrentDateTime}</interviewLabel>
     <label>Account: Record Launched Flow Example</label>
     <processMetadataValues>

--- a/nebula-logger/recipes/lwc/loggerLWCDemo/loggerLWCDemo.js-meta.xml
+++ b/nebula-logger/recipes/lwc/loggerLWCDemo/loggerLWCDemo.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__Tab</target>

--- a/nebula-logger/recipes/lwc/loggerLWCLegacyDemo/loggerLWCLegacyDemo.js-meta.xml
+++ b/nebula-logger/recipes/lwc/loggerLWCLegacyDemo/loggerLWCLegacyDemo.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__Tab</target>

--- a/nebula-logger/recipes/triggers/Account_Trigger_Logger_Example.trigger-meta.xml
+++ b/nebula-logger/recipes/triggers/Account_Trigger_Logger_Example.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>58.0</apiVersion>
     <status>Active</status>
 </ApexTrigger>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.10.6",
+    "version": "4.11.0",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/scripts/build/create-and-install-package-version.ps1
+++ b/scripts/build/create-and-install-package-version.ps1
@@ -120,8 +120,10 @@ function Update-README-Package-Version-Id {
     ((Get-Content -path $targetreadme -Raw) -replace "btn-install-unlocked-package-sandbox.png\)\]\(https:\/\/test.salesforce.com\/packaging\/installPackage.apexp\?p0=.{0,18}", $sandboxUnlockedPackageReplacement) | Set-Content -Path $targetreadme -NoNewline
     $productionUnlockedPackageReplacement = "btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=$packageVersionId"
     ((Get-Content -path $targetreadme -Raw) -replace "btn-install-unlocked-package-production.png\)\]\(https:\/\/login.salesforce.com\/packaging\/installPackage.apexp\?p0=.{0,18}", $productionUnlockedPackageReplacement) | Set-Content -Path $targetreadme -NoNewline
-    $sfdxUnlockedPackageReplacement = "sfdx package install --wait 20 --security-type AdminsOnly --package $packageVersionId"
-    ((Get-Content -path $targetreadme -Raw) -replace "sfdx package install --wait 20 --security-type AdminsOnly --package .{0,18}", $sfdxUnlockedPackageReplacement) | Set-Content -Path $targetreadme -NoNewline
+    $sfUnlockedPackageReplacement = "sf package install --wait 20 --security-type AdminsOnly --package $packageVersionId"
+    ((Get-Content -path $targetreadme -Raw) -replace "sf package install --wait 20 --security-type AdminsOnly --package .{0,18}", $sfUnlockedPackageReplacement) | Set-Content -Path $targetreadme -NoNewline
+    $sfdxUnlockedPackageReplacement = "sfdx force:package:install --wait 20 --securitytype AdminsOnly --package $packageVersionId"
+    ((Get-Content -path $targetreadme -Raw) -replace "sfdx force:package:install --wait 20 --securitytype AdminsOnly --package .{0,18}", $sfdxUnlockedPackageReplacement) | Set-Content -Path $targetreadme -NoNewline
 }
 
 function Install-Package-Version {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -147,7 +147,7 @@
         "Nebula Logger - Core@4.10.4-new-logger-home-page": "04t5Y0000023SC7QAM",
         "Nebula Logger - Core@4.10.5-new-custom-index-for-origin-location-field": "04t5Y0000023SCHQA2",
         "Nebula Logger - Core@4.10.6-more-log__c-and-logentry__c-fields": "04t5Y0000023SCqQAM",
-        "Nebula Logger - Core@4.11.0-summer-'23-release": "04t5Y0000023SDUQA2",
+        "Nebula Logger - Core@4.11.0-summer-'23-release": "04t5Y0000023SI6QAM",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -147,6 +147,7 @@
         "Nebula Logger - Core@4.10.4-new-logger-home-page": "04t5Y0000023SC7QAM",
         "Nebula Logger - Core@4.10.5-new-custom-index-for-origin-location-field": "04t5Y0000023SCHQA2",
         "Nebula Logger - Core@4.10.6-more-log__c-and-logentry__c-fields": "04t5Y0000023SCqQAM",
+        "Nebula Logger - Core@4.11.0-summer-'23-release": "04t5Y0000023SDUQA2",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,7 +1,7 @@
 {
     "name": "Nebula Logger",
     "namespace": "",
-    "sourceApiVersion": "57.0",
+    "sourceApiVersion": "58.0",
     "sfdcLoginUrl": "https://login.salesforce.com",
     "plugins": {
         "sfdx-plugin-prettier": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -13,9 +13,9 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.10.6.NEXT",
-            "versionName": "More Log__c and LogEntry__c fields",
-            "versionDescription": "Added more fields to capture additional Flow details, organization details, and browser details via logger LWC",
+            "versionNumber": "4.11.0.NEXT",
+            "versionName": "Summer '23 Release",
+            "versionDescription": "Updated all metadata to API v58.0, added LoggerParameter__mdt record to disable the LWC logEntryEventStream",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"


### PR DESCRIPTION
# Manage Package Changes

One change in this PR that's specific to the manage package: `.forceignore` has been updated to exclude the new `CustomIndex` for the field `LogEntry__c.OriginLocation__c` (added in [`v4.10.5`](https://github.com/jongpie/NebulaLogger/releases/tag/v4.10.5)). The `CustomIndex` metadata type is considered generally available by Salesforce, but there have been a handful of gack errors reported that are related to the custom index failing to deploy in some orgs. So, as a precaution, the `CustomIndex` is unfortunately being excluded from the managed package this release to avoid any related upgrade issues - hopefully, the index will be added to the next managed package version, [the Winter '24 release](https://github.com/jongpie/NebulaLogger/milestone/12).

# Core Unlocked Package Changes

## Metadata API Version Updated to `v58.0`
- Updated all metadata to API `v58.0` (Summer '23 release)
- Updated some picklist values to have options for API v58.0 and 59.0
- Simplified some Apex calls to `String.join()` to remove extra conversions of `Set<String>` to `List<String>` - Summer '23 now supports iterating over `Set<Object>`
- Retrieved the metadata for fields & objects so the repo's version more closely matches the XML returned by the platform

## `logEntryEventStream` LWC Enhancements
Currently, the LWC `logEntryEventStream` uses the [emp API](https://developer.salesforce.com/docs/component-library/bundle/lightning-emp-api/nocumentation) to subscribe/display the stream of `LogEntryEvent__e` platform events, which counts towards your org's daily limit for platform event delivery allocation ([the docs for Platform Event Allocations](https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_event_limits.htm) has more details on this limit). 

To help mitigate the usage of the org daily limit for platform event daily delivery allocations, this release includes 2 related changes:

  - Added new control "Max Number of Events to Stream" (shown as `#1` in the screenshot below) to set the max number of events to deliver to the LWC before the component auto-pauses the stream. A counter of the total number of events streamed for your session has also been added (shown as `#2` in the screenshot below), as well as a `<lightning-progress-ring>` to show the percentage of events to stream before the component auto-pauses itself (shown as `#3` in the screenshot below) 
    
     ![image](https://github.com/jongpie/NebulaLogger/assets/1267157/90ab86d2-4907-4741-8c66-34d0170f70b6)

  - Resolved #488 by adding new `LoggerParameter__mdt` record `EnableLogEntryEventStream` - when set to false, the entire component is completely disabled for the entire organization. The buttons on the LWC are hidden, input elements are disabled, and a warning message is displayed:
   
     ![image](https://github.com/jongpie/NebulaLogger/assets/1267157/79879537-96bf-4698-9f21-5d69cd1125d6)

## `loggerHomeHeader` LWC Enhancements
- Added plugin information to the header component in 2 places:
  - Added a count of enabled plugins directly below the lightning card's title. This only displays when 1 or more plugins are enabled in your org (not available in the managed package)
    
    ![image](https://github.com/jongpie/NebulaLogger/assets/1267157/da81bf6f-21ac-4a59-b1a7-299686d28dd0)

  - Added a comma-separated list of enabled plugins to 'Environment Details' button modal. This only displays when 1 or more plugins are enabled in your org (not available in the managed package)
    
    ![image](https://github.com/jongpie/NebulaLogger/assets/1267157/2ba23a03-5f4f-4dd6-bf54-e1f6a68aefae)

## `LoggerHomePage` FlexiPage Changes
- Updated the `LoggerAdmin` dashboard component on the `LoggerHomePage` FlexiPage to _not_ hide the dashboard on error (controlled by updating the `componentInstanceProperties` attribute `hideOnError` to `false` - shown in App Builder with MS Paint's amazing ⚡ shape in the screenshot below). Previously, if the dashboard had any errors (such as permission issues with the running user), the home page just displayed an unhelpful empty space in place of the dashboard, making it hard to tell if the page had loaded properly or if the dashboard had an error. Now, the dashboard will display either way.

  ![image](https://github.com/jongpie/NebulaLogger/assets/1267157/2ef94636-75bf-4327-9820-4957c0e58ee6)


## `LoggerAdmin` Dashboard Changes
- Removed the XML node `<runningUser>test-triqc8kt7jj0@example.com</runningUser>` in `LoggerAdmin.dashboard-meta.xml` that caused problems for orgs that deploy the metadata (instead of using the unlocked or managed packages)
  - This value was from a scratch org used for building the dashboard, and including it in the metadata worked fine when deploying to other scratch orgs & when creating/installing package versions (even though that particular username would not exist in other orgs). However, when deploying Nebula Logger's metadata to production orgs, the deployment would fail due to not being able to find the matching user. Removing the XML node entirely avoids the deployment issue altogether, and seems cleaner than storing a random scratch org username inside of `git`

## More Label Changes
- Updated the labels for several metadata items to start with "Nebula Logger" (instead of just "Logger") for clarity on what metadata is part of Nebula Logger - this is especially helpful in orgs that deploy the metadata (instead of using the unlocked or managed packages). The changed metadata includes:
  - `AnimationRule`
  - `CustomPermission`
  - `FlexiPage`
  - `GlobalValueSet`
  - LWCs
  - Permission Sets
  - Visualforce page

## Updated Permission Sets
- Small bugfix from [`v4.10.6` release](https://github.com/jongpie/NebulaLogger/releases/tag/v4.10.6) - updated the `LoggerAdmin` & `LoggerLogViewer` permission sets to add missing Apex class access to `LoggerHomeHeaderController`

# `README.md` & Pipeline Changes
- Updated `README.md` to include the package installation command for the SF CLI (in addition to the SFDX CLI)
- Updated `README.md` to use the "classic" commands for SFDX CLI to better support people that are still using older versions of the SFDX CLI
- Updated the pipeline's pwsh script so it automatically update the package version ID in `README.md` for the new SF CLI command