### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 4. Enable logging and set the logging level for different users & profiles using `LoggerSettings__c` custom hierarchy setting
     - In addition to the required fields on this Custom Setting record, `LoggerSettings__c` ships with `SystemLogMessageFormat__c`, which uses Handlebars-esque syntax to refer to fields on the `LogEntryEvent__e` Platform Event. You can use curly braces to denote merge field logic, eg: `{OriginLocation__c}\n{Message__c}` - this will output the contents of `LogEntryEvent__e.OriginLocation__c`, a line break, and then the contents of `LogEntryEvent__e.Message__c`
 5. Automatically mask sensitive data by configuring `LogEntryDataMaskRule__mdt` custom metadata rules
-6. View related log entries on any Lighting SObject flexipage by adding the 'Related Log Entries' component in App Builder
+6. View related log entries on any Lightning SObject flexipage by adding the 'Related Log Entries' component in App Builder
 7. Dynamically assign tags to `Log__c` and `LogEntry__c` records for tagging/labeling your logs
 8. Plugin framework: easily build or install plugins that enhance the `Log__c` and `LogEntry__c` objects, using Apex or Flow (not currently available in the managed package)
 9. Event-Driven Integrations with [Platform Events](https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_events_intro.htm), an event-driven messaging architecture. External integrations can subscribe to log events using the `LogEntryEvent__e` object - see more details at [the Platform Events Developer Guide site](https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_events_subscribe_cometd.htm)

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/LogEntry__c.object-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/LogEntry__c.object-meta.xml
@@ -150,7 +150,7 @@
     <compactLayoutAssignment>LogEntryCompactLayout</compactLayoutAssignment>
     <deploymentStatus>Deployed</deploymentStatus>
     <description
-    >Used by Nebula Logger to represent a single log message within a transaction - log entries can be generated via Apex, Flow, Process Builder, Lighting Web Components, and Aura Components.</description>
+    >Used by Nebula Logger to represent a single log message within a transaction - log entries can be generated via Apex, Flow, Process Builder, Lightning Web Components, and Aura Components.</description>
     <enableActivities>true</enableActivities>
     <enableBulkApi>true</enableBulkApi>
     <enableFeeds>true</enableFeeds>


### PR DESCRIPTION
Typo in the README jumped out at me when I first browsed the repo, decided to grep for it and found another instance.
