### PR TITLE
Increase coverage for LoggerEngineDataSelector to >75%

### DIFF
--- a/nebula-logger/core/tests/logger-engine/classes/LoggerEngineDataSelector_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerEngineDataSelector_Tests.cls
@@ -176,6 +176,23 @@ private class LoggerEngineDataSelector_Tests {
         System.Assert.isNull(returnedUser);
     }
 
+    @IsTest
+    static void it_returns_a_list_of_network_proxies() {
+
+        Map<Id, Network> networkMap = new Map<Id, Network>([
+            SELECT Id
+            FROM Network
+        ]);
+
+        Test.startTest();
+
+        Map<Id, LoggerSObjectProxy.Network> proxyMap = LoggerEngineDataSelector.getInstance().getNetworkProxies(new List<Id>(networkMap.keySet()));
+
+        Test.stopTest();
+
+        System.assertEquals(networkMap.size(), proxyMap.size(), 'Should get a proxy for each provided network id');
+    }
+
     private class MockLoggerEngineDataSelector extends LoggerEngineDataSelector {
         private Integer authSessionQueryCount = 0;
         private Integer organizationQueryCount = 0;


### PR DESCRIPTION
Increases coverage for `LoggerEngineDataSelector` by testing `LoggerEngineDataSelector.getNetworkProxies()`. This class previously had only 69% coverage, causing issues when RunSpecifiedTests.

The way this test is written, it should pass and get the necessary coverage even if there are zero `Network`s in the org (is this even possible?)

Very happy to learn how you'd like this updated to see it merged - I see my code style is a little different to other functions in this class but not quite sure exactly how you'd like it.