### PR TITLE
Added custom index for Log__c.LogRetentionDate__c

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.11.4
+## Unlocked Package - v4.11.5
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZdPQAW)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZdPQAW)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.11.5
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZdPQAW)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZdPQAW)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZdZQAW)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZdZQAW)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001HZdPQAW`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001HZdZQAW`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001HZdPQAW`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001HZdZQAW`
 
 ---
 

--- a/nebula-logger/core/main/log-management/customindex/Log__c.LogRetentionDate__c.indx-meta.xml
+++ b/nebula-logger/core/main/log-management/customindex/Log__c.LogRetentionDate__c.indx-meta.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomIndex xmlns="http://soap.sforce.com/2006/04/metadata">
+    <allowNullValues>true</allowNullValues>
+</CustomIndex>

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.11.4';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.11.5';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final Set<String> IGNORED_APEX_CLASSES = initializeIgnoredApexClasses();
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
@@ -6,7 +6,7 @@
 import { LightningElement, api } from 'lwc';
 import { createLoggerService } from './loggerService';
 
-const CURRENT_VERSION_NUMBER = 'v4.11.4';
+const CURRENT_VERSION_NUMBER = 'v4.11.5';
 
 export default class Logger extends LightningElement {
     #loggerService = createLoggerService();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.11.4",
+    "version": "4.11.5",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -13,9 +13,9 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.11.4.NEXT",
-            "versionName": "Removed Chatter dependencies",
-            "versionDescription": "Removed several Chatter components from FlexiPages - the use of these components would block the installation of Nebula Logger in orgs with Chatter disabled",
+            "versionNumber": "4.11.5.NEXT",
+            "versionName": "Custom Index for Log Retention Date",
+            "versionDescription": "Added a custom index to Log__c.LogRetentionDate__c to help speed up the job LogBatchPurger in orgs with large data volumes (LDV)",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -152,6 +152,7 @@
         "Nebula Logger - Core@4.11.2-new-exception-methods-for-apex": "04t5Y000001TsZAQA0",
         "Nebula Logger - Core@4.11.3-bugfix-for-unhandled-email-exception": "04t5Y000001HZd0QAG",
         "Nebula Logger - Core@4.11.4-removed-chatter-dependencies": "04t5Y000001HZdPQAW",
+        "Nebula Logger - Core@4.11.5-custom-index-for-log-retention-date": "04t5Y000001HZdZQAW",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
The data purge job `LogBatchPurger` filters on the field `Log__c.LogRetentionDate__c` in several queries to determine which records to delete. In orgs with large data volumes (LDV), the queries can have performance issues because the field is not indexed. Now that custom indexes are generally available (GA), a new custom index for the field `Log__c.LogRetentionDate__c` should help speed up the LogBatchPurger job (among other things that use this field, such as list views, etc.).