### PR TITLE
New method + overloads Logger.setAsyncContext()

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
               if: ${{ github.event_name == 'pull_request' }}
               shell: bash
               run: |
+                  npx sf version
                   echo "${{ env.DEV_HUB_JWT_SERVER_KEY }}" > ./jwt-server.key
                   npx sf org login jwt --instance-url ${{ env.DEV_HUB_AUTH_URL }} --client-id ${{ env.DEV_HUB_CONSUMER_KEY }} --username ${{ env.DEV_HUB_BOT_USERNAME }} --jwt-key-file ./jwt-server.key --set-default-dev-hub
               env:
@@ -149,6 +150,7 @@ jobs:
             - name: 'Authorize Dev Hub'
               shell: bash
               run: |
+                  npx sf version
                   echo "${{ env.DEV_HUB_JWT_SERVER_KEY }}" > ./jwt-server.key
                   npx sf org login jwt --instance-url ${{ env.DEV_HUB_AUTH_URL }} --client-id ${{ env.DEV_HUB_CONSUMER_KEY }} --username ${{ env.DEV_HUB_BOT_USERNAME }} --jwt-key-file ./jwt-server.key --set-default-dev-hub
               env:
@@ -210,6 +212,7 @@ jobs:
             - name: 'Authorize Dev Hub'
               shell: bash
               run: |
+                  npx sf version
                   echo "${{ env.DEV_HUB_JWT_SERVER_KEY }}" > ./jwt-server.key
                   npx sf org login jwt --instance-url ${{ env.DEV_HUB_AUTH_URL }} --client-id ${{ env.DEV_HUB_CONSUMER_KEY }} --username ${{ env.DEV_HUB_BOT_USERNAME }} --jwt-key-file ./jwt-server.key --set-default-dev-hub
               env:
@@ -283,6 +286,7 @@ jobs:
             - name: 'Authorize Dev Hub'
               shell: bash
               run: |
+                  npx sf version
                   echo "${{ env.DEV_HUB_JWT_SERVER_KEY }}" > ./jwt-server.key
                   npx sf org login jwt --instance-url ${{ env.DEV_HUB_AUTH_URL }} --client-id ${{ env.DEV_HUB_CONSUMER_KEY }} --username ${{ env.DEV_HUB_BOT_USERNAME }} --jwt-key-file ./jwt-server.key --set-default-dev-hub
               env:
@@ -328,6 +332,7 @@ jobs:
             - name: 'Authorize Dev Hub'
               shell: bash
               run: |
+                  npx sf version
                   echo "${{ env.DEV_HUB_JWT_SERVER_KEY }}" > ./jwt-server.key
                   npx sf org login jwt --instance-url ${{ env.DEV_HUB_AUTH_URL }} --client-id ${{ env.DEV_HUB_CONSUMER_KEY }} --username ${{ env.DEV_HUB_BOT_USERNAME }} --jwt-key-file ./jwt-server.key --set-default-dev-hub
               env:
@@ -401,6 +406,7 @@ jobs:
             - name: 'Authorize Dev Hub'
               shell: bash
               run: |
+                  npx sf version
                   echo "${{ env.DEV_HUB_JWT_SERVER_KEY }}" > ./jwt-server.key
                   npx sf org login jwt --instance-url ${{ env.DEV_HUB_AUTH_URL }} --client-id ${{ env.DEV_HUB_CONSUMER_KEY }} --username ${{ env.DEV_HUB_BOT_USERNAME }} --jwt-key-file ./jwt-server.key --set-default-dev-hub
               env:

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.11.6
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZdZQAW)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZdZQAW)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZfGQAW)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZfGQAW)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001HZdZQAW`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001HZfGQAW`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001HZdZQAW`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001HZfGQAW`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.11.5
+## Unlocked Package - v4.11.6
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZdZQAW)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZdZQAW)

--- a/docs/apex/Logger-Engine/Logger.md
+++ b/docs/apex/Logger-Engine/Logger.md
@@ -3550,6 +3550,8 @@ String
 
 The current API version, in the format `v00.0`
 
+#### `getPackageId()` → `String`
+
 #### `getParentLogTransactionId()` → `String`
 
 Returns the transaction ID value that will be used to relate the current transaction&apos;s log to a parent log
@@ -4850,6 +4852,46 @@ Saves any entries in Logger&apos;s buffer, using the specified save method for o
 | ---------------- | ------------------------------------------------------------------------- |
 | `saveMethodName` | The String value of the save method to use for this specific save action. |
 
+#### `setAsyncContext(Database.BatchableContext batchableContext)` → `void`
+
+Stores additional details about the current transacation&apos;s async context
+
+##### Parameters
+
+| Param              | Description                                            |
+| ------------------ | ------------------------------------------------------ |
+| `batchableContext` | - The instance of `Database.BatchableContext` to track |
+
+#### `setAsyncContext(System.FinalizerContext finalizerContext)` → `void`
+
+Stores additional details about the current transacation&apos;s async context
+
+##### Parameters
+
+| Param              | Description                                          |
+| ------------------ | ---------------------------------------------------- |
+| `finalizerContext` | - The instance of `System.FinalizerContext` to track |
+
+#### `setAsyncContext(System.QueueableContext queueableContext)` → `void`
+
+Stores additional details about the current transacation&apos;s async context
+
+##### Parameters
+
+| Param              | Description                                          |
+| ------------------ | ---------------------------------------------------- |
+| `queueableContext` | - The instance of `System.QueueableContext` to track |
+
+#### `setAsyncContext(System.SchedulableContext schedulableContext)` → `void`
+
+Stores additional details about the current transacation&apos;s async context
+
+##### Parameters
+
+| Param                | Description                                            |
+| -------------------- | ------------------------------------------------------ |
+| `schedulableContext` | - The instance of `System.SchedulableContext` to track |
+
 #### `setParentLogTransactionId(String parentTransactionId)` → `void`
 
 Relates the current transaction&apos;s log to a parent log via the field Log**c.ParentLog**c This is useful for relating multiple asynchronous operations together, such as batch &amp; queueable jobs.
@@ -5764,13 +5806,29 @@ A string containing the UUID value.
 
 ##### Properties
 
+###### `childJobId` → `String`
+
+###### `jobId` → `String`
+
 ###### `key` → `String`
 
 ###### `name` → `String`
 
+###### `triggerId` → `String`
+
+###### `type` → `String`
+
 ---
 
 ##### Methods
+
+###### `AsyncContext(Database.BatchableContext batchableContext)` → `public`
+
+###### `AsyncContext(System.FinalizerContext finalizerContext)` → `public`
+
+###### `AsyncContext(System.QueueableContext queueableContext)` → `public`
+
+###### `AsyncContext(System.SchedulableContext schedulableContext)` → `public`
 
 ###### `insertRecords(List<SObject> records)` → `void`
 

--- a/docs/apex/Logger-Engine/Logger.md
+++ b/docs/apex/Logger-Engine/Logger.md
@@ -3550,8 +3550,6 @@ String
 
 The current API version, in the format `v00.0`
 
-#### `getPackageId()` → `String`
-
 #### `getParentLogTransactionId()` → `String`
 
 Returns the transaction ID value that will be used to relate the current transaction&apos;s log to a parent log
@@ -5808,11 +5806,11 @@ A string containing the UUID value.
 
 ###### `childJobId` → `String`
 
-###### `jobId` → `String`
-
 ###### `key` → `String`
 
 ###### `name` → `String`
+
+###### `parentJobId` → `String`
 
 ###### `triggerId` → `String`
 

--- a/docs/apex/Test-Utilities/LoggerMockDataCreator.md
+++ b/docs/apex/Test-Utilities/LoggerMockDataCreator.md
@@ -36,9 +36,9 @@ Creates an instance of the class `MockBatchableContext` that implements the inte
 
 ##### Parameters
 
-| Param   | Description                                                                             |
-| ------- | --------------------------------------------------------------------------------------- |
-| `jobId` | A string value to use as the batchable job ID - this can be a true ID, or just a string |
+| Param   | Description                                                                              |
+| ------- | ---------------------------------------------------------------------------------------- |
+| `jobId` | A string value to use as the async Apex job ID - this can be a true ID, or just a string |
 
 ##### Return
 
@@ -338,6 +338,26 @@ Database.UpsertResult
 
 The mock instance of `Database.UpsertResult`
 
+#### `createFinalizerContext(String asyncApexJobId)` → `MockFinalizerContext`
+
+Creates an instance of the class `MockFinalizerContext` that implements the interface `System.FinalizerContext`. This can be used when testing batch jobs.
+
+##### Parameters
+
+| Param            | Description                                                                              |
+| ---------------- | ---------------------------------------------------------------------------------------- |
+| `asyncApexJobId` | A string value to use as the async Apex job ID - this can be a true ID, or just a string |
+
+##### Return
+
+**Type**
+
+MockFinalizerContext
+
+**Description**
+
+The instance of `MockFinalizerContext`
+
 #### `createHttpCallout()` → `MockHttpCallout`
 
 Generates an instance of the class `MockHttpCallout` that implements the interface `System.HttpCalloutMock`. This can be used when testing batch jobs.
@@ -399,6 +419,46 @@ String
 **Description**
 
 The mock record ID for the specified SObject Type
+
+#### `createQueueableContext(String jobId)` → `MockQueueableContext`
+
+Creates an instance of the class `MockQueueableContext` that implements the interface `System.QueueableContext`. This can be used when testing batch jobs.
+
+##### Parameters
+
+| Param   | Description                                                                              |
+| ------- | ---------------------------------------------------------------------------------------- |
+| `jobId` | A string value to use as the async Apex job ID - this can be a true ID, or just a string |
+
+##### Return
+
+**Type**
+
+MockQueueableContext
+
+**Description**
+
+The instance of `MockQueueableContext`
+
+#### `createSchedulableContext(String jobId)` → `MockSchedulableContext`
+
+Creates an instance of the class `MockSchedulableContext` that implements the interface `System.SchedulableContext`. This can be used when testing batch jobs.
+
+##### Parameters
+
+| Param       | Description                                                                            |
+| ----------- | -------------------------------------------------------------------------------------- |
+| `triggerId` | A string value to use as the cron trigger ID - this can be a true ID, or just a string |
+
+##### Return
+
+**Type**
+
+MockSchedulableContext
+
+**Description**
+
+The instance of `MockSchedulableContext`
 
 #### `createUser()` → `User`
 
@@ -572,7 +632,7 @@ A new copy of the original `SObject` record that has the specified read-only fie
 
 ###### `MockBatchableContext(String jobId)`
 
-###### `MockBatchableContext(String jobId, Id childJobId)`
+###### `MockBatchableContext(String jobId, String childJobId)`
 
 ---
 
@@ -581,6 +641,28 @@ A new copy of the original `SObject` record that has the specified read-only fie
 ###### `getChildJobId()` → `String`
 
 ###### `getJobId()` → `String`
+
+---
+
+#### LoggerMockDataCreator.MockFinalizerContext class
+
+---
+
+##### Constructors
+
+###### `MockFinalizerContext(String asyncApexJobId)`
+
+---
+
+##### Methods
+
+###### `getAsyncApexJobId()` → `String`
+
+###### `getException()` → `Exception`
+
+###### `getRequestId()` → `Id`
+
+###### `getResult()` → `System.ParentJobResult`
 
 ---
 
@@ -617,6 +699,38 @@ A new copy of the original `SObject` record that has the specified read-only fie
 ###### `setStatus(String statusMessage)` → `MockHttpCallout`
 
 ###### `setStatusCode(Integer statusCode)` → `MockHttpCallout`
+
+---
+
+#### LoggerMockDataCreator.MockQueueableContext class
+
+---
+
+##### Constructors
+
+###### `MockQueueableContext(String jobId)`
+
+---
+
+##### Methods
+
+###### `getJobId()` → `String`
+
+---
+
+#### LoggerMockDataCreator.MockSchedulableContext class
+
+---
+
+##### Constructors
+
+###### `MockSchedulableContext(String triggerId)`
+
+---
+
+##### Methods
+
+###### `getTriggerId()` → `String`
 
 ---
 

--- a/docs/apex/Test-Utilities/LoggerMockDataCreator.md
+++ b/docs/apex/Test-Utilities/LoggerMockDataCreator.md
@@ -30,26 +30,6 @@ AggregateResult
 
 The mock instance of `AggregateResult`
 
-#### `createBatchableContext(String jobId)` → `MockBatchableContext`
-
-Creates an instance of the class `MockBatchableContext` that implements the interface `Database.BatchableContext`. This can be used when testing batch jobs.
-
-##### Parameters
-
-| Param   | Description                                                                              |
-| ------- | ---------------------------------------------------------------------------------------- |
-| `jobId` | A string value to use as the async Apex job ID - this can be a true ID, or just a string |
-
-##### Return
-
-**Type**
-
-MockBatchableContext
-
-**Description**
-
-The instance of `MockBatchableContext`
-
 #### `createDataBuilder(Schema.SObjectType sobjectType)` → `SObjectTestDataBuilder`
 
 Creates a new builder instance for the specified `SObjectType`, including creating a new `SObject` record. The new `SObject` record is created with any default field values that have been configured on the `SObjectType`.
@@ -338,26 +318,6 @@ Database.UpsertResult
 
 The mock instance of `Database.UpsertResult`
 
-#### `createFinalizerContext(String asyncApexJobId)` → `MockFinalizerContext`
-
-Creates an instance of the class `MockFinalizerContext` that implements the interface `System.FinalizerContext`. This can be used when testing batch jobs.
-
-##### Parameters
-
-| Param            | Description                                                                              |
-| ---------------- | ---------------------------------------------------------------------------------------- |
-| `asyncApexJobId` | A string value to use as the async Apex job ID - this can be a true ID, or just a string |
-
-##### Return
-
-**Type**
-
-MockFinalizerContext
-
-**Description**
-
-The instance of `MockFinalizerContext`
-
 #### `createHttpCallout()` → `MockHttpCallout`
 
 Generates an instance of the class `MockHttpCallout` that implements the interface `System.HttpCalloutMock`. This can be used when testing batch jobs.
@@ -419,46 +379,6 @@ String
 **Description**
 
 The mock record ID for the specified SObject Type
-
-#### `createQueueableContext(String jobId)` → `MockQueueableContext`
-
-Creates an instance of the class `MockQueueableContext` that implements the interface `System.QueueableContext`. This can be used when testing batch jobs.
-
-##### Parameters
-
-| Param   | Description                                                                              |
-| ------- | ---------------------------------------------------------------------------------------- |
-| `jobId` | A string value to use as the async Apex job ID - this can be a true ID, or just a string |
-
-##### Return
-
-**Type**
-
-MockQueueableContext
-
-**Description**
-
-The instance of `MockQueueableContext`
-
-#### `createSchedulableContext(String jobId)` → `MockSchedulableContext`
-
-Creates an instance of the class `MockSchedulableContext` that implements the interface `System.SchedulableContext`. This can be used when testing batch jobs.
-
-##### Parameters
-
-| Param       | Description                                                                            |
-| ----------- | -------------------------------------------------------------------------------------- |
-| `triggerId` | A string value to use as the cron trigger ID - this can be a true ID, or just a string |
-
-##### Return
-
-**Type**
-
-MockSchedulableContext
-
-**Description**
-
-The instance of `MockSchedulableContext`
 
 #### `createUser()` → `User`
 
@@ -630,17 +550,17 @@ A new copy of the original `SObject` record that has the specified read-only fie
 
 ##### Constructors
 
-###### `MockBatchableContext(String jobId)`
+###### `MockBatchableContext(Id jobId)`
 
-###### `MockBatchableContext(String jobId, String childJobId)`
+###### `MockBatchableContext(Id jobId, Id childJobId)`
 
 ---
 
 ##### Methods
 
-###### `getChildJobId()` → `String`
+###### `getChildJobId()` → `Id`
 
-###### `getJobId()` → `String`
+###### `getJobId()` → `Id`
 
 ---
 
@@ -650,13 +570,13 @@ A new copy of the original `SObject` record that has the specified read-only fie
 
 ##### Constructors
 
-###### `MockFinalizerContext(String asyncApexJobId)`
+###### `MockFinalizerContext(Id asyncApexJobId)`
 
 ---
 
 ##### Methods
 
-###### `getAsyncApexJobId()` → `String`
+###### `getAsyncApexJobId()` → `Id`
 
 ###### `getException()` → `Exception`
 
@@ -708,13 +628,13 @@ A new copy of the original `SObject` record that has the specified read-only fie
 
 ##### Constructors
 
-###### `MockQueueableContext(String jobId)`
+###### `MockQueueableContext(Id jobId)`
 
 ---
 
 ##### Methods
 
-###### `getJobId()` → `String`
+###### `getJobId()` → `Id`
 
 ---
 
@@ -724,13 +644,13 @@ A new copy of the original `SObject` record that has the specified read-only fie
 
 ##### Constructors
 
-###### `MockSchedulableContext(String triggerId)`
+###### `MockSchedulableContext(Id triggerId)`
 
 ---
 
 ##### Methods
 
-###### `getTriggerId()` → `String`
+###### `getTriggerId()` → `Id`
 
 ---
 

--- a/nebula-logger/core/main/log-management/classes/LogBatchPurgeScheduler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogBatchPurgeScheduler.cls
@@ -37,6 +37,7 @@ global with sharing class LogBatchPurgeScheduler implements System.Schedulable {
      * @param schedulableContext The instance of `System.SchedulableContext` provided by the platform at runtime
      */
     global void execute(System.SchedulableContext schedulableContext) {
+        Logger.setAsyncContext(schedulableContext);
         if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
             LogMessage logMessage = new LogMessage(SCHEDULER_SYSTEM_MESSAGE_TEMPLATE, schedulableContext);
             Logger.info(logMessage);

--- a/nebula-logger/core/main/log-management/classes/LogBatchPurger.cls
+++ b/nebula-logger/core/main/log-management/classes/LogBatchPurger.cls
@@ -75,6 +75,7 @@ global with sharing class LogBatchPurger implements Database.Batchable<SObject>,
             throw noDeleteAccessException;
         }
 
+        Logger.setAsyncContext(batchableContext);
         // Each batchable method runs in a separate transaction,
         // so store the first transaction ID to later relate the other transactions
         this.originalTransactionId = Logger.getTransactionId();
@@ -112,6 +113,7 @@ global with sharing class LogBatchPurger implements Database.Batchable<SObject>,
      * @param scopeRecords - The log records to purge.
      */
     global void execute(Database.BatchableContext batchableContext, List<SObject> scopeRecords) {
+        Logger.setAsyncContext(batchableContext);
         Logger.setParentLogTransactionId(this.originalTransactionId);
         try {
             this.totalProcessedRecords += scopeRecords.size();
@@ -135,6 +137,7 @@ global with sharing class LogBatchPurger implements Database.Batchable<SObject>,
      * @param batchableContext - The context of the batch jobs
      */
     global void finish(Database.BatchableContext batchableContext) {
+        Logger.setAsyncContext(batchableContext);
         Logger.setParentLogTransactionId(this.originalTransactionId);
         LoggerBatchableContext input = new LoggerBatchableContext(batchableContext, this.currentSObjectType);
         this.executePlugins(BatchableMethod.FINISH, input, null);

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
@@ -148,6 +148,10 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
                 // TODO Log__c.ApiVersion__c and LogEntryEvent__e.ApiVersion__c are both deprecated,
                 // in a future release, remove this reference (and delete the fields)
                 ApiVersion__c = logEntryEvent.ApiVersion__c,
+                AsyncContextChildJobId__c = logEntryEvent.AsyncContextChildJobId__c,
+                AsyncContextParentJobId__c = logEntryEvent.AsyncContextParentJobId__c,
+                AsyncContextTriggerId__c = logEntryEvent.AsyncContextTriggerId__c,
+                AsyncContextType__c = logEntryEvent.AsyncContextType__c,
                 ImpersonatedBy__c = logEntryEvent.ImpersonatedById__c,
                 Locale__c = logEntryEvent.Locale__c,
                 LoggedBy__c = logEntryEvent.LoggedById__c,

--- a/nebula-logger/core/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <flexiPageRegions>
         <itemInstances>
@@ -548,6 +548,12 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.AsyncContextParentJobId__c</fieldItem>
                 <identifier>RecordAsyncContextParentJobId_cField</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.AsyncContextParentJobId__c}</leftValue>
+                        <operator>NE</operator>
+                    </criteria>
+                </visibilityRule>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -558,6 +564,12 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.AsyncContextChildJobId__c</fieldItem>
                 <identifier>RecordAsyncContextChildJobId_cField</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.AsyncContextChildJobId__c}</leftValue>
+                        <operator>NE</operator>
+                    </criteria>
+                </visibilityRule>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -568,6 +580,12 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.AsyncContextTriggerId__c</fieldItem>
                 <identifier>RecordAsyncContextTriggerId_cField</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.AsyncContextChildJobId__c}</leftValue>
+                        <operator>NE</operator>
+                    </criteria>
+                </visibilityRule>
             </fieldInstance>
         </itemInstances>
         <name>Facet-22c5f237-327a-4fc9-80b3-8305ba0accab</name>
@@ -1061,9 +1079,26 @@
                 <componentName>flexipage:fieldSection</componentName>
                 <identifier>flexipage_fieldSection7</identifier>
                 <visibilityRule>
+                    <booleanFilter>1 OR 2 OR 3 OR 4</booleanFilter>
                     <criteria>
-                        <leftValue>{!Record.AsyncContextChildJobId__c}</leftValue>
-                        <operator>NE</operator>
+                        <leftValue>{!Record.AsyncContextType__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Database.BatchableContext</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!Record.AsyncContextType__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>System.FinalizerContext</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!Record.AsyncContextType__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>System.QueueableContext</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!Record.AsyncContextType__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>System.SchedulableContext</rightValue>
                     </criteria>
                 </visibilityRule>
             </componentInstance>
@@ -1204,10 +1239,98 @@
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>active</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-0f2e71a4-ac08-400c-8f11-6c6e44a085cb</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>title</name>
+                    <value>Log Entries</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:tab</componentName>
+                <identifier>customTab</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-82b9e667-1aa4-42ed-8a09-ac611351ece9</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>title</name>
+                    <value>Standard.Tab.detail</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:tab</componentName>
+                <identifier>detailTab</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-f428f9bd-8335-4c6e-994c-9fb022741a70</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>title</name>
+                    <value>History</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:tab</componentName>
+                <identifier>customTab2</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-0bb71d38-e0b0-4931-838e-b2254d40c2ea</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>title</name>
+                    <value>Related Logs</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:tab</componentName>
+                <identifier>customTab3</identifier>
+            </componentInstance>
+        </itemInstances>
         <name>Facet-4be58932-ea47-4516-80d6-14dedd7c1fc0</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>numberOfTopicsToDisplay</name>
+                    <value>10</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>searchHint</name>
+                    <value>Type a topic name and press Enter.</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>title</name>
+                    <value>Topics</value>
+                </componentInstanceProperties>
+                <componentName>forceChatter:topicsOnRecordWrapper</componentName>
+                <identifier>forceChatter_topicsOnRecordWrapper</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>tabs</name>
+                    <value>Facet-4be58932-ea47-4516-80d6-14dedd7c1fc0</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:tabset</componentName>
+                <identifier>flexipage_tabset</identifier>
+            </componentInstance>
+        </itemInstances>
         <name>main</name>
         <type>Region</type>
     </flexiPageRegions>

--- a/nebula-logger/core/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
@@ -582,7 +582,7 @@
                 <identifier>RecordAsyncContextTriggerId_cField</identifier>
                 <visibilityRule>
                     <criteria>
-                        <leftValue>{!Record.AsyncContextChildJobId__c}</leftValue>
+                        <leftValue>{!Record.AsyncContextTriggerId__c}</leftValue>
                         <operator>NE</operator>
                     </criteria>
                 </visibilityRule>

--- a/nebula-logger/core/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <flexiPageRegions>
         <itemInstances>
@@ -532,6 +532,78 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
+                <fieldItem>Record.AsyncContextType__c</fieldItem>
+                <identifier>RecordAsyncContextType_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-dd5e3466-ea03-4853-be00-33411ed46ec6</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.AsyncContextParentJobId__c</fieldItem>
+                <identifier>RecordAsyncContextParentJobId_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.AsyncContextChildJobId__c</fieldItem>
+                <identifier>RecordAsyncContextChildJobId_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.AsyncContextTriggerId__c</fieldItem>
+                <identifier>RecordAsyncContextTriggerId_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <name>Facet-22c5f237-327a-4fc9-80b3-8305ba0accab</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-dd5e3466-ea03-4853-be00-33411ed46ec6</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column13</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>body</name>
+                    <value>Facet-22c5f237-327a-4fc9-80b3-8305ba0accab</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:column</componentName>
+                <identifier>flexipage_column14</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>Facet-f8d9fe6c-1984-475a-82e2-ceeb68937d16</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.SessionId__c</fieldItem>
                 <identifier>RecordSessionId__cField</identifier>
             </fieldInstance>
@@ -976,6 +1048,30 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>columns</name>
+                    <value>Facet-f8d9fe6c-1984-475a-82e2-ceeb68937d16</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>horizontalAlignment</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>label</name>
+                    <value>Async Context Details</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:fieldSection</componentName>
+                <identifier>flexipage_fieldSection7</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.AsyncContextChildJobId__c}</leftValue>
+                        <operator>NE</operator>
+                    </criteria>
+                </visibilityRule>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>columns</name>
                     <value>Facet-9fb0fd0b-69be-44f7-8c04-fb654709fe28</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
@@ -1108,98 +1204,10 @@
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>active</name>
-                    <value>true</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>body</name>
-                    <value>Facet-0f2e71a4-ac08-400c-8f11-6c6e44a085cb</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>title</name>
-                    <value>Log Entries</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:tab</componentName>
-                <identifier>customTab</identifier>
-            </componentInstance>
-        </itemInstances>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>body</name>
-                    <value>Facet-82b9e667-1aa4-42ed-8a09-ac611351ece9</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>title</name>
-                    <value>Standard.Tab.detail</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:tab</componentName>
-                <identifier>detailTab</identifier>
-            </componentInstance>
-        </itemInstances>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>body</name>
-                    <value>Facet-f428f9bd-8335-4c6e-994c-9fb022741a70</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>title</name>
-                    <value>History</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:tab</componentName>
-                <identifier>customTab2</identifier>
-            </componentInstance>
-        </itemInstances>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>body</name>
-                    <value>Facet-0bb71d38-e0b0-4931-838e-b2254d40c2ea</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>title</name>
-                    <value>Related Logs</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:tab</componentName>
-                <identifier>customTab3</identifier>
-            </componentInstance>
-        </itemInstances>
         <name>Facet-4be58932-ea47-4516-80d6-14dedd7c1fc0</name>
         <type>Facet</type>
     </flexiPageRegions>
     <flexiPageRegions>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>numberOfTopicsToDisplay</name>
-                    <value>10</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>searchHint</name>
-                    <value>Type a topic name and press Enter.</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>title</name>
-                    <value>Topics</value>
-                </componentInstanceProperties>
-                <componentName>forceChatter:topicsOnRecordWrapper</componentName>
-                <identifier>forceChatter_topicsOnRecordWrapper</identifier>
-            </componentInstance>
-        </itemInstances>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>tabs</name>
-                    <value>Facet-4be58932-ea47-4516-80d6-14dedd7c1fc0</value>
-                </componentInstanceProperties>
-                <componentName>flexipage:tabset</componentName>
-                <identifier>flexipage_tabset</identifier>
-            </componentInstance>
-        </itemInstances>
         <name>main</name>
         <type>Region</type>
     </flexiPageRegions>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/AsyncContextChildJobId__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/AsyncContextChildJobId__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AsyncContextChildJobId__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <externalId>false</externalId>
+    <label>Async Context Child Job ID</label>
+    <length>18</length>
+    <required>false</required>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/AsyncContextParentJobId__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/AsyncContextParentJobId__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AsyncContextParentJobId__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <externalId>false</externalId>
+    <label>Async Context Parent Job ID</label>
+    <length>18</length>
+    <required>false</required>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/AsyncContextTriggerId__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/AsyncContextTriggerId__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AsyncContextTriggerId__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <externalId>false</externalId>
+    <label>Async Context Trigger ID</label>
+    <length>18</length>
+    <required>false</required>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/AsyncContextType__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/AsyncContextType__c.field-meta.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AsyncContextType__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <externalId>false</externalId>
+    <label>Async Context Type</label>
+    <required>false</required>
+    <securityClassification>Confidential</securityClassification>sd
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>false</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Database.BatchableContext</fullName>
+                <default>true</default>
+                <label>Database.BatchableContext</label>
+            </value>
+            <value>
+                <fullName>System.FinalizerContext</fullName>
+                <default>false</default>
+                <label>System.FinalizerContext</label>
+            </value>
+            <value>
+                <fullName>System.QueueableContext</fullName>
+                <default>false</default>
+                <label>System.QueueableContext</label>
+            </value>
+            <value>
+                <fullName>System.SchedulableContext</fullName>
+                <default>false</default>
+                <label>System.SchedulableContext</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/AsyncContextType__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/AsyncContextType__c.field-meta.xml
@@ -17,7 +17,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>Database.BatchableContext</fullName>
-                <default>true</default>
+                <default>false</default>
                 <label>Database.BatchableContext</label>
             </value>
             <value>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -835,6 +835,26 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.AsyncContextChildJobId__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.AsyncContextParentJobId__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.AsyncContextTriggerId__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.AsyncContextType__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.ClosedBy__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -615,6 +615,26 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.AsyncContextChildJobId__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.AsyncContextParentJobId__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.AsyncContextTriggerId__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.AsyncContextType__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.EndTime__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -759,6 +759,26 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.AsyncContextChildJobId__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.AsyncContextParentJobId__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.AsyncContextTriggerId__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.AsyncContextType__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.ClosedBy__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -764,7 +764,7 @@ global with sharing class LogEntryEventBuilder {
             this.debugMessage = message;
         }
 
-        // 1 of 2 places in the codebase (except tests) that should use System.debug()
+        // One of few limited places in the codebase (except tests) that should use System.debug()
         // The rest of the codebase should use a method in Logger.cls
         System.debug(this.entryLoggingLevel, this.debugMessage);
     }

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -3464,6 +3464,7 @@ global with sharing class Logger {
          * @param queueableContext The context of the current queue, provided by the platform
          */
         global void execute(System.QueueableContext queueableContext) {
+            Logger.setAsyncContext(queueableContext);
             LoggerDataStore.getEventBus().publishRecords(this.logEntryEvents);
         }
     }

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -24,6 +24,7 @@ global with sharing class Logger {
     private static final Map<String, SaveMethod> SAVE_METHOD_NAME_TO_SAVE_METHOD = new Map<String, SaveMethod>();
     private static final String TRANSACTION_ID = new Uuid().getValue();
 
+    private static AsyncContext currentAsyncContext;
     private static String currentEntryScenario;
     private static Integer currentTransactionEntryNumber = 1;
     @TestVisible
@@ -159,6 +160,38 @@ global with sharing class Logger {
      */
     global static Quiddity getCurrentQuiddity() {
         return TRANSACTION_QUIDDITY;
+    }
+
+    /**
+     * @description Stores additional details about the current transacation's async context
+     * @param  batchableContext - The instance of `Database.BatchableContext` to track
+     */
+    global static void setAsyncContext(Database.BatchableContext batchableContext) {
+        currentAsyncContext = new AsyncContext(batchableContext);
+    }
+
+    /**
+     * @description Stores additional details about the current transacation's async context
+     * @param  finalizerContext - The instance of `System.FinalizerContext` to track
+     */
+    global static void setAsyncContext(System.FinalizerContext finalizerContext) {
+        currentAsyncContext = new AsyncContext(finalizerContext);
+    }
+
+    /**
+     * @description Stores additional details about the current transacation's async context
+     * @param  queueableContext - The instance of `System.QueueableContext` to track
+     */
+    global static void setAsyncContext(System.QueueableContext queueableContext) {
+        currentAsyncContext = new AsyncContext(queueableContext);
+    }
+
+    /**
+     * @description Stores additional details about the current transacation's async context
+     * @param  schedulableContext - The instance of `System.SchedulableContext` to track
+     */
+    global static void setAsyncContext(System.SchedulableContext schedulableContext) {
+        currentAsyncContext = new AsyncContext(schedulableContext);
     }
 
     /**
@@ -3144,11 +3177,8 @@ global with sharing class Logger {
         List<LogEntryEvent__e> logEntryEvents = new List<LogEntryEvent__e>();
         for (LogEntryEventBuilder logEntryEventBuilder : LOG_ENTRIES_BUFFER) {
             if (logEntryEventBuilder.shouldSave() == true) {
-                LogEntryEvent__e logEntryEvent = logEntryEventBuilder.getLogEntryEvent();
-                logEntryEvent.ParentLogTransactionId__c = getParentLogTransactionId();
-                logEntryEvent.TransactionScenario__c = transactionScenario;
-
-                logEntryEvents.add(logEntryEvent);
+                finalizeEntry(logEntryEventBuilder);
+                logEntryEvents.add(logEntryEventBuilder.getLogEntryEvent());
             }
         }
 
@@ -3320,6 +3350,19 @@ global with sharing class Logger {
         return logEntryEventBuilder;
     }
 
+    private static void finalizeEntry(LogEntryEventBuilder logEntryEventBuilder) {
+        LogEntryEvent__e logEntryEvent = logEntryEventBuilder.getLogEntryEvent();
+        logEntryEvent.ParentLogTransactionId__c = getParentLogTransactionId();
+        logEntryEvent.TransactionScenario__c = transactionScenario;
+
+        if (currentAsyncContext != null) {
+            logEntryEvent.AsyncContextChildJobId__c = currentAsyncContext.childJobId;
+            logEntryEvent.AsyncContextParentJobId__c = currentAsyncContext.jobId;
+            logEntryEvent.AsyncContextTriggerId__c = currentAsyncContext.triggerId;
+            logEntryEvent.AsyncContextType__c = currentAsyncContext.type;
+        }
+    }
+
     private static Set<String> initializeIgnoredApexClasses() {
         return new Set<String>{ Logger.class.getName(), LogEntryEventBuilder.class.getName(), LogMessage.class.getName() };
     }
@@ -3440,6 +3483,35 @@ global with sharing class Logger {
     public class StatusApiResponseProduct {
         public String key { get; set; }
         public String name { get; set; }
+    }
+
+    // Inner class for tracking details about the current transaction's async context
+    private class AsyncContext {
+        public final String type;
+        public final String jobId;
+        public final String childJobId;
+        public final String triggerId;
+
+        public AsyncContext(Database.BatchableContext batchableContext) {
+            this.childJobId = batchableContext?.getChildJobId();
+            this.jobId = batchableContext?.getJobId();
+            this.type = Database.BatchableContext.class.getName();
+        }
+
+        public AsyncContext(System.FinalizerContext finalizerContext) {
+            this.jobId = finalizerContext?.getAsyncApexJobId();
+            this.type = System.FinalizerContext.class.getName();
+        }
+
+        public AsyncContext(System.QueueableContext queueableContext) {
+            this.jobId = queueableContext?.getJobId();
+            this.type = System.QueueableContext.class.getName();
+        }
+
+        public AsyncContext(System.SchedulableContext schedulableContext) {
+            this.triggerId = schedulableContext?.getTriggerId();
+            this.type = System.SchedulableContext.class.getName();
+        }
     }
 
     // Inner class for saving log entries via the REST API (using the current user's session ID)

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -3486,6 +3486,7 @@ global with sharing class Logger {
     }
 
     // Inner class for tracking details about the current transaction's async context
+    @SuppressWarnings('PMD.ApexDoc')
     private class AsyncContext {
         public final String type;
         public final String parentJobId;

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -97,10 +97,11 @@ global with sharing class Logger {
     }
 
     static {
-        // 1 of 2 places in the codebase (except tests) that should use System.debug()
+        // One of few limited places in the codebase (except tests) that should use System.debug()
         // The rest of the codebase should use a method in Logger.cls
         System.debug(System.LoggingLevel.INFO, 'Nebula Logger - Version Number: ' + getVersionNumber());
         System.debug(System.LoggingLevel.INFO, 'Nebula Logger - Transaction ID: ' + getTransactionId());
+        System.debug(System.LoggingLevel.INFO, 'Nebula Logger - Organization API Version: ' + getOrganizationApiVersion());
         setScenario(getUserSettings().DefaultScenario__c);
     }
 
@@ -167,7 +168,7 @@ global with sharing class Logger {
      * @param  batchableContext - The instance of `Database.BatchableContext` to track
      */
     global static void setAsyncContext(Database.BatchableContext batchableContext) {
-        currentAsyncContext = new AsyncContext(batchableContext);
+        setAsyncContext(new AsyncContext(batchableContext));
     }
 
     /**
@@ -175,7 +176,7 @@ global with sharing class Logger {
      * @param  finalizerContext - The instance of `System.FinalizerContext` to track
      */
     global static void setAsyncContext(System.FinalizerContext finalizerContext) {
-        currentAsyncContext = new AsyncContext(finalizerContext);
+        setAsyncContext(new AsyncContext(finalizerContext));
     }
 
     /**
@@ -183,7 +184,7 @@ global with sharing class Logger {
      * @param  queueableContext - The instance of `System.QueueableContext` to track
      */
     global static void setAsyncContext(System.QueueableContext queueableContext) {
-        currentAsyncContext = new AsyncContext(queueableContext);
+        setAsyncContext(new AsyncContext(queueableContext));
     }
 
     /**
@@ -191,7 +192,7 @@ global with sharing class Logger {
      * @param  schedulableContext - The instance of `System.SchedulableContext` to track
      */
     global static void setAsyncContext(System.SchedulableContext schedulableContext) {
-        currentAsyncContext = new AsyncContext(schedulableContext);
+        setAsyncContext(new AsyncContext(schedulableContext));
     }
 
     /**
@@ -3040,6 +3041,11 @@ global with sharing class Logger {
     global static void setScenario(String scenario) {
         if (LoggerParameter.USE_FIRST_SCENARIO_FOR_TRANSACTION == false || String.isBlank(transactionScenario) == true) {
             transactionScenario = scenario;
+            // One of few limited places in the codebase (except tests) that should use System.debug()
+            // The rest of the codebase should use a method in Logger.cls
+            if (String.isNotBlank(transactionScenario) == true) {
+                System.debug(System.LoggingLevel.INFO, 'Nebula Logger - Transaction Scenario: ' + transactionScenario);
+            }
         }
 
         if (String.isNotBlank(scenario) == true && scenario == currentEntryScenario) {
@@ -3048,6 +3054,11 @@ global with sharing class Logger {
 
         currentEntryScenario = scenario;
         orderedScenarios.add(scenario);
+        // One of few limited places in the codebase (except tests) that should use System.debug()
+        // The rest of the codebase should use a method in Logger.cls
+        if (String.isNotBlank(transactionScenario) == true) {
+            System.debug(System.LoggingLevel.INFO, 'Nebula Logger - Entry Scenario: ' + currentEntryScenario);
+        }
         LoggerScenarioRule__mdt matchingScenarioRule = LoggerScenarioRule.getInstance(scenario);
         if (matchingScenarioRule != null) {
             LoggerSettings__c userSettings = getUserSettings();
@@ -3384,6 +3395,11 @@ global with sharing class Logger {
         } else {
             return null;
         }
+    }
+
+    private static void setAsyncContext(AsyncContext asyncContext) {
+        currentAsyncContext = asyncContext;
+        System.debug(System.LoggingLevel.INFO, 'Nebula Logger - Async Context: ' + JSON.serializePretty(asyncContext));
     }
 
     private static SaveMethod getSaveMethod(String saveMethodName) {

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.11.5';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.11.6';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final Set<String> IGNORED_APEX_CLASSES = initializeIgnoredApexClasses();
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
@@ -3357,7 +3357,7 @@ global with sharing class Logger {
 
         if (currentAsyncContext != null) {
             logEntryEvent.AsyncContextChildJobId__c = currentAsyncContext.childJobId;
-            logEntryEvent.AsyncContextParentJobId__c = currentAsyncContext.jobId;
+            logEntryEvent.AsyncContextParentJobId__c = currentAsyncContext.parentJobId;
             logEntryEvent.AsyncContextTriggerId__c = currentAsyncContext.triggerId;
             logEntryEvent.AsyncContextType__c = currentAsyncContext.type;
         }
@@ -3488,23 +3488,23 @@ global with sharing class Logger {
     // Inner class for tracking details about the current transaction's async context
     private class AsyncContext {
         public final String type;
-        public final String jobId;
+        public final String parentJobId;
         public final String childJobId;
         public final String triggerId;
 
         public AsyncContext(Database.BatchableContext batchableContext) {
             this.childJobId = batchableContext?.getChildJobId();
-            this.jobId = batchableContext?.getJobId();
+            this.parentJobId = batchableContext?.getJobId();
             this.type = Database.BatchableContext.class.getName();
         }
 
         public AsyncContext(System.FinalizerContext finalizerContext) {
-            this.jobId = finalizerContext?.getAsyncApexJobId();
+            this.parentJobId = finalizerContext?.getAsyncApexJobId();
             this.type = System.FinalizerContext.class.getName();
         }
 
         public AsyncContext(System.QueueableContext queueableContext) {
-            this.jobId = queueableContext?.getJobId();
+            this.parentJobId = queueableContext?.getJobId();
             this.type = System.QueueableContext.class.getName();
         }
 

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
@@ -6,7 +6,7 @@
 import { LightningElement, api } from 'lwc';
 import { createLoggerService } from './loggerService';
 
-const CURRENT_VERSION_NUMBER = 'v4.11.5';
+const CURRENT_VERSION_NUMBER = 'v4.11.6';
 
 export default class Logger extends LightningElement {
     #loggerService = createLoggerService();

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/AsyncContextChildJobId__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/AsyncContextChildJobId__c.field-meta.xml
@@ -4,7 +4,7 @@
     <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <label>Async Context Async Child Job ID</label>
+    <label>Async Context Child Job ID</label>
     <length>18</length>
     <required>false</required>
     <securityClassification>Confidential</securityClassification>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/AsyncContextChildJobId__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/AsyncContextChildJobId__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AsyncContextChildJobId__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <externalId>false</externalId>
+    <label>Async Context Async Child Job ID</label>
+    <length>18</length>
+    <required>false</required>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/AsyncContextParentJobId__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/AsyncContextParentJobId__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AsyncContextParentJobId__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <externalId>false</externalId>
+    <label>Async Context Parent Job ID</label>
+    <length>18</length>
+    <required>false</required>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/AsyncContextTriggerId__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/AsyncContextTriggerId__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AsyncContextTriggerId__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <externalId>false</externalId>
+    <label>Async Context Trigger ID</label>
+    <length>18</length>
+    <required>false</required>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/AsyncContextType__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/AsyncContextType__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>AsyncContextType__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <externalId>false</externalId>
+    <label>Async Context Type</label>
+    <length>255</length>
+    <required>false</required>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
+++ b/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
@@ -34,11 +34,41 @@ public class LoggerMockDataCreator {
     /**
      * @description Creates an instance of the class `MockBatchableContext` that implements the interface `Database.BatchableContext`.
      *              This can be used when testing batch jobs.
-     * @param  jobId A string value to use as the batchable job ID - this can be a true ID, or just a string
+     * @param  jobId A string value to use as the async Apex job ID - this can be a true ID, or just a string
      * @return       The instance of `MockBatchableContext`
      */
     public static MockBatchableContext createBatchableContext(String jobId) {
         return new MockBatchableContext(jobId);
+    }
+
+    /**
+     * @description Creates an instance of the class `MockFinalizerContext` that implements the interface `System.FinalizerContext`.
+     *              This can be used when testing batch jobs.
+     * @param  asyncApexJobId A string value to use as the async Apex job ID - this can be a true ID, or just a string
+     * @return                The instance of `MockFinalizerContext`
+     */
+    public static MockFinalizerContext createFinalizerContext(String asyncApexJobId) {
+        return new MockFinalizerContext(asyncApexJobId);
+    }
+
+    /**
+     * @description Creates an instance of the class `MockQueueableContext` that implements the interface `System.QueueableContext`.
+     *              This can be used when testing batch jobs.
+     * @param  jobId A string value to use as the async Apex job ID - this can be a true ID, or just a string
+     * @return       The instance of `MockQueueableContext`
+     */
+    public static MockQueueableContext createQueueableContext(String jobId) {
+        return new MockQueueableContext(jobId);
+    }
+
+    /**
+     * @description Creates an instance of the class `MockSchedulableContext` that implements the interface `System.SchedulableContext`.
+     *              This can be used when testing batch jobs.
+     * @param  triggerId A string value to use as the cron trigger ID - this can be a true ID, or just a string
+     * @return           The instance of `MockSchedulableContext`
+     */
+    public static MockSchedulableContext createSchedulableContext(String jobId) {
+        return new MockSchedulableContext(jobId);
     }
 
     /**
@@ -438,7 +468,7 @@ public class LoggerMockDataCreator {
             this(jobId, null);
         }
 
-        public MockBatchableContext(String jobId, Id childJobId) {
+        public MockBatchableContext(String jobId, String childJobId) {
             this.jobId = jobId;
             this.childJobId = childJobId;
         }
@@ -449,6 +479,57 @@ public class LoggerMockDataCreator {
 
         public String getChildJobId() {
             return this.childJobId;
+        }
+    }
+
+    @SuppressWarnings('PMD.ApexDoc')
+    public class MockFinalizerContext implements System.FinalizerContext {
+        private String asyncApexJobId;
+
+        public MockFinalizerContext(String asyncApexJobId) {
+            this.asyncApexJobId = asyncApexJobId;
+        }
+
+        public String getAsyncApexJobId() {
+            return this.asyncApexJobId;
+        }
+
+        public Exception getException() {
+            return null;
+        }
+
+        public System.ParentJobResult getResult() {
+            return System.ParentJobResult.SUCCESS;
+        }
+
+        public Id getRequestId() {
+            return System.Request.getCurrent().getRequestId();
+        }
+    }
+
+    @SuppressWarnings('PMD.ApexDoc')
+    public class MockQueueableContext implements System.QueueableContext {
+        private String jobId;
+
+        public MockQueueableContext(String jobId) {
+            this.jobId = jobId;
+        }
+
+        public String getJobId() {
+            return this.jobId;
+        }
+    }
+
+    @SuppressWarnings('PMD.ApexDoc')
+    public class MockSchedulableContext implements System.SchedulableContext {
+        private String triggerId;
+
+        public MockSchedulableContext(String triggerId) {
+            this.triggerId = triggerId;
+        }
+
+        public String getTriggerId() {
+            return this.triggerId;
         }
     }
 

--- a/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
+++ b/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
@@ -34,7 +34,7 @@ public class LoggerMockDataCreator {
     /**
      * @description Creates an instance of the class `MockBatchableContext` that implements the interface `Database.BatchableContext`.
      *              This can be used when testing batch jobs.
-     * @param  jobId A string value to use as the async Apex job ID - this can be a true ID, or just a string
+     * @param  jobId A string value to use as the async Apex job ID
      * @return       The instance of `MockBatchableContext`
      */
     public static MockBatchableContext createBatchableContext(String jobId) {
@@ -44,7 +44,7 @@ public class LoggerMockDataCreator {
     /**
      * @description Creates an instance of the class `MockFinalizerContext` that implements the interface `System.FinalizerContext`.
      *              This can be used when testing batch jobs.
-     * @param  asyncApexJobId A string value to use as the async Apex job ID - this can be a true ID, or just a string
+     * @param  asyncApexJobId A string value to use as the async Apex job ID
      * @return                The instance of `MockFinalizerContext`
      */
     public static MockFinalizerContext createFinalizerContext(String asyncApexJobId) {
@@ -54,7 +54,7 @@ public class LoggerMockDataCreator {
     /**
      * @description Creates an instance of the class `MockQueueableContext` that implements the interface `System.QueueableContext`.
      *              This can be used when testing batch jobs.
-     * @param  jobId A string value to use as the async Apex job ID - this can be a true ID, or just a string
+     * @param  jobId A string value to use as the async Apex job ID
      * @return       The instance of `MockQueueableContext`
      */
     public static MockQueueableContext createQueueableContext(String jobId) {
@@ -461,36 +461,36 @@ public class LoggerMockDataCreator {
 
     @SuppressWarnings('PMD.ApexDoc')
     public class MockBatchableContext implements Database.BatchableContext {
-        private String childJobId;
-        private String jobId;
+        private Id childJobId;
+        private Id jobId;
 
-        public MockBatchableContext(String jobId) {
+        public MockBatchableContext(Id jobId) {
             this(jobId, null);
         }
 
-        public MockBatchableContext(String jobId, String childJobId) {
+        public MockBatchableContext(Id jobId, Id childJobId) {
             this.jobId = jobId;
             this.childJobId = childJobId;
         }
 
-        public String getJobId() {
+        public Id getJobId() {
             return this.jobId;
         }
 
-        public String getChildJobId() {
+        public Id getChildJobId() {
             return this.childJobId;
         }
     }
 
     @SuppressWarnings('PMD.ApexDoc')
     public class MockFinalizerContext implements System.FinalizerContext {
-        private String asyncApexJobId;
+        private Id asyncApexJobId;
 
-        public MockFinalizerContext(String asyncApexJobId) {
+        public MockFinalizerContext(Id asyncApexJobId) {
             this.asyncApexJobId = asyncApexJobId;
         }
 
-        public String getAsyncApexJobId() {
+        public Id getAsyncApexJobId() {
             return this.asyncApexJobId;
         }
 
@@ -509,26 +509,26 @@ public class LoggerMockDataCreator {
 
     @SuppressWarnings('PMD.ApexDoc')
     public class MockQueueableContext implements System.QueueableContext {
-        private String jobId;
+        private Id jobId;
 
-        public MockQueueableContext(String jobId) {
+        public MockQueueableContext(Id jobId) {
             this.jobId = jobId;
         }
 
-        public String getJobId() {
+        public Id getJobId() {
             return this.jobId;
         }
     }
 
     @SuppressWarnings('PMD.ApexDoc')
     public class MockSchedulableContext implements System.SchedulableContext {
-        private String triggerId;
+        private Id triggerId;
 
-        public MockSchedulableContext(String triggerId) {
+        public MockSchedulableContext(Id triggerId) {
             this.triggerId = triggerId;
         }
 
-        public String getTriggerId() {
+        public Id getTriggerId() {
             return this.triggerId;
         }
     }

--- a/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
+++ b/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
@@ -424,6 +424,11 @@ public class LoggerMockDataCreator {
         private Id childJobId;
         private Id jobId;
 
+        public MockBatchableContext() {
+            this.jobId = createId(Schema.AsyncApexJob.SObjectType);
+            this.childJobId = createId(Schema.AsyncApexJob.SObjectType);
+        }
+
         public MockBatchableContext(Id jobId) {
             this(jobId, null);
         }
@@ -445,6 +450,10 @@ public class LoggerMockDataCreator {
     @SuppressWarnings('PMD.ApexDoc')
     public class MockFinalizerContext implements System.FinalizerContext {
         private Id asyncApexJobId;
+
+        public MockBatchableContext() {
+            this.asyncApexJobId = createId(Schema.AsyncApexJob.SObjectType);
+        }
 
         public MockFinalizerContext(Id asyncApexJobId) {
             this.asyncApexJobId = asyncApexJobId;
@@ -470,6 +479,10 @@ public class LoggerMockDataCreator {
     @SuppressWarnings('PMD.ApexDoc')
     public class MockQueueableContext implements System.QueueableContext {
         private Id jobId;
+
+        public MockQueueableContext() {
+            this.jobId = createId(Schema.AsyncApexJob.SObjectType);
+        }
 
         public MockQueueableContext(Id jobId) {
             this.jobId = jobId;

--- a/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
+++ b/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
@@ -67,8 +67,8 @@ public class LoggerMockDataCreator {
      * @param  triggerId A string value to use as the cron trigger ID - this can be a true ID, or just a string
      * @return           The instance of `MockSchedulableContext`
      */
-    public static MockSchedulableContext createSchedulableContext(String jobId) {
-        return new MockSchedulableContext(jobId);
+    public static MockSchedulableContext createSchedulableContext(String triggerId) {
+        return new MockSchedulableContext(triggerId);
     }
 
     /**

--- a/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
+++ b/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
@@ -32,46 +32,6 @@ public class LoggerMockDataCreator {
     }
 
     /**
-     * @description Creates an instance of the class `MockBatchableContext` that implements the interface `Database.BatchableContext`.
-     *              This can be used when testing batch jobs.
-     * @param  jobId A string value to use as the async Apex job ID
-     * @return       The instance of `MockBatchableContext`
-     */
-    public static MockBatchableContext createBatchableContext(String jobId) {
-        return new MockBatchableContext(jobId);
-    }
-
-    /**
-     * @description Creates an instance of the class `MockFinalizerContext` that implements the interface `System.FinalizerContext`.
-     *              This can be used when testing batch jobs.
-     * @param  asyncApexJobId A string value to use as the async Apex job ID
-     * @return                The instance of `MockFinalizerContext`
-     */
-    public static MockFinalizerContext createFinalizerContext(String asyncApexJobId) {
-        return new MockFinalizerContext(asyncApexJobId);
-    }
-
-    /**
-     * @description Creates an instance of the class `MockQueueableContext` that implements the interface `System.QueueableContext`.
-     *              This can be used when testing batch jobs.
-     * @param  jobId A string value to use as the async Apex job ID
-     * @return       The instance of `MockQueueableContext`
-     */
-    public static MockQueueableContext createQueueableContext(String jobId) {
-        return new MockQueueableContext(jobId);
-    }
-
-    /**
-     * @description Creates an instance of the class `MockSchedulableContext` that implements the interface `System.SchedulableContext`.
-     *              This can be used when testing batch jobs.
-     * @param  triggerId A string value to use as the cron trigger ID - this can be a true ID, or just a string
-     * @return           The instance of `MockSchedulableContext`
-     */
-    public static MockSchedulableContext createSchedulableContext(String triggerId) {
-        return new MockSchedulableContext(triggerId);
-    }
-
-    /**
      * @description Creates a mock instance of `Database.LeadConvertResult` - a mock is used instead of an actual instance
      *              to help speed up tests, and to support writing unit tests (instead of integration tests). A fake
      *              record ID is automatically included.

--- a/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
+++ b/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
@@ -451,7 +451,7 @@ public class LoggerMockDataCreator {
     public class MockFinalizerContext implements System.FinalizerContext {
         private Id asyncApexJobId;
 
-        public MockBatchableContext() {
+        public MockFinalizerContext() {
             this.asyncApexJobId = createId(Schema.AsyncApexJob.SObjectType);
         }
 
@@ -496,6 +496,10 @@ public class LoggerMockDataCreator {
     @SuppressWarnings('PMD.ApexDoc')
     public class MockSchedulableContext implements System.SchedulableContext {
         private Id triggerId;
+
+        public MockSchedulableContext() {
+            this.triggerId = createId(Schema.CronTrigger.SObjectType);
+        }
 
         public MockSchedulableContext(Id triggerId) {
             this.triggerId = triggerId;

--- a/nebula-logger/core/tests/log-management/classes/LogBatchPurger_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogBatchPurger_Tests.cls
@@ -59,7 +59,7 @@ private class LogBatchPurger_Tests {
         LogBatchPurger batchJobInstance = new LogBatchPurger();
         batchJobInstance.currentSObjectType = Schema.Log__c.SObjectType;
         List<Log__c> nullLogsList = null;
-        Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
         System.Exception thrownNullPointerException;
 
         try {
@@ -262,7 +262,7 @@ private class LogBatchPurger_Tests {
         System.Assert.isFalse(ranPluginFinish);
         System.Assert.isNull(pluginConfiguration);
         System.Assert.isNull(batchInput);
-        Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
 
         batchJobInstance.start(mockBatchableContext);
 
@@ -315,7 +315,7 @@ private class LogBatchPurger_Tests {
         System.Assert.isNull(batchInput);
         List<Log__c> logsToDelete = [SELECT Id FROM Log__c];
         System.Assert.areNotEqual(0, logsToDelete.size());
-        Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
 
         batchJobInstance.execute(mockBatchableContext, logsToDelete);
 
@@ -367,7 +367,7 @@ private class LogBatchPurger_Tests {
         System.Assert.isFalse(ranPluginFinish);
         System.Assert.isNull(pluginConfiguration);
         System.Assert.isNull(batchInput);
-        Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
 
         batchJobInstance.finish(mockBatchableContext);
 

--- a/nebula-logger/core/tests/log-management/classes/LogBatchPurger_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogBatchPurger_Tests.cls
@@ -59,7 +59,7 @@ private class LogBatchPurger_Tests {
         LogBatchPurger batchJobInstance = new LogBatchPurger();
         batchJobInstance.currentSObjectType = Schema.Log__c.SObjectType;
         List<Log__c> nullLogsList = null;
-        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext();
         System.Exception thrownNullPointerException;
 
         try {
@@ -262,7 +262,7 @@ private class LogBatchPurger_Tests {
         System.Assert.isFalse(ranPluginFinish);
         System.Assert.isNull(pluginConfiguration);
         System.Assert.isNull(batchInput);
-        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext();
 
         batchJobInstance.start(mockBatchableContext);
 
@@ -315,7 +315,7 @@ private class LogBatchPurger_Tests {
         System.Assert.isNull(batchInput);
         List<Log__c> logsToDelete = [SELECT Id FROM Log__c];
         System.Assert.areNotEqual(0, logsToDelete.size());
-        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext();
 
         batchJobInstance.execute(mockBatchableContext, logsToDelete);
 
@@ -367,7 +367,7 @@ private class LogBatchPurger_Tests {
         System.Assert.isFalse(ranPluginFinish);
         System.Assert.isNull(pluginConfiguration);
         System.Assert.isNull(batchInput);
-        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext();
 
         batchJobInstance.finish(mockBatchableContext);
 

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -1194,6 +1194,10 @@ private class LogEntryEventHandler_Tests {
                 ApiReleaseNumber__c,
                 ApiReleaseVersion__c,
                 ApiVersion__c,
+                AsyncContextChildJobId__c,
+                AsyncContextParentJobId__c,
+                AsyncContextTriggerId__c,
+                AsyncContextType__c,
                 Id,
                 Locale__c,
                 LoggedBy__c,
@@ -1354,6 +1358,10 @@ private class LogEntryEventHandler_Tests {
         Id logOwnerId = logEntryEvent.LoggedById__c == null ? System.UserInfo.getUserId() : logEntryEvent.LoggedById__c;
 
         System.Assert.areEqual(logEntryEvent.ApiVersion__c, log.ApiVersion__c, 'log.ApiVersion__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.AsyncContextChildJobId__c, log.AsyncContextChildJobId__c, 'log.AsyncContextChildJobId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.AsyncContextParentJobId__c, log.AsyncContextParentJobId__c, 'log.AsyncContextParentJobId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.AsyncContextTriggerId__c, log.AsyncContextTriggerId__c, 'log.AsyncContextTriggerId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.AsyncContextType__c, log.AsyncContextType__c, 'log.AsyncContextTriggerId__c was not properly set');
         System.Assert.areEqual(logEntryEvent.Locale__c, log.Locale__c, 'log.Locale__c was not properly set');
         System.Assert.areEqual(logEntryEvent.LoggedById__c, log.LoggedBy__c, 'log.LoggedBy__c was not properly set');
         System.Assert.areEqual(logEntryEvent.LoggedByUsername__c, log.LoggedByUsername__c, 'log.LoggedByUsername__c was not properly set');

--- a/nebula-logger/core/tests/log-management/classes/LoggerBatchableContext_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerBatchableContext_Tests.cls
@@ -8,7 +8,7 @@
 private class LoggerBatchableContext_Tests {
     @IsTest
     static void it_constructs_instance_when_both_parameters_provided() {
-        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext();
         Schema.SObjectType sobjectType = Schema.LogEntryEvent__e.SObjectType;
 
         LoggerBatchableContext context = new LoggerBatchableContext(mockBatchableContext, sobjectType);

--- a/nebula-logger/core/tests/log-management/classes/LoggerBatchableContext_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerBatchableContext_Tests.cls
@@ -8,7 +8,7 @@
 private class LoggerBatchableContext_Tests {
     @IsTest
     static void it_constructs_instance_when_both_parameters_provided() {
-        Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
         Schema.SObjectType sobjectType = Schema.LogEntryEvent__e.SObjectType;
 
         LoggerBatchableContext context = new LoggerBatchableContext(mockBatchableContext, sobjectType);

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -657,6 +657,98 @@ private class Logger_Tests {
     }
 
     @IsTest
+    static void it_should_set_async_context_details_for_batchable_context_when_event_published() {
+        Id mockAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
+        Database.BatchableContext mockContext = LoggerMockDataCreator.createBatchableContext(mockAsyncApexJobId);
+        LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        LogEntryEvent__e logEntryEvent = Logger.info('hello, world').getLogEntryEvent();
+        System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextParentJobId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextTriggerId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextType__c);
+
+        Logger.setAsyncContext(mockContext);
+        Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
+
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(logEntryEvent, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0));
+        System.Assert.areEqual(mockContext.getChildJobId(), logEntryEvent.AsyncContextChildJobId__c);
+        System.Assert.areEqual(mockContext.getJobId(), logEntryEvent.AsyncContextParentJobId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextTriggerId__c);
+        System.Assert.areEqual(Database.BatchableContext.class.getName(), logEntryEvent.AsyncContextType__c);
+    }
+
+    @IsTest
+    static void it_should_set_async_context_details_for_finalizer_context_when_event_published() {
+        Id mockAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
+        System.FinalizerContext mockContext = LoggerMockDataCreator.createFinalizerContext(mockAsyncApexJobId);
+        LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        LogEntryEvent__e logEntryEvent = Logger.info('hello, world').getLogEntryEvent();
+        System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextParentJobId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextTriggerId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextType__c);
+
+        Logger.setAsyncContext(mockContext);
+        Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
+
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(logEntryEvent, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0));
+        System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);
+        System.Assert.areEqual(mockContext.getAsyncApexJobId(), logEntryEvent.AsyncContextParentJobId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextTriggerId__c);
+        System.Assert.areEqual(System.FinalizerContext.class.getName(), logEntryEvent.AsyncContextType__c);
+    }
+
+    @IsTest
+    static void it_should_set_async_context_details_for_queueable_context_when_event_published() {
+        Id mockAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
+        System.QueueableContext mockContext = LoggerMockDataCreator.createQueueableContext(mockAsyncApexJobId);
+        LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        LogEntryEvent__e logEntryEvent = Logger.info('hello, world').getLogEntryEvent();
+        System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextParentJobId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextTriggerId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextType__c);
+
+        Logger.setAsyncContext(mockContext);
+        Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
+
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(logEntryEvent, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0));
+        System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);
+        System.Assert.areEqual(mockContext.getJobId(), logEntryEvent.AsyncContextParentJobId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextTriggerId__c);
+        System.Assert.areEqual(System.QueueableContext.class.getName(), logEntryEvent.AsyncContextType__c);
+    }
+
+    @IsTest
+    static void it_should_set_async_context_details_for_schedulable_context_when_event_published() {
+        Id mockAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
+        System.SchedulableContext mockContext = LoggerMockDataCreator.createSchedulableContext(mockAsyncApexJobId);
+        LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        LogEntryEvent__e logEntryEvent = Logger.info('hello, world').getLogEntryEvent();
+        System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextParentJobId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextTriggerId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextType__c);
+
+        Logger.setAsyncContext(mockContext);
+        Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
+
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        System.Assert.areEqual(logEntryEvent, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0));
+        System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);
+        System.Assert.isNull(logEntryEvent.AsyncContextParentJobId__c);
+        System.Assert.areEqual(mockContext.getTriggerId(), logEntryEvent.AsyncContextTriggerId__c);
+        System.Assert.areEqual(System.SchedulableContext.class.getName(), logEntryEvent.AsyncContextType__c);
+    }
+
+    @IsTest
     static void it_should_set_parent_transaction_id() {
         String expectedParentTransactionId = 'imagineThisWereAGuid';
 

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -658,19 +658,24 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_set_async_context_details_for_batchable_context_when_event_published() {
-        Id mockAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
-        Database.BatchableContext mockContext = new LoggerMockDataCreator.MockBatchableContext(mockAsyncApexJobId);
+        Id mockParentAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
+        Id mockChildAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
+        Database.BatchableContext mockContext = new LoggerMockDataCreator.MockBatchableContext(mockParentAsyncApexJobId, mockChildAsyncApexJobId);
+        System.Assert.areEqual(mockChildAsyncApexJobId, mockContext.getChildJobId());
+        System.Assert.areEqual(mockParentAsyncApexJobId, mockContext.getJobId());
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e logEntryEvent = Logger.info('hello, world').getLogEntryEvent();
         System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);
         System.Assert.isNull(logEntryEvent.AsyncContextParentJobId__c);
         System.Assert.isNull(logEntryEvent.AsyncContextTriggerId__c);
         System.Assert.isNull(logEntryEvent.AsyncContextType__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         Logger.setAsyncContext(mockContext);
         Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
 
+        System.Assert.areEqual(0, Logger.getBufferSize());
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         System.Assert.areEqual(logEntryEvent, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0));
         System.Assert.areEqual(mockContext.getChildJobId(), logEntryEvent.AsyncContextChildJobId__c);
@@ -681,19 +686,22 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_set_async_context_details_for_finalizer_context_when_event_published() {
-        Id mockAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
-        System.FinalizerContext mockContext = new LoggerMockDataCreator.MockFinalizerContext(mockAsyncApexJobId);
+        Id mockParentAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
+        System.FinalizerContext mockContext = new LoggerMockDataCreator.MockFinalizerContext(mockParentAsyncApexJobId);
+        System.Assert.areEqual(mockParentAsyncApexJobId, mockContext.getAsyncApexJobId());
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e logEntryEvent = Logger.info('hello, world').getLogEntryEvent();
         System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);
         System.Assert.isNull(logEntryEvent.AsyncContextParentJobId__c);
         System.Assert.isNull(logEntryEvent.AsyncContextTriggerId__c);
         System.Assert.isNull(logEntryEvent.AsyncContextType__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         Logger.setAsyncContext(mockContext);
         Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
 
+        System.Assert.areEqual(0, Logger.getBufferSize());
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         System.Assert.areEqual(logEntryEvent, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0));
         System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);
@@ -704,19 +712,22 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_set_async_context_details_for_queueable_context_when_event_published() {
-        Id mockAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
-        System.QueueableContext mockContext = new LoggerMockDataCreator.MockQueueableContext(mockAsyncApexJobId);
+        Id mockParentAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
+        System.QueueableContext mockContext = new LoggerMockDataCreator.MockQueueableContext(mockParentAsyncApexJobId);
+        System.Assert.areEqual(mockParentAsyncApexJobId, mockContext.getJobId());
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e logEntryEvent = Logger.info('hello, world').getLogEntryEvent();
         System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);
         System.Assert.isNull(logEntryEvent.AsyncContextParentJobId__c);
         System.Assert.isNull(logEntryEvent.AsyncContextTriggerId__c);
         System.Assert.isNull(logEntryEvent.AsyncContextType__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         Logger.setAsyncContext(mockContext);
         Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
 
+        System.Assert.areEqual(0, Logger.getBufferSize());
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         System.Assert.areEqual(logEntryEvent, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0));
         System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);
@@ -727,19 +738,21 @@ private class Logger_Tests {
 
     @IsTest
     static void it_should_set_async_context_details_for_schedulable_context_when_event_published() {
-        Id mockAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
-        System.SchedulableContext mockContext = new LoggerMockDataCreator.MockSchedulableContext(mockAsyncApexJobId);
+        Id mockCronTriggerId = LoggerMockDataCreator.createId(Schema.CronTrigger.SObjectType);
+        System.SchedulableContext mockContext = new LoggerMockDataCreator.MockSchedulableContext(mockCronTriggerId);
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
-        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e logEntryEvent = Logger.info('hello, world').getLogEntryEvent();
         System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);
         System.Assert.isNull(logEntryEvent.AsyncContextParentJobId__c);
         System.Assert.isNull(logEntryEvent.AsyncContextTriggerId__c);
         System.Assert.isNull(logEntryEvent.AsyncContextType__c);
+        System.Assert.areEqual(1, Logger.getBufferSize());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
 
         Logger.setAsyncContext(mockContext);
         Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
 
+        System.Assert.areEqual(0, Logger.getBufferSize());
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         System.Assert.areEqual(logEntryEvent, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0));
         System.Assert.isNull(logEntryEvent.AsyncContextChildJobId__c);

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -659,7 +659,7 @@ private class Logger_Tests {
     @IsTest
     static void it_should_set_async_context_details_for_batchable_context_when_event_published() {
         Id mockAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
-        Database.BatchableContext mockContext = LoggerMockDataCreator.createBatchableContext(mockAsyncApexJobId);
+        Database.BatchableContext mockContext = new LoggerMockDataCreator.MockBatchableContext(mockAsyncApexJobId);
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e logEntryEvent = Logger.info('hello, world').getLogEntryEvent();
@@ -682,7 +682,7 @@ private class Logger_Tests {
     @IsTest
     static void it_should_set_async_context_details_for_finalizer_context_when_event_published() {
         Id mockAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
-        System.FinalizerContext mockContext = LoggerMockDataCreator.createFinalizerContext(mockAsyncApexJobId);
+        System.FinalizerContext mockContext = new LoggerMockDataCreator.MockFinalizerContext(mockAsyncApexJobId);
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e logEntryEvent = Logger.info('hello, world').getLogEntryEvent();
@@ -705,7 +705,7 @@ private class Logger_Tests {
     @IsTest
     static void it_should_set_async_context_details_for_queueable_context_when_event_published() {
         Id mockAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
-        System.QueueableContext mockContext = LoggerMockDataCreator.createQueueableContext(mockAsyncApexJobId);
+        System.QueueableContext mockContext = new LoggerMockDataCreator.MockQueueableContext(mockAsyncApexJobId);
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e logEntryEvent = Logger.info('hello, world').getLogEntryEvent();
@@ -728,7 +728,7 @@ private class Logger_Tests {
     @IsTest
     static void it_should_set_async_context_details_for_schedulable_context_when_event_published() {
         Id mockAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
-        System.SchedulableContext mockContext = LoggerMockDataCreator.createSchedulableContext(mockAsyncApexJobId);
+        System.SchedulableContext mockContext = new LoggerMockDataCreator.MockSchedulableContext(mockAsyncApexJobId);
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e logEntryEvent = Logger.info('hello, world').getLogEntryEvent();

--- a/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Flow.cls
+++ b/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Flow.cls
@@ -59,7 +59,7 @@ private class LogBatchPurger_Tests_Flow {
         LoggerTestConfigurator.setMock(mockPluginConfiguration);
         LogBatchPurger batchJobInstance = new LogBatchPurger();
         batchJobInstance.currentSObjectType = Schema.LogEntry__c.SObjectType;
-        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext();
 
         batchJobInstance.start(mockBatchableContext);
 
@@ -109,7 +109,7 @@ private class LogBatchPurger_Tests_Flow {
         LogBatchPurger batchJobInstance = new LogBatchPurger();
         List<Log__c> logsToDelete = [SELECT Id FROM Log__c];
         System.Assert.areNotEqual(0, logsToDelete.size());
-        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext();
 
         batchJobInstance.execute(mockBatchableContext, logsToDelete);
 
@@ -160,7 +160,7 @@ private class LogBatchPurger_Tests_Flow {
     //     LogBatchPurger batchJobInstance = new LogBatchPurger();
     //     List<Log__c> logsToDelete = [SELECT Id FROM Log__c];
     //     System.Assert.areNotEqual(0, logsToDelete.size(), 'There should be some records to delete');
-    //     Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
+    //     Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext();
 
     //     batchJobInstance.finish(mockBatchableContext);
 

--- a/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Flow.cls
+++ b/nebula-logger/extra-tests/tests/LogBatchPurger_Tests_Flow.cls
@@ -59,7 +59,7 @@ private class LogBatchPurger_Tests_Flow {
         LoggerTestConfigurator.setMock(mockPluginConfiguration);
         LogBatchPurger batchJobInstance = new LogBatchPurger();
         batchJobInstance.currentSObjectType = Schema.LogEntry__c.SObjectType;
-        Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
 
         batchJobInstance.start(mockBatchableContext);
 
@@ -109,7 +109,7 @@ private class LogBatchPurger_Tests_Flow {
         LogBatchPurger batchJobInstance = new LogBatchPurger();
         List<Log__c> logsToDelete = [SELECT Id FROM Log__c];
         System.Assert.areNotEqual(0, logsToDelete.size());
-        Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
+        Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
 
         batchJobInstance.execute(mockBatchableContext, logsToDelete);
 
@@ -160,7 +160,7 @@ private class LogBatchPurger_Tests_Flow {
     //     LogBatchPurger batchJobInstance = new LogBatchPurger();
     //     List<Log__c> logsToDelete = [SELECT Id FROM Log__c];
     //     System.Assert.areNotEqual(0, logsToDelete.size(), 'There should be some records to delete');
-    //     Database.BatchableContext mockBatchableContext = LoggerMockDataCreator.createBatchableContext('some_fake_job_id');
+    //     Database.BatchableContext mockBatchableContext = new LoggerMockDataCreator.MockBatchableContext('some_fake_job_id');
 
     //     batchJobInstance.finish(mockBatchableContext);
 

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFinalizer.cls
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFinalizer.cls
@@ -9,25 +9,26 @@
 public without sharing virtual class LogFinalizer implements System.Finalizer {
     /**
      * @description Is called by any `System.Queueable` where the finalizer is attached after the Queueable's `execute` method finishes
-     * @param fc The `System.FinalizerContext` associated with the finalizer
+     * @param finalizerContext The `System.FinalizerContext` associated with the finalizer
      */
-    public void execute(System.FinalizerContext fc) {
-        switch on fc.getResult() {
+    public void execute(System.FinalizerContext finalizerContext) {
+        Logger.setAsyncContext(finalizerContext);
+        switch on finalizerContext.getResult() {
             when UNHANDLED_EXCEPTION {
                 Logger.error('There was an error during this queueable job');
-                Logger.error('Error details', fc.getException());
+                Logger.error('Error details', finalizerContext.getException());
             }
         }
-        this.innerExecute(fc);
+        this.innerExecute(finalizerContext);
         Logger.saveLog();
     }
 
     /**
      * @description Subscribers can optionally override this method with their own implementation to do further processing/re-queueing
-     * @param fc The `System.FinalizerContext` associated with the finalizer
+     * @param finalizerContext The `System.FinalizerContext` associated with the finalizer
      */
     @SuppressWarnings('PMD.EmptyStatementBlock')
-    protected virtual void innerExecute(System.FinalizerContext fc) {
+    protected virtual void innerExecute(System.FinalizerContext finalizerContext) {
         // subscribers can override this to do their own post-processing if necessary, otherwise it's a no-op
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nebula-logger",
-    "version": "4.11.2",
+    "version": "4.11.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nebula-logger",
-            "version": "4.11.2",
+            "version": "4.11.6",
             "license": "MIT",
             "dependencies": {
                 "@xmldom/xmldom": ">=0.8.4",
@@ -42,7 +42,7 @@
                 "@ljharb/eslint-config": "latest",
                 "@lwc/eslint-plugin-lwc": "latest",
                 "@prettier/plugin-xml": "latest",
-                "@salesforce/cli": "^2.0.0",
+                "@salesforce/cli": "^2.9.8",
                 "@salesforce/eslint-config-lwc": "latest",
                 "@salesforce/eslint-plugin-lightning": "latest",
                 "@salesforce/sfdx-lwc-jest": "^1.3.0",
@@ -2930,44 +2930,44 @@
             }
         },
         "node_modules/@salesforce/cli": {
-            "version": "2.2.7",
-            "resolved": "https://registry.npmjs.org/@salesforce/cli/-/cli-2.2.7.tgz",
-            "integrity": "sha512-CLcQxKZpLiYighla74nne9u8BUksU8RousJqwfPXSDE1iexPPI3j1vbC+lNYffpuBaP2mepbbnMAtJ4zPIrvNA==",
+            "version": "2.9.8",
+            "resolved": "https://registry.npmjs.org/@salesforce/cli/-/cli-2.9.8.tgz",
+            "integrity": "sha512-tTJWml7TyfZ9aZee//YWeZvAJZq0BvH12gtWkYl8LpUa4gIJ0opNaYrQshyjkNuYveMNTGn73f1nMxRq/FY6vQ==",
             "dev": true,
             "hasInstallScript": true,
             "hasShrinkwrap": true,
             "dependencies": {
-                "@oclif/core": "2.10.0",
-                "@oclif/plugin-autocomplete": "2.3.3",
-                "@oclif/plugin-commands": "2.2.20",
-                "@oclif/plugin-help": "5.2.14",
-                "@oclif/plugin-not-found": "2.3.34",
-                "@oclif/plugin-plugins": "3.1.8",
-                "@oclif/plugin-search": "0.0.21",
-                "@oclif/plugin-update": "3.1.28",
-                "@oclif/plugin-version": "1.3.7",
-                "@oclif/plugin-warn-if-update-available": "2.0.45",
-                "@oclif/plugin-which": "2.2.27",
-                "@salesforce/core": "^4.3.5",
-                "@salesforce/plugin-apex": "2.3.8",
-                "@salesforce/plugin-auth": "2.8.9",
-                "@salesforce/plugin-data": "2.5.3",
-                "@salesforce/plugin-deploy-retrieve": "1.16.3",
-                "@salesforce/plugin-info": "2.6.32",
-                "@salesforce/plugin-limits": "2.3.27",
-                "@salesforce/plugin-login": "1.2.22",
-                "@salesforce/plugin-org": "2.9.27",
-                "@salesforce/plugin-schema": "2.3.21",
-                "@salesforce/plugin-settings": "1.4.21",
-                "@salesforce/plugin-sobject": "0.1.40",
-                "@salesforce/plugin-source": "2.10.27",
-                "@salesforce/plugin-telemetry": "2.2.3",
-                "@salesforce/plugin-templates": "55.5.7",
-                "@salesforce/plugin-trust": "2.4.34",
-                "@salesforce/plugin-user": "2.3.27",
-                "@salesforce/sf-plugins-core": "3.1.12",
+                "@oclif/core": "2.15.0",
+                "@oclif/plugin-autocomplete": "2.3.8",
+                "@oclif/plugin-commands": "2.2.25",
+                "@oclif/plugin-help": "5.2.19",
+                "@oclif/plugin-not-found": "2.4.1",
+                "@oclif/plugin-plugins": "3.6.1",
+                "@oclif/plugin-search": "0.0.22",
+                "@oclif/plugin-update": "3.2.3",
+                "@oclif/plugin-version": "1.3.10",
+                "@oclif/plugin-warn-if-update-available": "2.1.0",
+                "@oclif/plugin-which": "2.2.32",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/plugin-apex": "2.3.14",
+                "@salesforce/plugin-auth": "2.8.16",
+                "@salesforce/plugin-data": "2.5.9",
+                "@salesforce/plugin-deploy-retrieve": "1.17.13",
+                "@salesforce/plugin-info": "2.6.42",
+                "@salesforce/plugin-limits": "2.3.34",
+                "@salesforce/plugin-login": "1.2.30",
+                "@salesforce/plugin-marketplace": "0.2.1",
+                "@salesforce/plugin-org": "2.10.7",
+                "@salesforce/plugin-schema": "2.3.25",
+                "@salesforce/plugin-settings": "1.4.28",
+                "@salesforce/plugin-sobject": "0.2.7",
+                "@salesforce/plugin-source": "2.10.33",
+                "@salesforce/plugin-telemetry": "2.3.2",
+                "@salesforce/plugin-templates": "55.5.11",
+                "@salesforce/plugin-trust": "2.6.10",
+                "@salesforce/plugin-user": "2.3.32",
+                "@salesforce/sf-plugins-core": "3.1.22",
                 "debug": "^4.3.4",
-                "semver": "^7.5.4",
                 "tslib": "^2.4.1"
             },
             "bin": {
@@ -3016,17 +3016,18 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@azure/core-auth": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.4.0.tgz",
-            "integrity": "sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.5.0.tgz",
+            "integrity": "sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
+                "@azure/core-util": "^1.1.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@azure/core-rest-pipeline": {
@@ -3051,45 +3052,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/@azure/core-rest-pipeline/node_modules/@azure/core-util": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.3.2.tgz",
-            "integrity": "sha512-2bECOUh88RvL1pMZTcc6OzfobBeWDBf5oBbhjIhT1MV9otMVWCzpOJkkiKtrnO88y5GGBelgY8At73KGAdbkeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "tslib": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@azure/core-rest-pipeline/node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@azure/core-rest-pipeline/node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/@azure/core-tracing": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
@@ -3104,9 +3066,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@azure/core-util": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.2.0.tgz",
-            "integrity": "sha512-ffGIw+Qs8bNKNLxz5UPkz4/VBM/EZY07mPve1ZYFqYUdPwFqRj0RPk0U7LZMOfT7GCck9YjuT1Rfp1PApNl1ng==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.4.0.tgz",
+            "integrity": "sha512-eGAyJpm3skVQoLiRqm/xPa+SXi/NPDdSHMxbRAz2lSprd+Zs+qrpQGQQ2VQ3Nttu+nSZR4XoYQC71LbEI7jsig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3131,17 +3093,17 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@azure/opentelemetry-instrumentation-azure-sdk": {
-            "version": "1.0.0-beta.4",
-            "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.4.tgz",
-            "integrity": "sha512-bSF2l47Od7kH+u/O67cmQCj5jmNeC+gUNDKr2cMfLBwSqk12T7B4JZQ34viEq2vhLWoKbZO7j6srPmKiSGPzNg==",
+            "version": "1.0.0-beta.5",
+            "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.5.tgz",
+            "integrity": "sha512-fsUarKQDvjhmBO4nIfaZkfNSApm1hZBzcvpNbSrXdcUBxu7lRvKsV5DnwszX7cnhLyVOW9yl1uigtRQ1yDANjA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@azure/core-tracing": "^1.0.0",
                 "@azure/logger": "^1.0.0",
                 "@opentelemetry/api": "^1.4.1",
-                "@opentelemetry/core": "^1.14.0",
-                "@opentelemetry/instrumentation": "^0.40.0",
+                "@opentelemetry/core": "^1.15.2",
+                "@opentelemetry/instrumentation": "^0.41.2",
                 "tslib": "^2.2.0"
             },
             "engines": {
@@ -3981,6 +3943,19 @@
                 "node": ">=14.14"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/@commitlint/read/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/@commitlint/resolve-extends": {
             "version": "17.4.4",
             "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.4.4.tgz",
@@ -4152,13 +4127,13 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@es-joy/jsdoccomment": {
-            "version": "0.39.4",
-            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.39.4.tgz",
-            "integrity": "sha512-Jvw915fjqQct445+yron7Dufix9A+m9j1fCJYlCo1FWlRvTxa3pjJelxdSTdaLWcTwRU6vbL+NYjO4YuNIS5Qg==",
+            "version": "0.40.1",
+            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.40.1.tgz",
+            "integrity": "sha512-YORCdZSusAlBrFpZ77pJjc5r1bQs5caPWtAu+WWmiSo+8XaUzseapVrfAtiRFbQWnrBxxLLEwF6f6ZG/UgCQCg==",
             "extraneous": true,
             "license": "MIT",
             "dependencies": {
-                "comment-parser": "1.3.1",
+                "comment-parser": "1.4.0",
                 "esquery": "^1.5.0",
                 "jsdoc-type-pratt-parser": "~4.0.0"
             },
@@ -4167,9 +4142,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@es-joy/jsdoccomment/node_modules/comment-parser": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-            "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.0.tgz",
+            "integrity": "sha512-QLyTNiZ2KDOibvFPlZ6ZngVsZ/0gYnE6uTXi5aoDg8ed3AkJAz4sEje3Y8a29hQ1s6A99MZXe47fLAXQ1rTqaw==",
             "extraneous": true,
             "license": "MIT",
             "engines": {
@@ -4203,9 +4178,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-            "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "extraneous": true,
             "license": "Apache-2.0",
             "engines": {
@@ -4216,9 +4191,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@eslint-community/regexpp": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-            "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+            "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
             "extraneous": true,
             "license": "MIT",
             "engines": {
@@ -4226,9 +4201,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@eslint/eslintrc": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-            "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+            "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
             "extraneous": true,
             "license": "MIT",
             "dependencies": {
@@ -4257,9 +4232,9 @@
             "license": "Python-2.0"
         },
         "node_modules/@salesforce/cli/node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-            "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "extraneous": true,
             "license": "Apache-2.0",
             "engines": {
@@ -4270,9 +4245,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@eslint/eslintrc/node_modules/espree": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-            "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "extraneous": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -4301,9 +4276,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@eslint/js": {
-            "version": "8.44.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-            "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
+            "integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
             "extraneous": true,
             "license": "MIT",
             "engines": {
@@ -4318,9 +4293,9 @@
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-            "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+            "version": "0.11.11",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+            "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
             "extraneous": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -4625,6 +4600,19 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/@npmcli/fs": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
+            "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/@npmcli/git": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-4.1.0.tgz",
@@ -4658,64 +4646,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/@npmcli/git/node_modules/hosted-git-info": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
-            "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^7.5.1"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@npmcli/git/node_modules/npm-install-checks": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.1.1.tgz",
-            "integrity": "sha512-dH3GmQL4vsPtld59cOn8uY0iOqRmqKvV+DLGwNXV/Q7MDgD2QfOADWd/mFXcIE5LVhYYGjA3baz6W9JneqnuCw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "semver": "^7.1.1"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@npmcli/git/node_modules/npm-package-arg": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-10.1.0.tgz",
-            "integrity": "sha512-uFyyCEmgBfZTtrKk/5xDfHp6+MdrqGotX/VoOyEEl3mBwiEE5FlBaePanazJSVMPT7vKepcjYBY2ztg9A3yPIA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "hosted-git-info": "^6.0.0",
-                "proc-log": "^3.0.0",
-                "semver": "^7.3.5",
-                "validate-npm-package-name": "^5.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@npmcli/git/node_modules/npm-pick-manifest": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-8.0.1.tgz",
-            "integrity": "sha512-mRtvlBjTsJvfCCdmPtiu2bdlx8d/KXtF7yNXNWe7G0Z36qWA9Ny5zXsI2PfBZEv7SXgoxTmNaTzGSbbzDZChoA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-install-checks": "^6.0.0",
-                "npm-normalize-package-bin": "^3.0.0",
-                "npm-package-arg": "^10.0.0",
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/@npmcli/git/node_modules/which": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
@@ -4733,76 +4663,33 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@npmcli/installed-package-contents": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz",
-            "integrity": "sha512-9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-2.0.2.tgz",
+            "integrity": "sha512-xACzLPhnfD51GKvTOOuNX2/V4G4mz9/1I2MfDoye9kBM3RYe5g2YbscsaGoTlaWqkxeiapBWyseULVKpSVHtKQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "npm-bundled": "^1.1.1",
-                "npm-normalize-package-bin": "^1.0.1"
+                "npm-bundled": "^3.0.0",
+                "npm-normalize-package-bin": "^3.0.0"
             },
             "bin": {
-                "installed-package-contents": "index.js"
+                "installed-package-contents": "lib/index.js"
             },
             "engines": {
-                "node": ">= 10"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/@npmcli/installed-package-contents/node_modules/npm-normalize-package-bin": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-            "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@npmcli/map-workspaces": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-2.0.4.tgz",
-            "integrity": "sha512-bMo0aAfwhVwqoVM5UzX1DJnlvVvzDCHae821jv48L1EsrYwfOZChlqWYXEtto/+BkBXetPbEWgau++/brh4oVg==",
+        "node_modules/@salesforce/cli/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-3.0.0.tgz",
+            "integrity": "sha512-Vq0eyEQy+elFpzsKjMss9kxqb9tG3YHg4dsyWuUENuzvSUWe1TCnW/vV9FkhvBk/brEDoDiVd+M1Btosa6ImdQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/name-from-folder": "^1.0.1",
-                "glob": "^8.0.1",
-                "minimatch": "^5.0.1",
-                "read-package-json-fast": "^2.0.3"
+                "npm-normalize-package-bin": "^3.0.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@npmcli/map-workspaces/node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@npmcli/move-file": {
@@ -4841,6 +4728,62 @@
             "license": "ISC",
             "dependencies": {
                 "infer-owner": "^1.0.4"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/@npmcli/run-script": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-6.0.2.tgz",
+            "integrity": "sha512-NCcr1uQo1k5U+SYlnIrbAh3cxy+OQT1VtqiAbxdymSlptbzBb62AjH2xXgjNCoP073hoa1CfCAcwoZ8k96C4nA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/node-gyp": "^3.0.0",
+                "@npmcli/promise-spawn": "^6.0.0",
+                "node-gyp": "^9.0.0",
+                "read-package-json-fast": "^3.0.0",
+                "which": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/@npmcli/run-script/node_modules/@npmcli/node-gyp": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-3.0.0.tgz",
+            "integrity": "sha512-gp8pRXC2oOxu0DUE1/M3bYtb1b3/DbJ5aM113+XJBgfXdussRAsX0YOrOhdd8WvnAR6auDBvJomGAkLKA5ydxA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/@npmcli/run-script/node_modules/@npmcli/promise-spawn": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz",
+            "integrity": "sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "which": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/@npmcli/run-script/node_modules/which": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+            "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/color": {
@@ -4916,9 +4859,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/core": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.10.0.tgz",
-            "integrity": "sha512-4csNtXBb+RKrhO2lBAwBvxuyk0B3NB45tAkSHOrJjUo1ufT+qpg9V+g7nHZBMlwoQmjlAjCOKtm6RHar8FrpZg==",
+            "version": "2.15.0",
+            "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.15.0.tgz",
+            "integrity": "sha512-fNEMG5DzJHhYmI3MgpByTvltBOMyFcnRIUMxbiz2ai8rhaYgaTHMG3Q38HcosfIvtw9nCjxpcQtC8MN8QtVCcA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4931,7 +4874,6 @@
                 "cli-progress": "^3.12.0",
                 "debug": "^4.3.4",
                 "ejs": "^3.1.8",
-                "fs-extra": "^9.1.0",
                 "get-package-type": "^0.1.0",
                 "globby": "^11.1.0",
                 "hyperlinker": "^1.0.0",
@@ -4941,7 +4883,6 @@
                 "natural-orderby": "^2.0.3",
                 "object-treeify": "^1.1.33",
                 "password-prompt": "^1.1.2",
-                "semver": "^7.5.3",
                 "slice-ansi": "^4.0.0",
                 "string-width": "^4.2.3",
                 "strip-ansi": "^6.0.1",
@@ -4955,22 +4896,6 @@
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/core/node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/core/node_modules/supports-color": {
@@ -5075,24 +5000,6 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/@oclif/dev-cli/node_modules/@oclif/plugin-help/node_modules/@oclif/config/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/@oclif/dev-cli/node_modules/@oclif/plugin-help/node_modules/@oclif/errors": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.5.tgz",
@@ -5108,39 +5015,6 @@
             },
             "engines": {
                 "node": ">=8.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/dev-cli/node_modules/@oclif/plugin-help/node_modules/@oclif/errors/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/dev-cli/node_modules/wrap-ansi": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/errors": {
@@ -5199,21 +5073,6 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/@oclif/help/node_modules/wrap-ansi": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/@oclif/linewrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
@@ -5238,35 +5097,18 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/plugin-autocomplete": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-2.3.3.tgz",
-            "integrity": "sha512-4/7l3YrACS7KfONoams7+xAbVfo7tje0t2Qp84/KAUpY1Yb/11AMPHtzgoRp5A5Y3OFPmLCfRF1YUydz+jGuwg==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-2.3.8.tgz",
+            "integrity": "sha512-cmRPss9OQxz8sRoaw5C/4t/Da7eBEIDJWKRsuzUSQBcPJCN3kTgjp24VTjPHT3j86197s/qkjCRct+3P0IGArg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oclif/core": "^2.8.2",
+                "@oclif/core": "^2.15.0",
                 "chalk": "^4.1.0",
-                "debug": "^4.3.4",
-                "fs-extra": "^9.0.1"
+                "debug": "^4.3.4"
             },
             "engines": {
                 "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-autocomplete/node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/plugin-command-snapshot": {
@@ -5289,13 +5131,13 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/plugin-commands": {
-            "version": "2.2.20",
-            "resolved": "https://registry.npmjs.org/@oclif/plugin-commands/-/plugin-commands-2.2.20.tgz",
-            "integrity": "sha512-zhF3rqVH+5AKAxzWKPl+Q8dAPQHoxPJh7QKxWXqsK/OdZ6L1UsstNY+mKDApnOQNVsLdglmexOz/IRDP2dVRBw==",
+            "version": "2.2.25",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-commands/-/plugin-commands-2.2.25.tgz",
+            "integrity": "sha512-DKlWM0B0b0ypOCvcpJk3PLZ+oKmaSgGuOUa5zjF/JiYUfS1eJXyO3wp47TZ/z67ANui8gEBQc12mFJCjHuc2GA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oclif/core": "^2.9.3",
+                "@oclif/core": "^2.15.0",
                 "lodash": "^4.17.11"
             },
             "engines": {
@@ -5303,27 +5145,27 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/plugin-help": {
-            "version": "5.2.14",
-            "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-5.2.14.tgz",
-            "integrity": "sha512-7hMLc6zqxeRfG4nvHHQPpbaBj60efM3ULFkCpHZkdLms/ezIkNo40F661QuraIjMP/NN+U6VSfBCGuPkRyxVkA==",
+            "version": "5.2.19",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-5.2.19.tgz",
+            "integrity": "sha512-gf6/dFtzMJ8RA4ovlBCBGJsZsd4jPXhYWJho+Gh6KmA+Ev9LupoExbE0qT+a2uHJyHEvIg4uX/MBW3qdERD/8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oclif/core": "^2.9.3"
+                "@oclif/core": "^2.15.0"
             },
             "engines": {
                 "node": ">=12.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/plugin-not-found": {
-            "version": "2.3.34",
-            "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-2.3.34.tgz",
-            "integrity": "sha512-uXUpw6o2e0aqnNn+XkGL7LbL+Th2rBD1JGtFbb6anmvUvz2skiGz0o23BYmrQW8tvU92ajPOykfClKD75ptZcw==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-2.4.1.tgz",
+            "integrity": "sha512-LqW7qpw5Q8ploRiup2jEIMQJXcxHP1tpwj45GApKQMe7GRdGdRdjBT9Tu+U2tdEgMqgMplAIhOsYCx2nc2nMSw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oclif/color": "^1.0.9",
-                "@oclif/core": "^2.9.4",
+                "@oclif/core": "^2.15.0",
+                "chalk": "^4",
                 "fast-levenshtein": "^3.0.0"
             },
             "engines": {
@@ -5331,45 +5173,27 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins": {
-            "version": "3.1.8",
-            "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-3.1.8.tgz",
-            "integrity": "sha512-514sFBzLcR9QCSMWCHt/1XntfjJEZvb637b9YuV4kwq749pKEPF7fjCxSV1gYQCCP4TjMB5gB4AwPL4cCbe+/A==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-3.6.1.tgz",
+            "integrity": "sha512-+Av9eVQ+WdjZbYZBDmSMrhw5vNTVIKSh3gC61dFHxXITMq8EQ2kJECFRfJ9lJbYvj8QjpPp9ISGieIerZNetmw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oclif/color": "^1.0.4",
-                "@oclif/core": "^2.8.7",
+                "@oclif/core": "^2.15.0",
                 "chalk": "^4.1.2",
                 "debug": "^4.3.4",
-                "fs-extra": "^9.0",
                 "http-call": "^5.2.2",
                 "load-json-file": "^5.3.0",
-                "npm": "^9.7.2",
+                "npm": "9.6.7",
                 "npm-run-path": "^4.0.1",
-                "semver": "^7.5.3",
+                "semver": "^7.5.4",
                 "shelljs": "^0.8.5",
-                "tslib": "^2.6.0",
+                "tslib": "^2.6.2",
                 "validate-npm-package-name": "^5.0.0",
                 "yarn": "^1.22.18"
             },
             "engines": {
                 "node": ">=16"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/load-json-file": {
@@ -5388,3125 +5212,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm": {
-            "version": "9.8.0",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.0.tgz",
-            "integrity": "sha512-AXeiBAdfM5K2jvBwA7EGLKeYyt0VnhmJRnlq4k2+M0Ao9v7yKJBqF8xFPzQL8kAybzwlfpTPCZwM4uTIszb3xA==",
-            "bundleDependencies": [
-                "@isaacs/string-locale-compare",
-                "@npmcli/arborist",
-                "@npmcli/config",
-                "@npmcli/map-workspaces",
-                "@npmcli/package-json",
-                "@npmcli/run-script",
-                "abbrev",
-                "archy",
-                "cacache",
-                "chalk",
-                "ci-info",
-                "cli-columns",
-                "cli-table3",
-                "columnify",
-                "fastest-levenshtein",
-                "fs-minipass",
-                "glob",
-                "graceful-fs",
-                "hosted-git-info",
-                "ini",
-                "init-package-json",
-                "is-cidr",
-                "json-parse-even-better-errors",
-                "libnpmaccess",
-                "libnpmdiff",
-                "libnpmexec",
-                "libnpmfund",
-                "libnpmhook",
-                "libnpmorg",
-                "libnpmpack",
-                "libnpmpublish",
-                "libnpmsearch",
-                "libnpmteam",
-                "libnpmversion",
-                "make-fetch-happen",
-                "minimatch",
-                "minipass",
-                "minipass-pipeline",
-                "ms",
-                "node-gyp",
-                "nopt",
-                "npm-audit-report",
-                "npm-install-checks",
-                "npm-package-arg",
-                "npm-pick-manifest",
-                "npm-profile",
-                "npm-registry-fetch",
-                "npm-user-validate",
-                "npmlog",
-                "p-map",
-                "pacote",
-                "parse-conflict-json",
-                "proc-log",
-                "qrcode-terminal",
-                "read",
-                "semver",
-                "sigstore",
-                "ssri",
-                "supports-color",
-                "tar",
-                "text-table",
-                "tiny-relative-date",
-                "treeverse",
-                "validate-npm-package-name",
-                "which",
-                "write-file-atomic"
-            ],
-            "dev": true,
-            "license": "Artistic-2.0",
-            "workspaces": [
-                "docs",
-                "smoke-tests",
-                "mock-globals",
-                "mock-registry",
-                "workspaces/*"
-            ],
-            "dependencies": {
-                "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^6.3.0",
-                "@npmcli/config": "^6.2.1",
-                "@npmcli/map-workspaces": "^3.0.4",
-                "@npmcli/package-json": "^4.0.0",
-                "@npmcli/run-script": "^6.0.2",
-                "abbrev": "^2.0.0",
-                "archy": "~1.0.0",
-                "cacache": "^17.1.3",
-                "chalk": "^5.2.0",
-                "ci-info": "^3.8.0",
-                "cli-columns": "^4.0.0",
-                "cli-table3": "^0.6.3",
-                "columnify": "^1.6.0",
-                "fastest-levenshtein": "^1.0.16",
-                "fs-minipass": "^3.0.2",
-                "glob": "^10.2.7",
-                "graceful-fs": "^4.2.11",
-                "hosted-git-info": "^6.1.1",
-                "ini": "^4.1.1",
-                "init-package-json": "^5.0.0",
-                "is-cidr": "^4.0.2",
-                "json-parse-even-better-errors": "^3.0.0",
-                "libnpmaccess": "^7.0.2",
-                "libnpmdiff": "^5.0.19",
-                "libnpmexec": "^6.0.2",
-                "libnpmfund": "^4.0.19",
-                "libnpmhook": "^9.0.3",
-                "libnpmorg": "^5.0.4",
-                "libnpmpack": "^5.0.19",
-                "libnpmpublish": "^7.5.0",
-                "libnpmsearch": "^6.0.2",
-                "libnpmteam": "^5.0.3",
-                "libnpmversion": "^4.0.2",
-                "make-fetch-happen": "^11.1.1",
-                "minimatch": "^9.0.0",
-                "minipass": "^5.0.0",
-                "minipass-pipeline": "^1.2.4",
-                "ms": "^2.1.2",
-                "node-gyp": "^9.4.0",
-                "nopt": "^7.2.0",
-                "npm-audit-report": "^5.0.0",
-                "npm-install-checks": "^6.1.1",
-                "npm-package-arg": "^10.1.0",
-                "npm-pick-manifest": "^8.0.1",
-                "npm-profile": "^7.0.1",
-                "npm-registry-fetch": "^14.0.5",
-                "npm-user-validate": "^2.0.0",
-                "npmlog": "^7.0.1",
-                "p-map": "^4.0.0",
-                "pacote": "^15.2.0",
-                "parse-conflict-json": "^3.0.1",
-                "proc-log": "^3.0.0",
-                "qrcode-terminal": "^0.12.0",
-                "read": "^2.1.0",
-                "semver": "^7.5.2",
-                "sigstore": "^1.7.0",
-                "ssri": "^10.0.4",
-                "supports-color": "^9.3.1",
-                "tar": "^6.1.15",
-                "text-table": "~0.2.0",
-                "tiny-relative-date": "^1.3.0",
-                "treeverse": "^3.0.0",
-                "validate-npm-package-name": "^5.0.0",
-                "which": "^3.0.1",
-                "write-file-atomic": "^5.0.1"
-            },
-            "bin": {
-                "npm": "bin/npm-cli.js",
-                "npx": "bin/npx-cli.js"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@colors/colors": {
-            "version": "1.5.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.1.90"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@isaacs/cliui": {
-            "version": "8.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^5.1.2",
-                "string-width-cjs": "npm:string-width@^4.2.0",
-                "strip-ansi": "^7.0.1",
-                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-                "wrap-ansi": "^8.1.0",
-                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
-            "version": "5.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@isaacs/string-locale-compare": {
-            "version": "1.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "6.3.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/fs": "^3.1.0",
-                "@npmcli/installed-package-contents": "^2.0.2",
-                "@npmcli/map-workspaces": "^3.0.2",
-                "@npmcli/metavuln-calculator": "^5.0.0",
-                "@npmcli/name-from-folder": "^2.0.0",
-                "@npmcli/node-gyp": "^3.0.0",
-                "@npmcli/package-json": "^4.0.0",
-                "@npmcli/query": "^3.0.0",
-                "@npmcli/run-script": "^6.0.0",
-                "bin-links": "^4.0.1",
-                "cacache": "^17.0.4",
-                "common-ancestor-path": "^1.0.1",
-                "hosted-git-info": "^6.1.1",
-                "json-parse-even-better-errors": "^3.0.0",
-                "json-stringify-nice": "^1.1.4",
-                "minimatch": "^9.0.0",
-                "nopt": "^7.0.0",
-                "npm-install-checks": "^6.0.0",
-                "npm-package-arg": "^10.1.0",
-                "npm-pick-manifest": "^8.0.1",
-                "npm-registry-fetch": "^14.0.3",
-                "npmlog": "^7.0.1",
-                "pacote": "^15.0.8",
-                "parse-conflict-json": "^3.0.0",
-                "proc-log": "^3.0.0",
-                "promise-all-reject-late": "^1.0.0",
-                "promise-call-limit": "^1.0.2",
-                "read-package-json-fast": "^3.0.2",
-                "semver": "^7.3.7",
-                "ssri": "^10.0.1",
-                "treeverse": "^3.0.0",
-                "walk-up-path": "^3.0.1"
-            },
-            "bin": {
-                "arborist": "bin/index.js"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/config": {
-            "version": "6.2.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/map-workspaces": "^3.0.2",
-                "ci-info": "^3.8.0",
-                "ini": "^4.1.0",
-                "nopt": "^7.0.0",
-                "proc-log": "^3.0.0",
-                "read-package-json-fast": "^3.0.2",
-                "semver": "^7.3.5",
-                "walk-up-path": "^3.0.1"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/disparity-colors": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "ansi-styles": "^4.3.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/fs": {
-            "version": "3.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/git": {
-            "version": "4.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/promise-spawn": "^6.0.0",
-                "lru-cache": "^7.4.4",
-                "npm-pick-manifest": "^8.0.0",
-                "proc-log": "^3.0.0",
-                "promise-inflight": "^1.0.1",
-                "promise-retry": "^2.0.1",
-                "semver": "^7.3.5",
-                "which": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-            "version": "2.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-bundled": "^3.0.0",
-                "npm-normalize-package-bin": "^3.0.0"
-            },
-            "bin": {
-                "installed-package-contents": "lib/index.js"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/map-workspaces": {
-            "version": "3.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/name-from-folder": "^2.0.0",
-                "glob": "^10.2.2",
-                "minimatch": "^9.0.0",
-                "read-package-json-fast": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-            "version": "5.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "cacache": "^17.0.0",
-                "json-parse-even-better-errors": "^3.0.0",
-                "pacote": "^15.0.0",
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/name-from-folder": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/node-gyp": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/package-json": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/git": "^4.1.0",
-                "glob": "^10.2.2",
-                "json-parse-even-better-errors": "^3.0.0",
-                "normalize-package-data": "^5.0.0",
-                "npm-normalize-package-bin": "^3.0.1",
-                "proc-log": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/promise-spawn": {
-            "version": "6.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "which": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/query": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "postcss-selector-parser": "^6.0.10"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@npmcli/run-script": {
-            "version": "6.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/node-gyp": "^3.0.0",
-                "@npmcli/promise-spawn": "^6.0.0",
-                "node-gyp": "^9.0.0",
-                "read-package-json-fast": "^3.0.0",
-                "which": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@pkgjs/parseargs": {
-            "version": "0.11.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-            "version": "0.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@sigstore/tuf": {
-            "version": "1.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@sigstore/protobuf-specs": "^0.1.0",
-                "tuf-js": "^1.1.7"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@tufjs/canonical-json": {
-            "version": "1.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/@tufjs/models": {
-            "version": "1.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "@tufjs/canonical-json": "1.0.0",
-                "minimatch": "^9.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/abbrev": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/abort-controller": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "event-target-shim": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=6.5"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/agent-base": {
-            "version": "6.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/agentkeepalive": {
-            "version": "4.3.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.1.0",
-                "depd": "^2.0.0",
-                "humanize-ms": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 8.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/aggregate-error": {
-            "version": "3.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "clean-stack": "^2.0.0",
-                "indent-string": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/aproba": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/archy": {
-            "version": "1.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/are-we-there-yet": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^4.1.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/base64-js": {
-            "version": "1.5.1",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/bin-links": {
-            "version": "4.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "cmd-shim": "^6.0.0",
-                "npm-normalize-package-bin": "^3.0.0",
-                "read-cmd-shim": "^4.0.0",
-                "write-file-atomic": "^5.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/binary-extensions": {
-            "version": "2.2.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/buffer": {
-            "version": "6.0.3",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/builtins": {
-            "version": "5.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "semver": "^7.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/cacache": {
-            "version": "17.1.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/fs": "^3.1.0",
-                "fs-minipass": "^3.0.0",
-                "glob": "^10.2.2",
-                "lru-cache": "^7.7.1",
-                "minipass": "^5.0.0",
-                "minipass-collect": "^1.0.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "p-map": "^4.0.0",
-                "ssri": "^10.0.0",
-                "tar": "^6.1.11",
-                "unique-filename": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/chalk": {
-            "version": "5.2.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/chownr": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/ci-info": {
-            "version": "3.8.0",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/sibiraj-s"
-                }
-            ],
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/cidr-regex": {
-            "version": "3.1.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "ip-regex": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/clean-stack": {
-            "version": "2.2.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/cli-columns": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/cli-table3": {
-            "version": "0.6.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "string-width": "^4.2.0"
-            },
-            "engines": {
-                "node": "10.* || >= 12.*"
-            },
-            "optionalDependencies": {
-                "@colors/colors": "1.5.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/clone": {
-            "version": "1.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/cmd-shim": {
-            "version": "6.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/color-convert": {
-            "version": "2.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/color-name": {
-            "version": "1.1.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/color-support": {
-            "version": "1.1.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "bin": {
-                "color-support": "bin.js"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/columnify": {
-            "version": "1.6.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "strip-ansi": "^6.0.1",
-                "wcwidth": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/common-ancestor-path": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/concat-map": {
-            "version": "0.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/console-control-strings": {
-            "version": "1.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/cross-spawn/node_modules/which": {
-            "version": "2.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/node-which"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/cssesc": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "bin": {
-                "cssesc": "bin/cssesc"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/debug": {
-            "version": "4.3.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/debug/node_modules/ms": {
-            "version": "2.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/defaults": {
-            "version": "1.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "clone": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/delegates": {
-            "version": "1.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/depd": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/diff": {
-            "version": "5.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/eastasianwidth": {
-            "version": "0.2.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/encoding": {
-            "version": "0.1.13",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "iconv-lite": "^0.6.2"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/env-paths": {
-            "version": "2.2.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/err-code": {
-            "version": "2.0.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/event-target-shim": {
-            "version": "5.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/events": {
-            "version": "3.3.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.x"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/exponential-backoff": {
-            "version": "3.1.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "Apache-2.0"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/fastest-levenshtein": {
-            "version": "1.0.16",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4.9.1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/foreground-child": {
-            "version": "3.1.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "cross-spawn": "^7.0.0",
-                "signal-exit": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/fs-minipass": {
-            "version": "3.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^5.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/function-bind": {
-            "version": "1.1.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/gauge": {
-            "version": "5.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "aproba": "^1.0.3 || ^2.0.0",
-                "color-support": "^1.1.3",
-                "console-control-strings": "^1.1.0",
-                "has-unicode": "^2.0.1",
-                "signal-exit": "^4.0.1",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1",
-                "wide-align": "^1.1.5"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/glob": {
-            "version": "10.2.7",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^2.0.3",
-                "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2",
-                "path-scurry": "^1.7.0"
-            },
-            "bin": {
-                "glob": "dist/cjs/src/bin.js"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/graceful-fs": {
-            "version": "4.2.11",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/has": {
-            "version": "1.0.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/has-unicode": {
-            "version": "2.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/hosted-git-info": {
-            "version": "6.1.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^7.5.1"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/http-cache-semantics": {
-            "version": "4.1.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/humanize-ms": {
-            "version": "1.2.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/ieee754": {
-            "version": "1.2.1",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "inBundle": true,
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/ignore-walk": {
-            "version": "6.0.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minimatch": "^9.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/imurmurhash": {
-            "version": "0.1.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.19"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/indent-string": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/inflight": {
-            "version": "1.0.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/inherits": {
-            "version": "2.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/ini": {
-            "version": "4.1.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/init-package-json": {
-            "version": "5.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-package-arg": "^10.0.0",
-                "promzard": "^1.0.0",
-                "read": "^2.0.0",
-                "read-package-json": "^6.0.0",
-                "semver": "^7.3.5",
-                "validate-npm-package-license": "^3.0.4",
-                "validate-npm-package-name": "^5.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/ip": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/ip-regex": {
-            "version": "4.3.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/is-cidr": {
-            "version": "4.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "cidr-regex": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/is-core-module": {
-            "version": "2.12.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "has": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/is-lambda": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/isexe": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/jackspeak": {
-            "version": "2.2.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/json-parse-even-better-errors": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/json-stringify-nice": {
-            "version": "1.1.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/jsonparse": {
-            "version": "1.3.1",
-            "dev": true,
-            "engines": [
-                "node >= 0.2.0"
-            ],
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/just-diff": {
-            "version": "6.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/just-diff-apply": {
-            "version": "5.5.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/libnpmaccess": {
-            "version": "7.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-package-arg": "^10.1.0",
-                "npm-registry-fetch": "^14.0.3"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/libnpmdiff": {
-            "version": "5.0.19",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/arborist": "^6.3.0",
-                "@npmcli/disparity-colors": "^3.0.0",
-                "@npmcli/installed-package-contents": "^2.0.2",
-                "binary-extensions": "^2.2.0",
-                "diff": "^5.1.0",
-                "minimatch": "^9.0.0",
-                "npm-package-arg": "^10.1.0",
-                "pacote": "^15.0.8",
-                "tar": "^6.1.13"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/libnpmexec": {
-            "version": "6.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/arborist": "^6.3.0",
-                "@npmcli/run-script": "^6.0.0",
-                "ci-info": "^3.7.1",
-                "npm-package-arg": "^10.1.0",
-                "npmlog": "^7.0.1",
-                "pacote": "^15.0.8",
-                "proc-log": "^3.0.0",
-                "read": "^2.0.0",
-                "read-package-json-fast": "^3.0.2",
-                "semver": "^7.3.7",
-                "walk-up-path": "^3.0.1"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/libnpmfund": {
-            "version": "4.0.19",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/arborist": "^6.3.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/libnpmhook": {
-            "version": "9.0.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "aproba": "^2.0.0",
-                "npm-registry-fetch": "^14.0.3"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/libnpmorg": {
-            "version": "5.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "aproba": "^2.0.0",
-                "npm-registry-fetch": "^14.0.3"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/libnpmpack": {
-            "version": "5.0.19",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/arborist": "^6.3.0",
-                "@npmcli/run-script": "^6.0.0",
-                "npm-package-arg": "^10.1.0",
-                "pacote": "^15.0.8"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/libnpmpublish": {
-            "version": "7.5.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "ci-info": "^3.6.1",
-                "normalize-package-data": "^5.0.0",
-                "npm-package-arg": "^10.1.0",
-                "npm-registry-fetch": "^14.0.3",
-                "proc-log": "^3.0.0",
-                "semver": "^7.3.7",
-                "sigstore": "^1.4.0",
-                "ssri": "^10.0.1"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/libnpmsearch": {
-            "version": "6.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-registry-fetch": "^14.0.3"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/libnpmteam": {
-            "version": "5.0.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "aproba": "^2.0.0",
-                "npm-registry-fetch": "^14.0.3"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/libnpmversion": {
-            "version": "4.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/git": "^4.0.1",
-                "@npmcli/run-script": "^6.0.0",
-                "json-parse-even-better-errors": "^3.0.0",
-                "proc-log": "^3.0.0",
-                "semver": "^7.3.7"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/lru-cache": {
-            "version": "7.18.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/make-fetch-happen": {
-            "version": "11.1.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "agentkeepalive": "^4.2.1",
-                "cacache": "^17.0.0",
-                "http-cache-semantics": "^4.1.1",
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "is-lambda": "^1.0.1",
-                "lru-cache": "^7.7.1",
-                "minipass": "^5.0.0",
-                "minipass-fetch": "^3.0.0",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^0.6.3",
-                "promise-retry": "^2.0.1",
-                "socks-proxy-agent": "^7.0.0",
-                "ssri": "^10.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minimatch": {
-            "version": "9.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minipass": {
-            "version": "5.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minipass-collect": {
-            "version": "1.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minipass-collect/node_modules/minipass": {
-            "version": "3.3.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minipass-fetch": {
-            "version": "3.0.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^5.0.0",
-                "minipass-sized": "^1.0.3",
-                "minizlib": "^2.1.2"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            },
-            "optionalDependencies": {
-                "encoding": "^0.1.13"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minipass-flush": {
-            "version": "1.0.5",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-            "version": "3.3.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minipass-json-stream": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "jsonparse": "^1.3.1",
-                "minipass": "^3.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
-            "version": "3.3.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minipass-pipeline": {
-            "version": "1.2.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
-            "version": "3.3.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minipass-sized": {
-            "version": "1.0.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-            "version": "3.3.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minizlib": {
-            "version": "2.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/minizlib/node_modules/minipass": {
-            "version": "3.3.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/mkdirp": {
-            "version": "1.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/ms": {
-            "version": "2.1.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/mute-stream": {
-            "version": "1.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/negotiator": {
-            "version": "0.6.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/node-gyp": {
-            "version": "9.4.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "env-paths": "^2.2.0",
-                "exponential-backoff": "^3.1.1",
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^11.0.3",
-                "nopt": "^6.0.0",
-                "npmlog": "^6.0.0",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.5",
-                "tar": "^6.1.2",
-                "which": "^2.0.2"
-            },
-            "bin": {
-                "node-gyp": "bin/node-gyp.js"
-            },
-            "engines": {
-                "node": "^12.13 || ^14.13 || >=16"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
-            "version": "1.1.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/node-gyp/node_modules/are-we-there-yet": {
-            "version": "3.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
-            "version": "4.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "aproba": "^1.0.3 || ^2.0.0",
-                "color-support": "^1.1.3",
-                "console-control-strings": "^1.1.0",
-                "has-unicode": "^2.0.1",
-                "signal-exit": "^3.0.7",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1",
-                "wide-align": "^1.1.5"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/node-gyp/node_modules/glob": {
-            "version": "7.2.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
-            "version": "3.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
-            "version": "6.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "^1.0.0"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
-            "version": "6.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "are-we-there-yet": "^3.0.0",
-                "console-control-strings": "^1.1.0",
-                "gauge": "^4.0.3",
-                "set-blocking": "^2.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/node-gyp/node_modules/readable-stream": {
-            "version": "3.6.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/node-gyp/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/node-gyp/node_modules/which": {
-            "version": "2.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/node-which"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/nopt": {
-            "version": "7.2.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "^2.0.0"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/normalize-package-data": {
-            "version": "5.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "hosted-git-info": "^6.0.0",
-                "is-core-module": "^2.8.1",
-                "semver": "^7.3.5",
-                "validate-npm-package-license": "^3.0.4"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/npm-audit-report": {
-            "version": "5.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/npm-bundled": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-normalize-package-bin": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/npm-install-checks": {
-            "version": "6.1.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "semver": "^7.1.1"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/npm-normalize-package-bin": {
-            "version": "3.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/npm-package-arg": {
-            "version": "10.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "hosted-git-info": "^6.0.0",
-                "proc-log": "^3.0.0",
-                "semver": "^7.3.5",
-                "validate-npm-package-name": "^5.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/npm-packlist": {
-            "version": "7.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "ignore-walk": "^6.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/npm-pick-manifest": {
-            "version": "8.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-install-checks": "^6.0.0",
-                "npm-normalize-package-bin": "^3.0.0",
-                "npm-package-arg": "^10.0.0",
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/npm-profile": {
-            "version": "7.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-registry-fetch": "^14.0.0",
-                "proc-log": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/npm-registry-fetch": {
-            "version": "14.0.5",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "make-fetch-happen": "^11.0.0",
-                "minipass": "^5.0.0",
-                "minipass-fetch": "^3.0.0",
-                "minipass-json-stream": "^1.0.1",
-                "minizlib": "^2.1.2",
-                "npm-package-arg": "^10.0.0",
-                "proc-log": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/npm-user-validate": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/npmlog": {
-            "version": "7.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "are-we-there-yet": "^4.0.0",
-                "console-control-strings": "^1.1.0",
-                "gauge": "^5.0.0",
-                "set-blocking": "^2.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/once": {
-            "version": "1.4.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/p-map": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "aggregate-error": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/pacote": {
-            "version": "15.2.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/git": "^4.0.0",
-                "@npmcli/installed-package-contents": "^2.0.1",
-                "@npmcli/promise-spawn": "^6.0.1",
-                "@npmcli/run-script": "^6.0.0",
-                "cacache": "^17.0.0",
-                "fs-minipass": "^3.0.0",
-                "minipass": "^5.0.0",
-                "npm-package-arg": "^10.0.0",
-                "npm-packlist": "^7.0.0",
-                "npm-pick-manifest": "^8.0.0",
-                "npm-registry-fetch": "^14.0.0",
-                "proc-log": "^3.0.0",
-                "promise-retry": "^2.0.1",
-                "read-package-json": "^6.0.0",
-                "read-package-json-fast": "^3.0.0",
-                "sigstore": "^1.3.0",
-                "ssri": "^10.0.0",
-                "tar": "^6.1.11"
-            },
-            "bin": {
-                "pacote": "lib/bin.js"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/parse-conflict-json": {
-            "version": "3.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "json-parse-even-better-errors": "^3.0.0",
-                "just-diff": "^6.0.0",
-                "just-diff-apply": "^5.2.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/path-key": {
-            "version": "3.1.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/path-scurry": {
-            "version": "1.9.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^9.1.1",
-                "minipass": "^5.0.0 || ^6.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "9.1.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "14 || >=16.14"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/postcss-selector-parser": {
-            "version": "6.0.13",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "cssesc": "^3.0.0",
-                "util-deprecate": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/proc-log": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/process": {
-            "version": "0.11.10",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/promise-all-reject-late": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/promise-call-limit": {
-            "version": "1.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/promise-inflight": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/promise-retry": {
-            "version": "2.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "err-code": "^2.0.2",
-                "retry": "^0.12.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/promzard": {
-            "version": "1.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "read": "^2.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/qrcode-terminal": {
-            "version": "0.12.0",
-            "dev": true,
-            "inBundle": true,
-            "bin": {
-                "qrcode-terminal": "bin/qrcode-terminal.js"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/read": {
-            "version": "2.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "mute-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/read-cmd-shim": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/read-package-json": {
-            "version": "6.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^10.2.2",
-                "json-parse-even-better-errors": "^3.0.0",
-                "normalize-package-data": "^5.0.0",
-                "npm-normalize-package-bin": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/read-package-json-fast": {
-            "version": "3.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "json-parse-even-better-errors": "^3.0.0",
-                "npm-normalize-package-bin": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/readable-stream": {
-            "version": "4.4.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "abort-controller": "^3.0.0",
-                "buffer": "^6.0.3",
-                "events": "^3.3.0",
-                "process": "^0.11.10"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/retry": {
-            "version": "0.12.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/rimraf": {
-            "version": "3.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/rimraf/node_modules/glob": {
-            "version": "7.2.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
-            "version": "3.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/semver": {
-            "version": "7.5.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/semver/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/set-blocking": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/shebang-command": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "shebang-regex": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/shebang-regex": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/signal-exit": {
-            "version": "4.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/sigstore": {
-            "version": "1.7.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@sigstore/protobuf-specs": "^0.1.0",
-                "@sigstore/tuf": "^1.0.1",
-                "make-fetch-happen": "^11.0.1"
-            },
-            "bin": {
-                "sigstore": "bin/sigstore.js"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/smart-buffer": {
-            "version": "4.2.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/socks": {
-            "version": "2.7.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ip": "^2.0.0",
-                "smart-buffer": "^4.2.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0",
-                "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/socks-proxy-agent": {
-            "version": "7.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^6.0.2",
-                "debug": "^4.3.3",
-                "socks": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/spdx-correct": {
-            "version": "3.2.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/spdx-exceptions": {
-            "version": "2.3.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "CC-BY-3.0"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/spdx-expression-parse": {
-            "version": "3.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/spdx-license-ids": {
-            "version": "3.0.13",
-            "dev": true,
-            "inBundle": true,
-            "license": "CC0-1.0"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/ssri": {
-            "version": "10.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^5.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/string_decoder": {
-            "version": "1.3.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.2.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/string-width": {
-            "version": "4.2.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/string-width-cjs": {
-            "name": "string-width",
-            "version": "4.2.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/strip-ansi-cjs": {
-            "name": "strip-ansi",
-            "version": "6.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/supports-color": {
-            "version": "9.3.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/tar": {
-            "version": "6.1.15",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^5.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-            "version": "3.3.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/text-table": {
-            "version": "0.2.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/tiny-relative-date": {
-            "version": "1.3.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/treeverse": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/tuf-js": {
-            "version": "1.1.7",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "@tufjs/models": "1.0.4",
-                "debug": "^4.3.4",
-                "make-fetch-happen": "^11.1.1"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/unique-filename": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "unique-slug": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/unique-slug": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "imurmurhash": "^0.1.4"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/validate-npm-package-license": {
-            "version": "3.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/validate-npm-package-name": {
-            "version": "5.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "builtins": "^5.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/walk-up-path": {
-            "version": "3.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/wcwidth": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "defaults": "^1.0.3"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/which": {
-            "version": "3.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/which.js"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/wide-align": {
-            "version": "1.1.5",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^1.0.2 || 2 || 3 || 4"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/wrap-ansi-cjs": {
-            "name": "wrap-ansi",
-            "version": "7.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
-            "version": "5.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/wrappy": {
-            "version": "1.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/write-file-atomic": {
-            "version": "5.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^4.0.1"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/npm/node_modules/yallist": {
-            "version": "4.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins/node_modules/parse-json": {
             "version": "4.0.0",
@@ -8533,16 +5238,16 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/plugin-search": {
-            "version": "0.0.21",
-            "resolved": "https://registry.npmjs.org/@oclif/plugin-search/-/plugin-search-0.0.21.tgz",
-            "integrity": "sha512-GWu1TgeZ+aKBwDa+JCm/rcsFAsX0reKNfiZcWonCroa7pnTrrr3LSaBeiI0Js3PZAsIEzD149TkREdaU2dNE7A==",
+            "version": "0.0.22",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-search/-/plugin-search-0.0.22.tgz",
+            "integrity": "sha512-YPOGOm2/hclKeNfddMHX753TgbVFXUJYrGX/abeduXBdFV+h+ZYrp6PK0fCPTWPjJZQt63b8Ejvkd418dF5lMg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@oclif/core": "^2.9.3",
                 "chalk": "^4",
                 "fuse.js": "^6.6.2",
-                "inquirer": "^8.2.5",
+                "inquirer": "^8.2.6",
                 "rxjs": "^7.8.1"
             },
             "engines": {
@@ -8550,20 +5255,20 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/plugin-update": {
-            "version": "3.1.28",
-            "resolved": "https://registry.npmjs.org/@oclif/plugin-update/-/plugin-update-3.1.28.tgz",
-            "integrity": "sha512-anP0kt73La0hzz9iqiBcxkXFwf7Mr+vQ+PdVnyKVTsI86yFWROFDmrBf5HSgF1rjvvGashvVGLq6hpKzSFUFJw==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-update/-/plugin-update-3.2.3.tgz",
+            "integrity": "sha512-JVKwp4ysG9GU4RmG59MZYMunz8onRI+wEQzJThyYkUFd0VfZviYt2FHsyoNtxi30l0tInC8APgKp1pCCO4e+FQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oclif/color": "^1.0.9",
-                "@oclif/core": "^2.9.3",
+                "@oclif/core": "^2.11.8",
+                "chalk": "^4",
                 "cross-spawn": "^7.0.3",
                 "debug": "^4.3.1",
                 "filesize": "^6.1.0",
                 "fs-extra": "^9.0.1",
                 "http-call": "^5.3.0",
-                "inquirer": "^8.2.5",
+                "inquirer": "^8.2.6",
                 "lodash.throttle": "^4.1.1",
                 "log-chopper": "^1.0.2",
                 "semver": "^7.5.4",
@@ -8589,63 +5294,59 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-version": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/@oclif/plugin-version/-/plugin-version-1.3.7.tgz",
-            "integrity": "sha512-OSap5pWHREaSmAM5ow1e4ukXwZdzKg7/Ezxc2UnxWMTRcT6GVwOpq1+l9nRCR8wj1UWuVW1rttdQXe7LSYWutA==",
+        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-update/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oclif/core": "^2.9.3"
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-version": {
+            "version": "1.3.10",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-version/-/plugin-version-1.3.10.tgz",
+            "integrity": "sha512-TiRZALUcv4hwGTPoTyA3nOWtRew9DT4Ge1FeYx16xnuAsWryvJe3IHXmCm6b1VYhzTJhV2XH5U1DqllrQB2YaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oclif/core": "^2.15.0"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@oclif/plugin-warn-if-update-available": {
-            "version": "2.0.45",
-            "resolved": "https://registry.npmjs.org/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-2.0.45.tgz",
-            "integrity": "sha512-MEncCUHW1vCOQdvt1z46jAblwvuGcs3Q1Gjl8IghazGJ0GRHzGOMILABpqVWR5uH/YJ3gfs05Tt7M4LdZ40N3g==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-2.1.0.tgz",
+            "integrity": "sha512-liTWd/qSIqALsikr88CAB9o2xGFt0LdT5REbhxtrx16/trRmkxQ+0RHK1FieGZAzEENx/4D3YcC/Y67a0uyO0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oclif/core": "^2.9.4",
+                "@oclif/core": "^2.15.0",
                 "chalk": "^4.1.0",
                 "debug": "^4.1.0",
-                "fs-extra": "^9.0.1",
                 "http-call": "^5.2.2",
-                "lodash": "^4.17.21",
+                "lodash.template": "^4.5.0",
                 "semver": "^7.5.4"
             },
             "engines": {
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/@oclif/plugin-warn-if-update-available/node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/@oclif/plugin-which": {
-            "version": "2.2.27",
-            "resolved": "https://registry.npmjs.org/@oclif/plugin-which/-/plugin-which-2.2.27.tgz",
-            "integrity": "sha512-rrfihOkg3zg2Asoo+4/cNaDMxZT5PrMPJkVypWRQjgRxTK8Hr6X4sf3Sm7Ldb4PjbvhE5iJTxPAWQAQ3f6gpIg==",
+            "version": "2.2.32",
+            "resolved": "https://registry.npmjs.org/@oclif/plugin-which/-/plugin-which-2.2.32.tgz",
+            "integrity": "sha512-6kWSBkw9tlGSfy2PF4dNoGc/c1a+FIitXSJTbMcXopWym8iZ8Jr7JrI24PxuqWqM6ciTzZqrqcnOs+EddlYAnw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oclif/core": "^2.9.4",
-                "tslib": "^2.6.0"
+                "@oclif/core": "^2.11.10",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -8823,14 +5524,13 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@opentelemetry/core": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.0.tgz",
-            "integrity": "sha512-GGTS6BytfaN8OgbCUOnxg/a9WVsVUj0484zXHZuBzvIXx7V4Tmkb0IHnnhS7Q0cBLNLgjNuvrCpQaP8fIvO4bg==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
+            "integrity": "sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/semantic-conventions": "1.15.0",
-                "tslib": "^2.3.1"
+                "@opentelemetry/semantic-conventions": "1.15.2"
             },
             "engines": {
                 "node": ">=14"
@@ -8840,16 +5540,16 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@opentelemetry/instrumentation": {
-            "version": "0.40.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.40.0.tgz",
-            "integrity": "sha512-23TzBKPflUS1uEq5SXymnQKQDSda35KvHjnvxdcDQGE+wg6hwDHgScUCWiBmZW4sxAaPcANfs+Wc9B7yDuyT6Q==",
+            "version": "0.41.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.41.2.tgz",
+            "integrity": "sha512-rxU72E0pKNH6ae2w5+xgVYZLzc5mlxAbGzF4shxMVK8YC2QQsfN38B2GPbj0jvrKWWNUElfclQ+YTykkNg/grw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/shimmer": "^1.0.2",
-                "import-in-the-middle": "1.3.5",
-                "require-in-the-middle": "^7.1.0",
-                "semver": "^7.3.2",
+                "import-in-the-middle": "1.4.2",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.1",
                 "shimmer": "^1.2.1"
             },
             "engines": {
@@ -8860,15 +5560,14 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@opentelemetry/resources": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.0.tgz",
-            "integrity": "sha512-Sb8A6ZXHXDlgHv32UNRE3y8McWE3vkb5dsSttYArYa5ZpwjiF5ge0vnnKUUnG7bY0AgF9VBIOORZE8gsrnD2WA==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.2.tgz",
+            "integrity": "sha512-xmMRLenT9CXmm5HMbzpZ1hWhaUowQf8UB4jMjFlAxx1QzQcsD3KFNAVX/CAWzFPtllTyTplrA4JrQ7sCH3qmYw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.15.0",
-                "@opentelemetry/semantic-conventions": "1.15.0",
-                "tslib": "^2.3.1"
+                "@opentelemetry/core": "1.15.2",
+                "@opentelemetry/semantic-conventions": "1.15.2"
             },
             "engines": {
                 "node": ">=14"
@@ -8878,16 +5577,15 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@opentelemetry/sdk-trace-base": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.0.tgz",
-            "integrity": "sha512-udt1c9VHipbZwvCPIQR1VLg25Z4AMR/g0X8KmcInbFruGWQ/lptVPkz3yvWAsGSta5yHNQ3uoPwcyCygGnQ6Lg==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.2.tgz",
+            "integrity": "sha512-BEaxGZbWtvnSPchV98qqqqa96AOcb41pjgvhfzDij10tkBhIu9m0Jd6tZ1tJB5ZHfHbTffqYVYE0AOGobec/EQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "1.15.0",
-                "@opentelemetry/resources": "1.15.0",
-                "@opentelemetry/semantic-conventions": "1.15.0",
-                "tslib": "^2.3.1"
+                "@opentelemetry/core": "1.15.2",
+                "@opentelemetry/resources": "1.15.2",
+                "@opentelemetry/semantic-conventions": "1.15.2"
             },
             "engines": {
                 "node": ">=14"
@@ -8897,14 +5595,11 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.0.tgz",
-            "integrity": "sha512-f3wwFrFyCpGrFBrFs7lCUJSCSCGyeKG52c+EKeobs3Dd29M75yO6GYkt6PkYPfDawxSlV5p+4yJPPk8tPObzTQ==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz",
+            "integrity": "sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw==",
             "dev": true,
             "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
             "engines": {
                 "node": ">=14"
             }
@@ -8921,19 +5616,19 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/apex-node": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-1.6.2.tgz",
-            "integrity": "sha512-EeBdfkVd6nA6MK8gdkNgk+aVuoxc8KzQvMIBzP1hBYNP0SDGOmq3bSINV3cyiAGCuBgt4VbYTznb/+iPdWRr/w==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-2.1.0.tgz",
+            "integrity": "sha512-W7OcqcBNHhf2wQMiPWOx/MED7ao1ZlML4vX5+A6hMDZTCZ5g34rj5wwVUQFOOAxHnS5F8jQUU5VpxpKo01jrTQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@salesforce/core": "^4.0.1",
+                "@salesforce/core": "^5.2.0",
                 "@types/istanbul-reports": "^3.0.1",
                 "faye": "1.4.0",
                 "glob": "^8.0.3",
                 "istanbul-lib-coverage": "^3.2.0",
-                "istanbul-lib-report": "^3.0.0",
-                "istanbul-reports": "^3.1.4"
+                "istanbul-lib-report": "^3.0.1",
+                "istanbul-reports": "^3.1.6"
             },
             "engines": {
                 "node": ">=16.13.0"
@@ -8994,29 +5689,52 @@
                 "safe-json-stringify": "~1"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/@salesforce/cli-plugins-testkit": {
+            "version": "4.2.9",
+            "resolved": "https://registry.npmjs.org/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-4.2.9.tgz",
+            "integrity": "sha512-v71dFmhlgwtmehK2QJ8+toeCYc39WQFu7R2wmhsHQeVA1UuYcx3uue5JnC392PIXddxQtjdR6eazk52tQg4nyA==",
+            "extraneous": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/kit": "^3.0.9",
+                "@salesforce/ts-types": "^2.0.2",
+                "@types/shelljs": "^0.8.12",
+                "debug": "^4.3.1",
+                "jszip": "^3.10.1",
+                "shelljs": "^0.8.4",
+                "strip-ansi": "6.0.1",
+                "ts-retry-promise": "^0.7.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/@salesforce/core": {
-            "version": "4.3.11",
-            "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-4.3.11.tgz",
-            "integrity": "sha512-rjrS0VoDlNaB4RYKLNZQ8+7QayWh5yTV79apCU9fYe0fR1D1p5tb+GAXe4B7AaOReQ8JOQhPBRMx1uzF3Lqn4A==",
+            "version": "5.2.7",
+            "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-5.2.7.tgz",
+            "integrity": "sha512-3tRWuPCSx4oTyD00fJUuxhulPMtaEF0BVvNvYcm38Axj/0WeLGOw7CFvoTupmmcCALHJFnxB1Kl20jDvrbB/7w==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@salesforce/bunyan": "^2.0.0",
-                "@salesforce/kit": "^3.0.4",
+                "@salesforce/kit": "^3.0.11",
                 "@salesforce/schemas": "^1.6.0",
-                "@salesforce/ts-types": "^2.0.2",
+                "@salesforce/ts-types": "^2.0.7",
                 "@types/semver": "^7.5.0",
                 "ajv": "^8.12.0",
                 "change-case": "^4.1.2",
-                "debug": "^3.2.7",
                 "faye": "^1.4.0",
                 "form-data": "^4.0.0",
                 "js2xmlparser": "^4.0.1",
                 "jsforce": "^2.0.0-beta.27",
-                "jsonwebtoken": "9.0.1",
+                "jsonwebtoken": "9.0.2",
                 "jszip": "3.10.1",
+                "pino": "^8.15.0",
+                "pino-abstract-transport": "^1.0.0",
+                "pino-pretty": "^10.2.0",
                 "proper-lockfile": "^4.1.2",
-                "ts-retry-promise": "^0.7.0"
+                "semver": "^7.5.4",
+                "ts-retry-promise": "^0.7.1"
             },
             "engines": {
                 "node": ">=16.0.0"
@@ -9037,16 +5755,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/core/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.1"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/core/node_modules/json-schema-traverse": {
@@ -9568,27 +6276,27 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/kit": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-3.0.6.tgz",
-            "integrity": "sha512-NtEU8dJn/zbGEWUjStSPRAlF8rq8lrOGAOAfaacsufLcpZikQZ8nZd6YUOk1A2siokPXDFCXyJbjT76F1rClpw==",
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-3.0.11.tgz",
+            "integrity": "sha512-ar44uFJfc/RCDWjz7LlrOtFCFHgNNUpddxe0eJCLqQuR/Xs3IlLZKuovWTx322Rzu+V9IIKrIdpz2IqA95/ClA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@salesforce/ts-types": "^2.0.5",
-                "tslib": "^2.6.0"
+                "@salesforce/ts-types": "^2.0.7",
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-apex": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-apex/-/plugin-apex-2.3.8.tgz",
-            "integrity": "sha512-0/DYPVF0uj3TZIBRyBVFnYBHvr9ZrWQtupjhHiyfICNSYBDotI0LCLqh/hn4ZMZXVnkxYEYLJLwe+jwVnHtzJw==",
+            "version": "2.3.14",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-apex/-/plugin-apex-2.3.14.tgz",
+            "integrity": "sha512-XRw7FhvfZr9zdJ9psNMmvxdr/zi62xBbLFQuZvjmbqt8zW0iV1llgcN7nYbxXHYmo9QCEMQRDgT1U4Hn74Obaw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.8.5",
-                "@salesforce/apex-node": "^1.6.2",
-                "@salesforce/core": "^4.1.0",
-                "@salesforce/sf-plugins-core": "^3.1.4",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/apex-node": "^2.1.0",
+                "@salesforce/core": "^5.2.6",
+                "@salesforce/sf-plugins-core": "^3.1.20",
                 "chalk": "^4.1.0",
                 "tslib": "^2"
             },
@@ -9597,19 +6305,19 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-auth": {
-            "version": "2.8.9",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-auth/-/plugin-auth-2.8.9.tgz",
-            "integrity": "sha512-gPE2kp9TV0ybwQH+UYmZT1cWp6O1QH7E3c5AdDLIpjp5rW23MqeZaM9pcpIW0mrAsro6feVzimcwsltZqgPFow==",
+            "version": "2.8.16",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-auth/-/plugin-auth-2.8.16.tgz",
+            "integrity": "sha512-H10I1xQbt+ALNZbDqfFraBmIMdDz4xyRqjEOkyz7IZPQ+1SbfK2TrfIP6in74YU+jxMcIrITLACVNRcDYytsZw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.9.3",
-                "@salesforce/core": "^4.3.6",
-                "@salesforce/kit": "^3.0.4",
-                "@salesforce/sf-plugins-core": "^3.1.4",
-                "@salesforce/ts-types": "^2.0.5",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/kit": "^3.0.9",
+                "@salesforce/sf-plugins-core": "^3.1.18",
+                "@salesforce/ts-types": "^2.0.6",
                 "chalk": "^4.1.2",
-                "inquirer": "^8.2.5",
+                "inquirer": "^8.2.6",
                 "open": "^8.2.1",
                 "tslib": "^2"
             },
@@ -9618,202 +6326,37 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference": {
-            "version": "2.4.6",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-command-reference/-/plugin-command-reference-2.4.6.tgz",
-            "integrity": "sha512-tqFSyquwoai3i+w9kiphaus1oG3tI8UOAuFkme5z7RT5ugQ9wF/AZ1R0owCfuCwEoluKWaID/kcqdDqgPHX94A==",
+            "version": "3.0.25",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-command-reference/-/plugin-command-reference-3.0.25.tgz",
+            "integrity": "sha512-ddieOyDapcK49HTqmbHy5bF+Iwzy59rkXr6iRoedRYEAGjj+5fYW1U2co9X/nuSUIRzT5uD13YpNqUVYG/LsbQ==",
             "extraneous": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.8.5",
-                "@salesforce/core": "^3.36.0",
-                "@salesforce/kit": "^3.0.0",
-                "@salesforce/sf-plugins-core": "^2.4.2",
-                "@salesforce/ts-types": "^2.0.1",
-                "chalk": "^3.0.0",
-                "handlebars": "^4.7.7",
+                "@oclif/core": "^2.11.7",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/kit": "^3.0.9",
+                "@salesforce/sf-plugins-core": "^3.1.14",
+                "@salesforce/ts-types": "^2.0.6",
+                "chalk": "^4",
+                "handlebars": "^4.7.8",
                 "tslib": "^2"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@salesforce/core": {
-            "version": "3.36.2",
-            "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.36.2.tgz",
-            "integrity": "sha512-IS1rR6Y0tMJYx/+TOAUQ9Gs+Vtum0MHLGfodT7ZJMQZQHEp1S4o0BJ8676uq5sASAnVL64GA+Et/LWCCOWWEuw==",
-            "extraneous": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@salesforce/bunyan": "^2.0.0",
-                "@salesforce/kit": "^1.9.2",
-                "@salesforce/schemas": "^1.5.1",
-                "@salesforce/ts-types": "^1.7.2",
-                "@types/semver": "^7.3.13",
-                "ajv": "^8.12.0",
-                "archiver": "^5.3.0",
-                "change-case": "^4.1.2",
-                "debug": "^3.2.7",
-                "faye": "^1.4.0",
-                "form-data": "^4.0.0",
-                "js2xmlparser": "^4.0.1",
-                "jsforce": "^2.0.0-beta.23",
-                "jsonwebtoken": "9.0.0",
-                "ts-retry-promise": "^0.7.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@salesforce/core/node_modules/@salesforce/kit": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-1.9.2.tgz",
-            "integrity": "sha512-kjZvjFNP6njhAiEa/ErdLXSDWZKafHYJyKCKz1wnSFmDM8TOpKHCCVw5cQo87ZQr8OqxqwUDIAlSBLyMzKi4Lg==",
-            "extraneous": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@salesforce/ts-types": "^1.7.3",
-                "shx": "^0.3.3",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@salesforce/core/node_modules/@salesforce/ts-types": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.7.3.tgz",
-            "integrity": "sha512-jpmekGqZ7tpHRJwf1rF0yBJ/IMC5mOrryNi4HZkKuNQn8RF97WpynmL8Om04mLTCESvCiif3y7NWfIcxtID2Gw==",
-            "extraneous": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@salesforce/sf-plugins-core": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/@salesforce/sf-plugins-core/-/sf-plugins-core-2.4.3.tgz",
-            "integrity": "sha512-gB1GY5GscR5vjLC2GJTO7hjmKH1IqeMj1cvvsnTdKpb3z0GAMpCZN3gPyC9OiIEE2JBQSlm3HUV4K+4zcMJjmQ==",
-            "extraneous": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@oclif/core": "^2.8.5",
-                "@salesforce/core": "^3.36.1",
-                "@salesforce/kit": "^1.9.2",
-                "@salesforce/ts-types": "^1.7.3",
-                "chalk": "^4",
-                "inquirer": "^8.2.5"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@salesforce/sf-plugins-core/node_modules/@salesforce/kit": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-1.9.2.tgz",
-            "integrity": "sha512-kjZvjFNP6njhAiEa/ErdLXSDWZKafHYJyKCKz1wnSFmDM8TOpKHCCVw5cQo87ZQr8OqxqwUDIAlSBLyMzKi4Lg==",
-            "extraneous": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@salesforce/ts-types": "^1.7.3",
-                "shx": "^0.3.3",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@salesforce/sf-plugins-core/node_modules/@salesforce/ts-types": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.7.3.tgz",
-            "integrity": "sha512-jpmekGqZ7tpHRJwf1rF0yBJ/IMC5mOrryNi4HZkKuNQn8RF97WpynmL8Om04mLTCESvCiif3y7NWfIcxtID2Gw==",
-            "extraneous": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@salesforce/sf-plugins-core/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/chalk": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "extraneous": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/jsonwebtoken": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-            "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "jws": "^3.2.2",
-                "lodash": "^4.17.21",
-                "ms": "^2.1.1",
-                "semver": "^7.3.8"
-            },
-            "engines": {
-                "node": ">=12",
-                "npm": ">=6"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-data": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-data/-/plugin-data-2.5.3.tgz",
-            "integrity": "sha512-dVo2ukMJJj75bLypuGEozwO4SDuFlzvq0T8RhjIE6WmgNveX7L1ijq3/tzGYlVQbVLwr9WDSV2SmBbvC8NuOnQ==",
+            "version": "2.5.9",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-data/-/plugin-data-2.5.9.tgz",
+            "integrity": "sha512-vxwEmLL1V9R4ZwfjSZKjni8LYSliytmeLWea51PlkNjKQb01b9XQr+e8cdwKnwYYaTe76xAHHusKJ8e/ik0XwQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.8.11",
-                "@salesforce/core": "^4.3.5",
-                "@salesforce/kit": "^3.0.6",
-                "@salesforce/sf-plugins-core": "^3.1.3",
-                "@salesforce/ts-types": "^2.0.3",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/kit": "^3.0.9",
+                "@salesforce/sf-plugins-core": "^3.1.22",
+                "@salesforce/ts-types": "^2.0.6",
                 "chalk": "^4.1.0",
                 "csv-parse": "^4.16.3",
                 "csv-stringify": "^6.4.0",
@@ -9825,21 +6368,20 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-deploy-retrieve": {
-            "version": "1.16.3",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-deploy-retrieve/-/plugin-deploy-retrieve-1.16.3.tgz",
-            "integrity": "sha512-q5NhZgscmJ8vdBYJxdfNaNPtC0tWlNzi43jhmzFe0hBtIgoacZghsLOYaft0BA4zabWMiohRHwpRv/efKY19FA==",
+            "version": "1.17.13",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-deploy-retrieve/-/plugin-deploy-retrieve-1.17.13.tgz",
+            "integrity": "sha512-sJRcWRzLIb14Af+ELgvCfemkv7KveyoHUb1jFjftxt+ntEt/a/CvdE7WeHFdIAwdWMURHmUtQ3lo0STtVaYnOQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.8.7",
-                "@salesforce/apex-node": "^1.6.2",
-                "@salesforce/core": "^4.3.10",
-                "@salesforce/kit": "^3.0.6",
-                "@salesforce/sf-plugins-core": "^3.1.3",
-                "@salesforce/source-deploy-retrieve": "^9.4.0",
-                "@salesforce/source-tracking": "^4.2.7",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/apex-node": "^2.1.0",
+                "@salesforce/core": "^5.2.7",
+                "@salesforce/kit": "^3.0.9",
+                "@salesforce/sf-plugins-core": "^3.1.20",
+                "@salesforce/source-deploy-retrieve": "^9.7.13",
+                "@salesforce/source-tracking": "^4.2.12",
                 "chalk": "^4.1.2",
-                "fs-extra": "^10.0.1",
                 "shelljs": "^0.8.5",
                 "tslib": "^2"
             },
@@ -9847,37 +6389,22 @@
                 "node": ">=16.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-deploy-retrieve/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-info": {
-            "version": "2.6.32",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-info/-/plugin-info-2.6.32.tgz",
-            "integrity": "sha512-jzfZIN64JP+Y/7G8Av3lj0X5UFq3chdfkJGBG1rYfNxivYo1wJEzyvOoaltuMUwRUmKXsk5xrSnM+OnB9vnc+w==",
+            "version": "2.6.42",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-info/-/plugin-info-2.6.42.tgz",
+            "integrity": "sha512-vxp7Mb2meG/CRe4ZxeqkVzhHM8lBd/s/HOiw//YLA0/+IYjYUdC3ksYlEdbYLOpFfSkiK8EIXyKnacqje0XGYg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.8.11",
-                "@salesforce/core": "^4.3.7",
-                "@salesforce/kit": "^3.0.4",
-                "@salesforce/sf-plugins-core": "^3.1.5",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/core": "^5.2.7",
+                "@salesforce/kit": "^3.0.9",
+                "@salesforce/sf-plugins-core": "^3.1.20",
                 "got": "^11.8.6",
                 "marked": "^4.3.0",
                 "marked-terminal": "^4.2.0",
                 "open": "^8.4.2",
-                "proxy-agent": "^6.2.1",
+                "proxy-agent": "^6.3.1",
                 "semver": "^7.5.4",
                 "tslib": "^2"
             },
@@ -9886,17 +6413,17 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-limits": {
-            "version": "2.3.27",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-limits/-/plugin-limits-2.3.27.tgz",
-            "integrity": "sha512-2A0JOVUKG6QIp8ZqVRVchoJbTlClKD+y5v3rBjY3/WK2Y/LYKklAKaLT/XxTtBFbzs+wgwx5AvmUUi4YPNOFHA==",
+            "version": "2.3.34",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-limits/-/plugin-limits-2.3.34.tgz",
+            "integrity": "sha512-LQ7O5PznZW32tWh951cBOVSprKbBd+K/G2+rxnvCE3dgcH2Io9hqeiq9me6gmT3FpsMF7/sEVn+BlohG/icXTw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.8.7",
-                "@salesforce/core": "^4.3.1",
-                "@salesforce/kit": "^3.0.3",
-                "@salesforce/sf-plugins-core": "^3.1.10",
-                "@salesforce/ts-types": "^2.0.4",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/kit": "^3.0.11",
+                "@salesforce/sf-plugins-core": "^3.1.22",
+                "@salesforce/ts-types": "^2.0.6",
                 "tslib": "^2"
             },
             "engines": {
@@ -9904,17 +6431,36 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-login": {
-            "version": "1.2.22",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-login/-/plugin-login-1.2.22.tgz",
-            "integrity": "sha512-PgtRhe5mOhwcyCpOGa4eXeLIVfXOPnGBcuIZJq3IL/F8f/n+0jcS4cmvwC5QBNn0BzZoW7VuH8a5jnnDXPEAoA==",
+            "version": "1.2.30",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-login/-/plugin-login-1.2.30.tgz",
+            "integrity": "sha512-1gcZ0nlrCRAMe/PdV0CAnDAUMjkHV4HYkTsdvj0nGFhle8D7DefW3B/bvSapNd1KLpkN9MdQnzjt+oleYxi3MA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.9.3",
-                "@salesforce/core": "^4.3.1",
-                "@salesforce/sf-plugins-core": "^3.1.11",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/core": "^5.2.5",
+                "@salesforce/sf-plugins-core": "^3.1.22",
                 "chalk": "^4.1.2",
-                "inquirer": "^8.2.5",
+                "inquirer": "^8.2.6",
+                "tslib": "^2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-marketplace": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-marketplace/-/plugin-marketplace-0.2.1.tgz",
+            "integrity": "sha512-d7+blQj4SN6HTPXqkxm31in7eiWCtlelFjRyIbOV5Tregw8hLJ3iO9ArWQA8cl2CZEYusFA19ZoRE52DRJwNjA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@oclif/core": "^2.15.0",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/kit": "^3.0.9",
+                "@salesforce/sf-plugins-core": "^3.1.14",
+                "got": "^11",
+                "proxy-agent": "^6.3.1",
                 "tslib": "^2"
             },
             "engines": {
@@ -9922,17 +6468,17 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-org": {
-            "version": "2.9.27",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-org/-/plugin-org-2.9.27.tgz",
-            "integrity": "sha512-OzuHutKXNHBjVTAfpM5tDbx0SLqXcaH+weyqins2sMoImxyr47GPj7Kd4wwLQCrRC0VpzLNxI7e0u40sD39KJw==",
+            "version": "2.10.7",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-org/-/plugin-org-2.10.7.tgz",
+            "integrity": "sha512-c2K8HsQPMWHPehAzxiX2Wk12+JEVey9ZVqRXmGl1Q3X2OEc5Q/dL9kj2C5A3zGWL1Gd/ppJN61ipBx5j591Gxw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.8.11",
-                "@salesforce/core": "^4.3.7",
-                "@salesforce/kit": "^3.0.6",
-                "@salesforce/sf-plugins-core": "^3.1.7",
-                "@salesforce/source-deploy-retrieve": "^9.3.2",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/kit": "^3.0.9",
+                "@salesforce/sf-plugins-core": "^3.1.22",
+                "@salesforce/source-deploy-retrieve": "^9.7.8",
                 "open": "^8.4.2",
                 "tslib": "^2"
             },
@@ -9941,34 +6487,30 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management": {
-            "version": "3.17.8",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-release-management/-/plugin-release-management-3.17.8.tgz",
-            "integrity": "sha512-VTETxcAiSZHb49q9/T4XlCbe0BMWMuNd7FO08moJy+XL5d9Ld6apDuF+0576ALQqaDF1q6tSb8AseIiIj8UMfg==",
+            "version": "4.1.19",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-release-management/-/plugin-release-management-4.1.19.tgz",
+            "integrity": "sha512-LflsY09sqbGay8/YszzGB62M8CRmoab5/LB0sFppvfBbTLgjDzCuPZkIWd+vR6d+v5nUfoR5OuLSV4l3zGXOOA==",
             "extraneous": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.8.2",
-                "@octokit/core": "^4.2.1",
+                "@oclif/core": "^2.11.7",
+                "@octokit/core": "^4.2.4",
                 "@octokit/plugin-paginate-rest": "^6.1.2",
-                "@octokit/plugin-throttling": "^5.1.1",
-                "@salesforce/core": "^3.36.2",
-                "@salesforce/kit": "^1.9.2",
-                "@salesforce/plugin-command-reference": "^2.4.1",
+                "@octokit/plugin-throttling": "^5.2.3",
+                "@salesforce/cli-plugins-testkit": "^4.2.9",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/kit": "^3.0.9",
+                "@salesforce/plugin-command-reference": "^3.0.25",
                 "@salesforce/plugin-trust": "^2.4.2",
-                "@salesforce/sf-plugins-core": "^2.4.3",
-                "@salesforce/ts-types": "^1.7.3",
-                "agent-base": "^6.0.2",
-                "aws-sdk": "^2.1377.0",
+                "@salesforce/sf-plugins-core": "^3.1.14",
+                "@salesforce/ts-types": "^2.0.6",
+                "aws-sdk": "^2.1413.0",
                 "chalk": "^4.1.0",
-                "conventional-changelog-conventionalcommits": "^4.6.1",
-                "conventional-changelog-preset-loader": "^2.3.4",
-                "conventional-commits-parser": "^3.2.2",
-                "fast-glob": "^3.2.12",
+                "fast-glob": "^3.3.0",
                 "got": "^11.8.6",
                 "just-diff": "^5.2.0",
-                "proxy-agent": "^5.0.0",
-                "proxy-from-env": "^1.1.0",
-                "semver": "^7.5.1",
+                "proxy-agent": "^6.3.0",
+                "semver": "^7.5.2",
                 "shelljs": "^0.8.4",
                 "standard-version": "^9.0.0",
                 "tslib": "^2",
@@ -9978,7 +6520,7 @@
                 "sf-release": "bin/run"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/@octokit/auth-token": {
@@ -10124,317 +6666,16 @@
                 "@octokit/openapi-types": "^18.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/@salesforce/core": {
-            "version": "3.36.2",
-            "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.36.2.tgz",
-            "integrity": "sha512-IS1rR6Y0tMJYx/+TOAUQ9Gs+Vtum0MHLGfodT7ZJMQZQHEp1S4o0BJ8676uq5sASAnVL64GA+Et/LWCCOWWEuw==",
-            "extraneous": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@salesforce/bunyan": "^2.0.0",
-                "@salesforce/kit": "^1.9.2",
-                "@salesforce/schemas": "^1.5.1",
-                "@salesforce/ts-types": "^1.7.2",
-                "@types/semver": "^7.3.13",
-                "ajv": "^8.12.0",
-                "archiver": "^5.3.0",
-                "change-case": "^4.1.2",
-                "debug": "^3.2.7",
-                "faye": "^1.4.0",
-                "form-data": "^4.0.0",
-                "js2xmlparser": "^4.0.1",
-                "jsforce": "^2.0.0-beta.23",
-                "jsonwebtoken": "9.0.0",
-                "ts-retry-promise": "^0.7.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/@salesforce/core/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/@salesforce/kit": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-1.9.2.tgz",
-            "integrity": "sha512-kjZvjFNP6njhAiEa/ErdLXSDWZKafHYJyKCKz1wnSFmDM8TOpKHCCVw5cQo87ZQr8OqxqwUDIAlSBLyMzKi4Lg==",
-            "extraneous": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@salesforce/ts-types": "^1.7.3",
-                "shx": "^0.3.3",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/@salesforce/sf-plugins-core": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/@salesforce/sf-plugins-core/-/sf-plugins-core-2.4.3.tgz",
-            "integrity": "sha512-gB1GY5GscR5vjLC2GJTO7hjmKH1IqeMj1cvvsnTdKpb3z0GAMpCZN3gPyC9OiIEE2JBQSlm3HUV4K+4zcMJjmQ==",
-            "extraneous": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@oclif/core": "^2.8.5",
-                "@salesforce/core": "^3.36.1",
-                "@salesforce/kit": "^1.9.2",
-                "@salesforce/ts-types": "^1.7.3",
-                "chalk": "^4",
-                "inquirer": "^8.2.5"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/@salesforce/ts-types": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.7.3.tgz",
-            "integrity": "sha512-jpmekGqZ7tpHRJwf1rF0yBJ/IMC5mOrryNi4HZkKuNQn8RF97WpynmL8Om04mLTCESvCiif3y7NWfIcxtID2Gw==",
-            "extraneous": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/data-uri-to-buffer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-            "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/degenerator": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-3.0.4.tgz",
-            "integrity": "sha512-Z66uPeBfHZAHVmue3HPfyKu2Q0rC2cRxbTOsvmU/po5fvvcx27W4mIu9n0PUlQih4oUYvcG1BsbtVv8x7KDOSw==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ast-types": "^0.13.2",
-                "escodegen": "^1.8.1",
-                "esprima": "^4.0.0",
-                "vm2": "^3.9.17"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/escodegen": {
-            "version": "1.14.3",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-            "extraneous": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "esprima": "^4.0.1",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1"
-            },
-            "bin": {
-                "escodegen": "bin/escodegen.js",
-                "esgenerate": "bin/esgenerate.js"
-            },
-            "engines": {
-                "node": ">=4.0"
-            },
-            "optionalDependencies": {
-                "source-map": "~0.6.1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "extraneous": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/fast-levenshtein": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "extraneous": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/get-uri": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
-            "integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@tootallnate/once": "1",
-                "data-uri-to-buffer": "3",
-                "debug": "4",
-                "file-uri-to-path": "2",
-                "fs-extra": "^8.1.0",
-                "ftp": "^0.3.10"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "extraneous": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/jsonwebtoken": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-            "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "jws": "^3.2.2",
-                "lodash": "^4.17.21",
-                "ms": "^2.1.1",
-                "semver": "^7.3.8"
-            },
-            "engines": {
-                "node": ">=12",
-                "npm": ">=6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/levn": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-            "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "extraneous": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^3.0.2"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/optionator": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.6",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "word-wrap": "~1.2.3"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/pac-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4",
-                "get-uri": "3",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "5",
-                "pac-resolver": "^5.0.0",
-                "raw-body": "^2.2.0",
-                "socks-proxy-agent": "5"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/pac-resolver": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.1.tgz",
-            "integrity": "sha512-cy7u00ko2KVgBAjuhevqpPeHIkCIqPe1v24cydhWjmeuzaBfmUWFCZJ1iAh5TuVzVZoUzXIW7K8sMYOZ84uZ9Q==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "degenerator": "^3.0.2",
-                "ip": "^1.1.5",
-                "netmask": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^6.0.0",
-                "debug": "4",
-                "http-proxy-agent": "^4.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "lru-cache": "^5.1.1",
-                "pac-proxy-agent": "^5.0.0",
-                "proxy-from-env": "^1.0.0",
-                "socks-proxy-agent": "^5.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "extraneous": true,
-            "license": "ISC"
-        },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema": {
-            "version": "2.3.21",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-schema/-/plugin-schema-2.3.21.tgz",
-            "integrity": "sha512-426NGuXHrqa0/1X8zYIs7KF76x0+nOiNl9UyKeUubi8KRYz30NDRcBTpCfn7Hm/PlKW5NEtLtMwwegAXMIssJQ==",
+            "version": "2.3.25",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-schema/-/plugin-schema-2.3.25.tgz",
+            "integrity": "sha512-7DBGffnhyscTQJJvcX5s0+xYfvSWx+yXlA2YUshikKFKEtuRBFy559hz95xf5C1PE9P23W3JJm5jhW3Pdbnm0Q==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.9.3",
-                "@salesforce/core": "^4.3.5",
-                "@salesforce/sf-plugins-core": "^3.1.11",
+                "@oclif/core": "^2.11.10",
+                "@salesforce/core": "^5.2.5",
+                "@salesforce/sf-plugins-core": "^3.1.14",
                 "tslib": "^2"
             },
             "engines": {
@@ -10442,15 +6683,15 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-settings": {
-            "version": "1.4.21",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-settings/-/plugin-settings-1.4.21.tgz",
-            "integrity": "sha512-UJk4vYf+toA9ERBW1hn/GAkCLduq79rwdckrphubgOdAkAHfTGhb+sUQmvRpHhkjSa6SDBOLHD0bqbXH/k+zjg==",
+            "version": "1.4.28",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-settings/-/plugin-settings-1.4.28.tgz",
+            "integrity": "sha512-ghSCZBiXNKdnPTLsRfHI2vmuLoVsREoOD520Bt1D0AzpYBOCtLyAt0zBZftbNNssy2jaTAzaMpjcx2UazHQhUA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.8.11",
-                "@salesforce/core": "^4.0.1",
-                "@salesforce/sf-plugins-core": "^3.1.0",
+                "@oclif/core": "^2.11.10",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/sf-plugins-core": "^3.1.20",
                 "fast-levenshtein": "^3.0.0",
                 "tslib": "^2"
             },
@@ -10459,20 +6700,20 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject": {
-            "version": "0.1.40",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-sobject/-/plugin-sobject-0.1.40.tgz",
-            "integrity": "sha512-0nhJ0JaQpoET3bOeu19oiZuvfTB1KqqD1tgzP0nU7VGvVS5KpnEyYadSQGSMF0zTcIziT+EUdtWTv/CKCpeMEQ==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-sobject/-/plugin-sobject-0.2.7.tgz",
+            "integrity": "sha512-Tiv5IxIDnSSEe1NRKZEIjnsmiBvQLGhVQrhdN6SEAuw8R0auqQCEgzu4GsWAwRm/mqBTouVnQwl5ZS2+ysFQPg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.9.3",
-                "@salesforce/core": "^4.3.5",
-                "@salesforce/kit": "^3.0.4",
-                "@salesforce/sf-plugins-core": "^3.1.10",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/kit": "^3.0.9",
+                "@salesforce/sf-plugins-core": "^3.1.22",
                 "change-case": "^4.1.2",
-                "fast-glob": "^3.2.12",
-                "fast-xml-parser": "^4.2.6",
-                "inquirer": "^8.2.5",
+                "fast-glob": "^3.3.1",
+                "fast-xml-parser": "^4.2.7",
+                "inquirer": "^8.2.6",
                 "js2xmlparser": "^4.0.2",
                 "tslib": "^2"
             },
@@ -10481,19 +6722,19 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-source": {
-            "version": "2.10.27",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-source/-/plugin-source-2.10.27.tgz",
-            "integrity": "sha512-lO/xVzTvTEqNdE4JIK3ZKtFntLY+OvnEjA7gZf1CLqqr83fWR4iTTfIYNyftiotZindGSqSh/2qTINc6Cx5nMg==",
+            "version": "2.10.33",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-source/-/plugin-source-2.10.33.tgz",
+            "integrity": "sha512-oDcAra4eAZnbhbEzKw6/lEzp0srJ+Lq3E4oYFQeEQrhw+NcUKaVr2gZj1DdAvMhIQfLRvp86xYiDfAjVpsqdrA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.8.10",
-                "@salesforce/apex-node": "^1.6.2",
-                "@salesforce/core": "^4.3.2",
-                "@salesforce/kit": "^3.0.2",
-                "@salesforce/sf-plugins-core": "^3.0.2",
-                "@salesforce/source-deploy-retrieve": "^9.2.2",
-                "@salesforce/source-tracking": "^4.2.5",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/apex-node": "^2.1.0",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/kit": "^3.0.9",
+                "@salesforce/sf-plugins-core": "^3.1.14",
+                "@salesforce/source-deploy-retrieve": "^9.7.4",
+                "@salesforce/source-tracking": "^4.2.10",
                 "chalk": "^4.1.2",
                 "got": "^11.8.6",
                 "proxy-agent": "^6.3.0",
@@ -10504,16 +6745,16 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-telemetry": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-telemetry/-/plugin-telemetry-2.2.3.tgz",
-            "integrity": "sha512-f6QEeO4TkkDRFsn/qK6ginZmSemcb98s3mSR8IgpKA1AQGej+GXB5OwXLNJyF653boONR7K0iDPzJ+Q+ZmTWgQ==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-telemetry/-/plugin-telemetry-2.3.2.tgz",
+            "integrity": "sha512-C6lDdnDtFldS+P/lyErjtc/NAJxaZGg0CXqlsKRZEy+TOt+Na2qOlvrxzIn4OVm0bkREExtlQMebVmGJoNOEFg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.8.5",
-                "@salesforce/core": "^4.2.1",
-                "@salesforce/sf-plugins-core": "^3.0.2",
-                "@salesforce/telemetry": "^3.2.29",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/sf-plugins-core": "^3.1.20",
+                "@salesforce/telemetry": "^4.1.3",
                 "debug": "^4.3.4",
                 "tslib": "^2"
             },
@@ -10522,16 +6763,16 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-templates": {
-            "version": "55.5.7",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-templates/-/plugin-templates-55.5.7.tgz",
-            "integrity": "sha512-rK8VuyA35r1ps5iPK95SCA2TXXARtNrL7O15jElA58exE6h9IaoSr+Q8kxA6LIBEBDaqz1Z/21avOzLI/L61RQ==",
+            "version": "55.5.11",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-templates/-/plugin-templates-55.5.11.tgz",
+            "integrity": "sha512-cnUNRYGWfXMJ/U3b0CjQS12snS21CAcVxSP9w2A1jV/WHZMcb5KVwUZ/6HTT1Iq/OGr8ze3KhC7rLmP9jaEorA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.9.4",
-                "@salesforce/core": "^4.2.1",
-                "@salesforce/sf-plugins-core": "^3.1.4",
-                "@salesforce/templates": "^57.1.2",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/core": "^5.2.6",
+                "@salesforce/sf-plugins-core": "^3.1.20",
+                "@salesforce/templates": "^59.0.1",
                 "tslib": "^2",
                 "yeoman-environment": "^3.19.3",
                 "yeoman-generator": "^5.9.0"
@@ -10541,18 +6782,17 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-trust": {
-            "version": "2.4.34",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-trust/-/plugin-trust-2.4.34.tgz",
-            "integrity": "sha512-xJw/43zM36ygVNwlPVbwr0HhN5mVInRo/pG/EZwJzRNhzTSN5jrLIPNJuhhIYxj8cn2jmYiAFpWSxah9/OLC1w==",
+            "version": "2.6.10",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-trust/-/plugin-trust-2.6.10.tgz",
+            "integrity": "sha512-aLVIRJyo280sEvyOGvCpAWtsT0YVIbKlOO6Muan2BbwRMmjy6rpFK8/SRgLNz/Mf69qNosQoyozjW9gSZsaByg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.8.11",
-                "@salesforce/core": "^4.0.1",
-                "@salesforce/sf-plugins-core": "^3.1.7",
-                "@salesforce/telemetry": "^3.2.29",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/core": "^5.2.1",
+                "@salesforce/sf-plugins-core": "^3.1.22",
                 "got": "^11",
-                "npm": "^8.19.4",
+                "npm": "9.6.7",
                 "npm-run-path": "^4.0.1",
                 "proxy-agent": "^6.3.0",
                 "shelljs": "^0.8.4",
@@ -10566,17 +6806,17 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-user": {
-            "version": "2.3.27",
-            "resolved": "https://registry.npmjs.org/@salesforce/plugin-user/-/plugin-user-2.3.27.tgz",
-            "integrity": "sha512-hseytTJpLoITuGC4bCZ3tEZO01+2PBtB/DXwl+wEiYIcc91DlTDfsUG48zAQP853pUS/mIr7x3MBXKZn+oK96w==",
+            "version": "2.3.32",
+            "resolved": "https://registry.npmjs.org/@salesforce/plugin-user/-/plugin-user-2.3.32.tgz",
+            "integrity": "sha512-Msljq9lATskNYzVZsHrxBDzSLOiju9Khtbw7irlfdDrpCRV0K9aViyLDZC6HcV5rfWkeW4T8dSnvnqLNp6EMRg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.8.11",
-                "@salesforce/core": "^4.3.7",
-                "@salesforce/kit": "^3.0.2",
-                "@salesforce/sf-plugins-core": "^3.0.2",
-                "@salesforce/ts-types": "^2.0.5",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/core": "^5.2.6",
+                "@salesforce/kit": "^3.0.9",
+                "@salesforce/sf-plugins-core": "^3.1.20",
+                "@salesforce/ts-types": "^2.0.7",
                 "tslib": "^2"
             },
             "engines": {
@@ -10598,16 +6838,16 @@
             "license": "ISC"
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/sf-plugins-core": {
-            "version": "3.1.12",
-            "resolved": "https://registry.npmjs.org/@salesforce/sf-plugins-core/-/sf-plugins-core-3.1.12.tgz",
-            "integrity": "sha512-XOZxg5SkDg+KHblzgclkjtEo3Hhq0oBLW6l3bD6P/JoEKOagOyHEXvegiLN/FIdkugLo5NB5l2TnodaKQ37Hpg==",
+            "version": "3.1.22",
+            "resolved": "https://registry.npmjs.org/@salesforce/sf-plugins-core/-/sf-plugins-core-3.1.22.tgz",
+            "integrity": "sha512-t8IvC+8LLzCU+skT3/FGjpkB6qm+VaL3uCbwrqgmZivzQc5tpRQpVcW9YbTgJUgkQrD58yurbkwX/jA9hMR6yg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@oclif/core": "^2.9.4",
-                "@salesforce/core": "^4.3.11",
-                "@salesforce/kit": "^3.0.6",
-                "@salesforce/ts-types": "^2.0.5",
+                "@oclif/core": "^2.15.0",
+                "@salesforce/core": "^5.2.6",
+                "@salesforce/kit": "^3.0.11",
+                "@salesforce/ts-types": "^2.0.7",
                 "chalk": "^4",
                 "inquirer": "^8.2.5"
             },
@@ -10616,24 +6856,24 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/source-deploy-retrieve": {
-            "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-9.5.0.tgz",
-            "integrity": "sha512-yjISk/euy77OOGyPxchUJt9jvc99Ia+tSXj3TJpaK552AqNq8WlT4Wnay+IKBa24SWFV57nvUtqaI8bcgkmm/Q==",
+            "version": "9.7.13",
+            "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-9.7.13.tgz",
+            "integrity": "sha512-QRhdepll3+ED9w4clI/RvcSLtuSbTzFPZenzrvJ2R7Pg5gXRZQIJrphEkAnY7oteVBBUxPVdYgbeuQxeoi98dg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@salesforce/core": "^4.3.1",
-                "@salesforce/kit": "^3.0.6",
-                "@salesforce/ts-types": "^2.0.5",
+                "@salesforce/core": "^5.2.7",
+                "@salesforce/kit": "^3.0.11",
+                "@salesforce/ts-types": "^2.0.7",
                 "fast-levenshtein": "^3.0.0",
-                "fast-xml-parser": "^4.2.5",
+                "fast-xml-parser": "^4.2.7",
                 "got": "^11.8.6",
                 "graceful-fs": "^4.2.11",
                 "ignore": "^5.2.4",
                 "jszip": "^3.10.1",
                 "mime": "2.6.0",
                 "minimatch": "^5.1.6",
-                "proxy-agent": "^6.3.0",
+                "proxy-agent": "^6.3.1",
                 "unzipper": "0.10.14"
             },
             "engines": {
@@ -10654,16 +6894,16 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/source-tracking": {
-            "version": "4.2.9",
-            "resolved": "https://registry.npmjs.org/@salesforce/source-tracking/-/source-tracking-4.2.9.tgz",
-            "integrity": "sha512-RskbDf1hiKlZjfXpJ6YkEaGyQ1x8gU/vBLViMEfwdqrWhdfffqS++vRrf1aecUZRFYIXgheSw5gR+aQBY7bmoA==",
+            "version": "4.2.12",
+            "resolved": "https://registry.npmjs.org/@salesforce/source-tracking/-/source-tracking-4.2.12.tgz",
+            "integrity": "sha512-hxN4rMmyOmZoUJTy5fyg33ovhKc0ffCqX6j0EqAX90gHO4OQqNMWvweogbzX7h8nkFyNv+ZLyDeJBAdMnTgnWw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@salesforce/core": "^4.3.11",
-                "@salesforce/kit": "^3.0.6",
-                "@salesforce/source-deploy-retrieve": "^9.4.2",
-                "@salesforce/ts-types": "^2.0.5",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/kit": "^3.0.9",
+                "@salesforce/source-deploy-retrieve": "^9.7.8",
+                "@salesforce/ts-types": "^2.0.6",
                 "fast-xml-parser": "^4.2.5",
                 "graceful-fs": "^4.2.11",
                 "isomorphic-git": "1.23.0",
@@ -10674,122 +6914,31 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/telemetry": {
-            "version": "3.2.29",
-            "resolved": "https://registry.npmjs.org/@salesforce/telemetry/-/telemetry-3.2.29.tgz",
-            "integrity": "sha512-BqWkPCy/rBb/pf1xstTUfQHGlSuP2T/vklkO6TFFQuKyW55E5Q22umFbE8YCwGBXoRv5yk9AwhTDX4y7MkIaOQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@salesforce/telemetry/-/telemetry-4.1.5.tgz",
+            "integrity": "sha512-Xu8tuXYyA7stnc6RNyona4dPaxgKkgVmWsllFzeloaKi89buCIsVmUTnt3sv3ERAHRno83bARMUEeh9tEaZLKw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@salesforce/core": "^3.36.1",
-                "@salesforce/ts-types": "^1.7.3",
-                "applicationinsights": "^2.6.0",
-                "axios": "^1.4.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/telemetry/node_modules/@salesforce/core": {
-            "version": "3.36.2",
-            "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-3.36.2.tgz",
-            "integrity": "sha512-IS1rR6Y0tMJYx/+TOAUQ9Gs+Vtum0MHLGfodT7ZJMQZQHEp1S4o0BJ8676uq5sASAnVL64GA+Et/LWCCOWWEuw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@salesforce/bunyan": "^2.0.0",
-                "@salesforce/kit": "^1.9.2",
-                "@salesforce/schemas": "^1.5.1",
-                "@salesforce/ts-types": "^1.7.2",
-                "@types/semver": "^7.3.13",
-                "ajv": "^8.12.0",
-                "archiver": "^5.3.0",
-                "change-case": "^4.1.2",
-                "debug": "^3.2.7",
-                "faye": "^1.4.0",
-                "form-data": "^4.0.0",
-                "js2xmlparser": "^4.0.1",
-                "jsforce": "^2.0.0-beta.23",
-                "jsonwebtoken": "9.0.0",
-                "ts-retry-promise": "^0.7.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/telemetry/node_modules/@salesforce/kit": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-1.9.2.tgz",
-            "integrity": "sha512-kjZvjFNP6njhAiEa/ErdLXSDWZKafHYJyKCKz1wnSFmDM8TOpKHCCVw5cQo87ZQr8OqxqwUDIAlSBLyMzKi4Lg==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@salesforce/ts-types": "^1.7.3",
-                "shx": "^0.3.3",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/telemetry/node_modules/@salesforce/ts-types": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.7.3.tgz",
-            "integrity": "sha512-jpmekGqZ7tpHRJwf1rF0yBJ/IMC5mOrryNi4HZkKuNQn8RF97WpynmL8Om04mLTCESvCiif3y7NWfIcxtID2Gw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/telemetry/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/telemetry/node_modules/debug": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/telemetry/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/telemetry/node_modules/jsonwebtoken": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-            "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "jws": "^3.2.2",
-                "lodash": "^4.17.21",
-                "ms": "^2.1.1",
-                "semver": "^7.3.8"
+                "@salesforce/core": "^5.2.7",
+                "@salesforce/ts-types": "^2.0.6",
+                "applicationinsights": "^2.7.3",
+                "got": "^11",
+                "proxy-agent": "^6.3.1"
             },
             "engines": {
-                "node": ">=12",
-                "npm": ">=6"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/templates": {
-            "version": "58.0.1",
+            "version": "59.0.1",
+            "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-59.0.1.tgz",
+            "integrity": "sha512-atu1rMpQ0RJdY/EhAvGlk65gweSgTpaq+YoJA5aLc2VX7lBqcUJVWQPLK6cNYheuzl3b9voqTrpopHkM2vBOEw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@salesforce/core": "^4.0.1",
-                "@salesforce/kit": "^1.7.1",
+                "@salesforce/core": "^5.2.0",
+                "@salesforce/kit": "^3.0.9",
                 "got": "^11.8.2",
                 "mime-types": "^2.1.27",
                 "proxy-agent": "^6.2.1",
@@ -10802,42 +6951,6 @@
                 "node": ">=16.13.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/templates/node_modules/@salesforce/kit": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@salesforce/kit/-/kit-1.9.2.tgz",
-            "integrity": "sha512-kjZvjFNP6njhAiEa/ErdLXSDWZKafHYJyKCKz1wnSFmDM8TOpKHCCVw5cQo87ZQr8OqxqwUDIAlSBLyMzKi4Lg==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@salesforce/ts-types": "^1.7.3",
-                "shx": "^0.3.3",
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/templates/node_modules/@salesforce/kit/node_modules/tslib": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
-            "license": "0BSD"
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/templates/node_modules/@salesforce/ts-types": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-1.7.3.tgz",
-            "integrity": "sha512-jpmekGqZ7tpHRJwf1rF0yBJ/IMC5mOrryNi4HZkKuNQn8RF97WpynmL8Om04mLTCESvCiif3y7NWfIcxtID2Gw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tslib": "^2.5.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/@salesforce/templates/node_modules/@salesforce/ts-types/node_modules/tslib": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-            "dev": true,
-            "license": "0BSD"
-        },
         "node_modules/@salesforce/cli/node_modules/@salesforce/templates/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -10846,15 +6959,15 @@
             "license": "0BSD"
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/ts-sinon": {
-            "version": "1.4.12",
-            "resolved": "https://registry.npmjs.org/@salesforce/ts-sinon/-/ts-sinon-1.4.12.tgz",
-            "integrity": "sha512-PSksX6flCKbWenghItnX8PvKepTlb/Ax8cgSyr8Y46xTDiE/UwmTBNnrf23HkgsNihwRhNbPXlucG1rDerO00A==",
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@salesforce/ts-sinon/-/ts-sinon-1.4.15.tgz",
+            "integrity": "sha512-mw//jI+QkkS+PEwqMtazlhdi3eYY49InnJ/EipmrsdsdV9b+W79D5N4C92LROYe9VNq+3q5VHJcT/jhARxZsTg==",
             "extraneous": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@salesforce/ts-types": "^2.0.5",
+                "@salesforce/ts-types": "^2.0.7",
                 "sinon": "^5.1.1",
-                "tslib": "^2.6.0"
+                "tslib": "^2.6.1"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/ts-sinon/node_modules/@sinonjs/samsam": {
@@ -10954,13 +7067,13 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@salesforce/ts-types": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.5.tgz",
-            "integrity": "sha512-X91De9ZK/X86lYcFAzoAt/pPeY6Lf+G7LyAJRx3FuYpdc+nocvniUnnJGXwSmyKMMxW2NifvQgST7FTZLZ5REA==",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-2.0.7.tgz",
+            "integrity": "sha512-8csXgstPuy6QXL3JavkIi/f8DOWHBNCvWeszrFu5sbVlcKO3YqOOCE+rDFGPkrZsYv5OywV6H8kEi877bWOz6Q==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "tslib": "^2.6.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=16.0.0"
@@ -11066,15 +7179,13 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@tootallnate/once": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true,
             "engines": {
-                "node": ">= 6"
+                "node": ">= 10"
             }
         },
         "node_modules/@salesforce/cli/node_modules/@tootallnate/quickjs-emscripten": {
@@ -11347,6 +7458,17 @@
             "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@salesforce/cli/node_modules/@types/shelljs": {
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.12.tgz",
+            "integrity": "sha512-ZA8U81/gldY+rR5zl/7HSHrG2KDfEb3lzG6uCUDhW1DTQE9yC/VBQ45fXnXq8f3CgInfhZmjtdu/WOUlrXRQUg==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/glob": "~7.2.0",
+                "@types/node": "*"
+            }
         },
         "node_modules/@salesforce/cli/node_modules/@types/shimmer": {
             "version": "1.0.2",
@@ -11631,9 +7753,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-            "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "extraneous": true,
             "license": "Apache-2.0",
             "engines": {
@@ -11688,6 +7810,16 @@
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/acorn-import-assertions": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+            "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": "^8"
             }
         },
         "node_modules/@salesforce/cli/node_modules/acorn-jsx": {
@@ -11826,15 +7958,13 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true,
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=8"
             }
         },
         "node_modules/@salesforce/cli/node_modules/ansi-styles": {
@@ -11888,25 +8018,25 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/applicationinsights": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.7.0.tgz",
-            "integrity": "sha512-/vV5X6M4TlRA5NxNZAdCE0gukzfK24mb3z18D5Kl/CyIfSVIkafsIji3mK+Zi5q+7dn6H1CkFazlcnLf40anHw==",
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.7.3.tgz",
+            "integrity": "sha512-JY8+kTEkjbA+kAVNWDtpfW2lqsrDALfDXuxOs74KLPu2y13fy/9WB52V4LfYVTVcW1/jYOXjTxNS2gPZIDh1iw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@azure/core-auth": "^1.4.0",
+                "@azure/core-auth": "^1.5.0",
                 "@azure/core-rest-pipeline": "1.10.1",
                 "@azure/core-util": "1.2.0",
-                "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.3",
+                "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.5",
                 "@microsoft/applicationinsights-web-snippet": "^1.0.1",
-                "@opentelemetry/api": "^1.0.4",
-                "@opentelemetry/core": "^1.12.0",
-                "@opentelemetry/sdk-trace-base": "^1.12.0",
-                "@opentelemetry/semantic-conventions": "^1.12.0",
+                "@opentelemetry/api": "^1.4.1",
+                "@opentelemetry/core": "^1.15.2",
+                "@opentelemetry/sdk-trace-base": "^1.15.2",
+                "@opentelemetry/semantic-conventions": "^1.15.2",
                 "cls-hooked": "^4.2.2",
                 "continuation-local-storage": "^3.2.1",
-                "diagnostic-channel": "1.1.0",
-                "diagnostic-channel-publishers": "1.0.6"
+                "diagnostic-channel": "1.1.1",
+                "diagnostic-channel-publishers": "1.0.7"
             },
             "engines": {
                 "node": ">=8.0.0"
@@ -11918,6 +8048,20 @@
                 "applicationinsights-native-metrics": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/applicationinsights/node_modules/@azure/core-util": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.2.0.tgz",
+            "integrity": "sha512-ffGIw+Qs8bNKNLxz5UPkz4/VBM/EZY07mPve1ZYFqYUdPwFqRj0RPk0U7LZMOfT7GCck9YjuT1Rfp1PApNl1ng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^1.0.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/aproba": {
@@ -12126,6 +8270,26 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/array.prototype.findlastindex": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.2.tgz",
+            "integrity": "sha512-tb5thFFlUcp7NdNF6/MpDk/1r/4awWG1FIz3YqDf+/zJSTezBb+/5WViH41obXULHVpDzoiCLpJ/ZO9YbJMsdw==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4",
+                "es-shim-unscopables": "^1.0.0",
+                "get-intrinsic": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/array.prototype.flat": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
@@ -12156,6 +8320,27 @@
                 "define-properties": "^1.1.4",
                 "es-abstract": "^1.20.4",
                 "es-shim-unscopables": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/arraybuffer.prototype.slice": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz",
+            "integrity": "sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-buffer-byte-length": "^1.0.0",
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "get-intrinsic": "^1.2.1",
+                "is-array-buffer": "^3.0.2",
+                "is-shared-array-buffer": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -12249,9 +8434,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/async-listener/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -12264,6 +8449,26 @@
             "integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@salesforce/cli/node_modules/async-retry": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+            "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "retry": "0.13.1"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/async-retry/node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "extraneous": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
         },
         "node_modules/@salesforce/cli/node_modules/asynckit": {
             "version": "0.4.0",
@@ -12282,6 +8487,16 @@
                 "node": ">= 4.0.0"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/atomic-sleep": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+            "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/available-typed-arrays": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -12296,9 +8511,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/aws-sdk": {
-            "version": "2.1420.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1420.0.tgz",
-            "integrity": "sha512-BvGzkKGgOXNj9WAeazvOLu48sCbU52mKLGIY5AjBKX4EuY8APcKKvl1R54kdUoJDnMwv0HwQpGvrVvLTDdOv/A==",
+            "version": "2.1455.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1455.0.tgz",
+            "integrity": "sha512-OCH3YcWZ1mqePNRcOxvnB4F270++X44K+/cKA7op2HYRKjTkIJjFVqJGVdMDPQAHlc0GTCKYD6CJOUEhR2pp7w==",
             "extraneous": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -12409,48 +8624,6 @@
             "license": "Unlicense",
             "engines": {
                 "node": ">=0.6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/bin-links": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-3.0.3.tgz",
-            "integrity": "sha512-zKdnMPWEdh4F5INR07/eBrodC7QrF5JKvqskjz/ZZRXg5YSAZIbn8zGhbhUrElzHBZ2fvEQdOU59RHcTG3GiwA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "cmd-shim": "^5.0.0",
-                "mkdirp-infer-owner": "^2.0.0",
-                "npm-normalize-package-bin": "^2.0.0",
-                "read-cmd-shim": "^3.0.0",
-                "rimraf": "^3.0.0",
-                "write-file-atomic": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-2.0.0.tgz",
-            "integrity": "sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/bin-links/node_modules/write-file-atomic": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-            "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.7"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/binary": {
@@ -12607,8 +8780,10 @@
             "version": "4.9.2",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
             "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4",
@@ -12648,13 +8823,6 @@
             "engines": {
                 "node": ">=0.10"
             }
-        },
-        "node_modules/@salesforce/cli/node_modules/buffer/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "extraneous": true,
-            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/buffers": {
             "version": "0.1.1",
@@ -12698,14 +8866,130 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/bytes": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "extraneous": true,
-            "license": "MIT",
+        "node_modules/@salesforce/cli/node_modules/cacache": {
+            "version": "17.1.4",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.4.tgz",
+            "integrity": "sha512-/aJwG2l3ZMJ1xNAnqbMpA40of9dj/pIH3QfiuQSqjfPJF747VR0J/bHn+/KdNnHKc6XQcWt/AfRSBft82W1d2A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/fs": "^3.1.0",
+                "fs-minipass": "^3.0.0",
+                "glob": "^10.2.2",
+                "lru-cache": "^7.7.1",
+                "minipass": "^7.0.3",
+                "minipass-collect": "^1.0.2",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "p-map": "^4.0.0",
+                "ssri": "^10.0.0",
+                "tar": "^6.1.11",
+                "unique-filename": "^3.0.0"
+            },
             "engines": {
-                "node": ">= 0.8"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/cacache/node_modules/foreground-child": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+            "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/cacache/node_modules/fs-minipass": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.2.tgz",
+            "integrity": "sha512-2GAfyfoaCDRrM6jaOS3UsBts8yJ55VioXdWcOL7dK9zdAuKT71+WBA4ifnNYqVjYv+4SsPxjK0JT4yIIn4cA/g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^5.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/cacache/node_modules/fs-minipass/node_modules/minipass": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/cacache/node_modules/glob": {
+            "version": "10.3.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+            "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^2.0.3",
+                "minimatch": "^9.0.1",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+                "path-scurry": "^1.10.1"
+            },
+            "bin": {
+                "glob": "dist/cjs/src/bin.js"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/cacache/node_modules/minimatch": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/cacache/node_modules/minipass": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+            "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/cacache/node_modules/signal-exit": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+            "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@salesforce/cli/node_modules/cacheable-lookup": {
@@ -12887,9 +9171,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/chai": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
-            "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+            "version": "4.3.8",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.8.tgz",
+            "integrity": "sha512-vX4YvVVtxlfSZ2VecZgFUTU5qPCYsobVI2O9FmwEXBhDigYGQA6jRXCycIs1yJnnWbZ6/+a2zNIF5DfVCcJBFQ==",
             "extraneous": true,
             "license": "MIT",
             "dependencies": {
@@ -13026,6 +9310,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/cjs-module-lexer": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+            "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@salesforce/cli/node_modules/clean-git-ref": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
@@ -13070,16 +9361,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/cli-boxes": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-            "integrity": "sha512-3Fo5wu8Ytle8q9iCzS4D2MWVL2X7JVWRiS1BnXbTFDhS9c/REkM9vd1AmabsoZoY5/dGi5TT9iKL8Kb6DeBRQg==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/cli-cursor": {
@@ -13287,13 +9568,6 @@
                 "readable-stream": "^2.3.5"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/cloneable-readable/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@salesforce/cli/node_modules/cloneable-readable/node_modules/readable-stream": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -13343,36 +9617,13 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/cls-hooked/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/cmd-shim": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-5.0.0.tgz",
-            "integrity": "sha512-qkCtZ59BidfEwHltnJwkyVZn+XQojdAySM1D1gSeh11Z4pW1Kpolkyo53L5noc0nrxmIvyFwTmJRo4xs7FFLPw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "mkdirp-infer-owner": "^2.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/color-convert": {
@@ -13404,6 +9655,13 @@
             "bin": {
                 "color-support": "bin.js"
             }
+        },
+        "node_modules/@salesforce/cli/node_modules/colorette": {
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/colors": {
             "version": "1.0.3",
@@ -13946,9 +10204,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/conventional-changelog-writer/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "extraneous": true,
             "license": "ISC",
             "bin": {
@@ -14502,33 +10760,23 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/diagnostic-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz",
-            "integrity": "sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
+            "integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "semver": "^5.3.0"
+                "semver": "^7.5.3"
             }
         },
         "node_modules/@salesforce/cli/node_modules/diagnostic-channel-publishers": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.6.tgz",
-            "integrity": "sha512-RE5AP4JmEm/CV06gOyFdgWWm3gMNOoXulod2mq4ysiz9s77ZhHb1P1DGrfePHjNOmgvWglhegmj5q8DNtjRrEg==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.7.tgz",
+            "integrity": "sha512-SEECbY5AiVt6DfLkhkaHNeshg1CogdLLANA8xlG/TKvS+XUgvIKl7VspJGYiEdL5OUyzMVnr7o0AwB7f+/Mjtg==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "diagnostic-channel": "*"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/diagnostic-channel/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver"
             }
         },
         "node_modules/@salesforce/cli/node_modules/diff": {
@@ -14685,13 +10933,6 @@
             "dependencies": {
                 "readable-stream": "^2.0.2"
             }
-        },
-        "node_modules/@salesforce/cli/node_modules/duplexer2/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/duplexer2/node_modules/readable-stream": {
             "version": "2.3.8",
@@ -14875,19 +11116,20 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/es-abstract": {
-            "version": "1.21.2",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
-            "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
+            "version": "1.22.1",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
+            "integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
             "extraneous": true,
             "license": "MIT",
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.0",
+                "arraybuffer.prototype.slice": "^1.0.1",
                 "available-typed-arrays": "^1.0.5",
                 "call-bind": "^1.0.2",
                 "es-set-tostringtag": "^2.0.1",
                 "es-to-primitive": "^1.2.1",
                 "function.prototype.name": "^1.1.5",
-                "get-intrinsic": "^1.2.0",
+                "get-intrinsic": "^1.2.1",
                 "get-symbol-description": "^1.0.0",
                 "globalthis": "^1.0.3",
                 "gopd": "^1.0.1",
@@ -14907,14 +11149,18 @@
                 "object-inspect": "^1.12.3",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.4.3",
+                "regexp.prototype.flags": "^1.5.0",
+                "safe-array-concat": "^1.0.0",
                 "safe-regex-test": "^1.0.0",
                 "string.prototype.trim": "^1.2.7",
                 "string.prototype.trimend": "^1.0.6",
                 "string.prototype.trimstart": "^1.0.6",
+                "typed-array-buffer": "^1.0.0",
+                "typed-array-byte-length": "^1.0.0",
+                "typed-array-byte-offset": "^1.0.0",
                 "typed-array-length": "^1.0.4",
                 "unbox-primitive": "^1.0.2",
-                "which-typed-array": "^1.1.9"
+                "which-typed-array": "^1.1.10"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -15019,28 +11265,28 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/eslint": {
-            "version": "8.45.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
-            "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
+            "integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
             "extraneous": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.4.0",
-                "@eslint/eslintrc": "^2.1.0",
-                "@eslint/js": "8.44.0",
-                "@humanwhocodes/config-array": "^0.11.10",
+                "@eslint-community/regexpp": "^4.6.1",
+                "@eslint/eslintrc": "^2.1.2",
+                "@eslint/js": "8.49.0",
+                "@humanwhocodes/config-array": "^0.11.11",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
-                "ajv": "^6.10.0",
+                "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.2.0",
-                "eslint-visitor-keys": "^3.4.1",
-                "espree": "^9.6.0",
+                "eslint-scope": "^7.2.2",
+                "eslint-visitor-keys": "^3.4.3",
+                "espree": "^9.6.1",
                 "esquery": "^1.4.2",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -15303,9 +11549,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/eslint-config-oclif-typescript/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "extraneous": true,
             "license": "ISC",
             "bin": {
@@ -15404,9 +11650,9 @@
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/eslint-config-prettier": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-            "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+            "version": "8.10.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+            "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
             "extraneous": true,
             "license": "MIT",
             "bin": {
@@ -15567,27 +11813,29 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/eslint-plugin-import": {
-            "version": "2.27.5",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
-            "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
+            "version": "2.28.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
+            "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
             "extraneous": true,
             "license": "MIT",
             "dependencies": {
                 "array-includes": "^3.1.6",
+                "array.prototype.findlastindex": "^1.2.2",
                 "array.prototype.flat": "^1.3.1",
                 "array.prototype.flatmap": "^1.3.1",
                 "debug": "^3.2.7",
                 "doctrine": "^2.1.0",
                 "eslint-import-resolver-node": "^0.3.7",
-                "eslint-module-utils": "^2.7.4",
+                "eslint-module-utils": "^2.8.0",
                 "has": "^1.0.3",
-                "is-core-module": "^2.11.0",
+                "is-core-module": "^2.13.0",
                 "is-glob": "^4.0.3",
                 "minimatch": "^3.1.2",
+                "object.fromentries": "^2.0.6",
+                "object.groupby": "^1.0.0",
                 "object.values": "^1.1.6",
-                "resolve": "^1.22.1",
-                "semver": "^6.3.0",
-                "tsconfig-paths": "^3.14.1"
+                "semver": "^6.3.1",
+                "tsconfig-paths": "^3.14.2"
             },
             "engines": {
                 "node": ">=4"
@@ -15607,9 +11855,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/eslint-plugin-import/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "extraneous": true,
             "license": "ISC",
             "bin": {
@@ -15617,20 +11865,20 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/eslint-plugin-jsdoc": {
-            "version": "46.4.4",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.4.4.tgz",
-            "integrity": "sha512-D8TGPOkq3bnzmYmA7Q6jdsW+Slx7CunhJk1tlouVq6wJjlP1p6eigZPvxFn7aufud/D66xBsNVMhkDQEuqumMg==",
+            "version": "46.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.6.0.tgz",
+            "integrity": "sha512-T/1gzsvnX45qABzyPEonEhFDttkTn7Igm/X89TXIkTLBOsNl2GYtyBqQPZGXZZ8J5VBzEhiCMvI2P2kXX4dnFw==",
             "extraneous": true,
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@es-joy/jsdoccomment": "~0.39.4",
+                "@es-joy/jsdoccomment": "~0.40.1",
                 "are-docs-informative": "^0.0.2",
-                "comment-parser": "1.3.1",
+                "comment-parser": "1.4.0",
                 "debug": "^4.3.4",
                 "escape-string-regexp": "^4.0.0",
                 "esquery": "^1.5.0",
                 "is-builtin-module": "^3.2.1",
-                "semver": "^7.5.1",
+                "semver": "^7.5.4",
                 "spdx-expression-parse": "^3.0.1"
             },
             "engines": {
@@ -15641,9 +11889,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/eslint-plugin-jsdoc/node_modules/comment-parser": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-            "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.0.tgz",
+            "integrity": "sha512-QLyTNiZ2KDOibvFPlZ6ZngVsZ/0gYnE6uTXi5aoDg8ed3AkJAz4sEje3Y8a29hQ1s6A99MZXe47fLAXQ1rTqaw==",
             "extraneous": true,
             "license": "MIT",
             "engines": {
@@ -15708,9 +11956,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/eslint-plugin-node/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "extraneous": true,
             "license": "ISC",
             "bin": {
@@ -15884,9 +12132,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/eslint/node_modules/eslint-scope": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-            "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "extraneous": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -15901,9 +12149,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/eslint/node_modules/eslint-visitor-keys": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-            "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "extraneous": true,
             "license": "Apache-2.0",
             "engines": {
@@ -15914,9 +12162,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/eslint/node_modules/espree": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-            "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "extraneous": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -16152,8 +12400,10 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
             "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.4.x"
             }
@@ -16227,6 +12477,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/fast-copy": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+            "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@salesforce/cli/node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -16235,9 +12492,9 @@
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/fast-glob": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-            "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+            "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16268,10 +12525,27 @@
                 "fastest-levenshtein": "^1.0.7"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/fast-redact": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
+            "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@salesforce/cli/node_modules/fast-xml-parser": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.6.tgz",
-            "integrity": "sha512-Xo1qV++h/Y3Ng8dphjahnYe+rGHaaNdsYOBWL9Y9GCPKpNKilJtilvWkLcI9f9X2DoKTLsZsGYAls5+JL5jfLA==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.7.tgz",
+            "integrity": "sha512-J8r6BriSLO1uj2miOk1NW0YVm8AGOOu3Si2HQp/cSmo6EA4m3fcwu2WKjJ4RK9wMLBtg69y1kS8baDiQBR41Ig==",
             "dev": true,
             "funding": [
                 {
@@ -16379,16 +12653,6 @@
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/file-uri-to-path": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
-            "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/@salesforce/cli/node_modules/filelist": {
@@ -16503,13 +12767,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/first-chunk-stream/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@salesforce/cli/node_modules/first-chunk-stream/node_modules/readable-stream": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -16609,8 +12866,10 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
             "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
-            "extraneous": true,
+            "dev": true,
             "license": "ISC",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "cross-spawn": "^7.0.0",
                 "signal-exit": "^3.0.2"
@@ -16675,16 +12934,6 @@
             },
             "engines": {
                 "node": ">=6 <7 || >=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/fs-extra/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "dev": true,
-            "license": "MIT",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
             }
         },
         "node_modules/@salesforce/cli/node_modules/fs-extra/node_modules/universalify": {
@@ -16759,39 +13008,6 @@
                 "rimraf": "bin.js"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/ftp": {
-            "version": "0.3.10",
-            "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
-            "integrity": "sha512-faFVML1aBx2UoDStmLwv2Wptt4vw5x03xxX172nhA5Y5HBshW5JweqQ2W4xL4dezQTG8inJsuYcpPHHU3X5OTQ==",
-            "extraneous": true,
-            "dependencies": {
-                "readable-stream": "1.1.x",
-                "xregexp": "2.0.0"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/ftp/node_modules/readable-stream": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-            "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/ftp/node_modules/string_decoder": {
-            "version": "0.10.31",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-            "extraneous": true,
-            "license": "MIT"
-        },
         "node_modules/@salesforce/cli/node_modules/function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -16843,26 +13059,6 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/gauge": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-            "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "aproba": "^1.0.3 || ^2.0.0",
-                "color-support": "^1.1.3",
-                "console-control-strings": "^1.1.0",
-                "has-unicode": "^2.0.1",
-                "signal-exit": "^3.0.7",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1",
-                "wide-align": "^1.1.5"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/gensync": {
@@ -16953,13 +13149,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/get-pkg-repo/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "extraneous": true,
-            "license": "MIT"
-        },
         "node_modules/@salesforce/cli/node_modules/get-pkg-repo/node_modules/lru-cache": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -17015,16 +13204,6 @@
             "dependencies": {
                 "readable-stream": "~2.3.6",
                 "xtend": "~4.0.1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/get-stdin": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha512-F5aQMywwJ2n85s4hJPTT9RPxGmubonuB10MNYo17/xph174n2MIR33HRguhzVag10O/npM7SPk73LMZNP+FaWw==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/get-stream": {
@@ -17138,9 +13317,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/git-semver-tags/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "extraneous": true,
             "license": "ISC",
             "bin": {
@@ -17367,14 +13546,14 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/handlebars": {
-            "version": "4.7.7",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-            "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+            "version": "4.7.8",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
             "extraneous": true,
             "license": "MIT",
             "dependencies": {
                 "minimist": "^1.2.5",
-                "neo-async": "^2.6.0",
+                "neo-async": "^2.6.2",
                 "source-map": "^0.6.1",
                 "wordwrap": "^1.0.0"
             },
@@ -17409,19 +13588,6 @@
             },
             "engines": {
                 "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/has-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/has-bigints": {
@@ -17554,6 +13720,63 @@
                 "tslib": "^2.0.3"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/help-me": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
+            "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "glob": "^8.0.0",
+                "readable-stream": "^3.6.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/help-me/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/help-me/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/hosted-git-info": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
+            "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^7.5.1"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -17600,23 +13823,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/http-errors": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "depd": "2.0.0",
-                "inherits": "2.0.4",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "toidentifier": "1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/http-parser-js": {
             "version": "0.5.8",
             "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
@@ -17625,15 +13831,13 @@
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/http-proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true,
             "dependencies": {
-                "@tootallnate/once": "1",
+                "@tootallnate/once": "2",
                 "agent-base": "6",
                 "debug": "4"
             },
@@ -17823,12 +14027,15 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/import-in-the-middle": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.5.tgz",
-            "integrity": "sha512-yzHlBqi1EBFrkieAnSt8eTgO5oLSl+YJ7qaOpUH/PMqQOMZoQ/RmDlwnTLQrwYto+gHYjRG+i/IbsB1eDx32NQ==",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+            "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
+                "acorn": "^8.8.2",
+                "acorn-import-assertions": "^1.9.0",
+                "cjs-module-lexer": "^1.2.2",
                 "module-details-from-path": "^1.0.3"
             }
         },
@@ -17897,9 +14104,9 @@
             "peer": true
         },
         "node_modules/@salesforce/cli/node_modules/inquirer": {
-            "version": "8.2.5",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
-            "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+            "version": "8.2.6",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+            "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17917,7 +14124,7 @@
                 "string-width": "^4.1.0",
                 "strip-ansi": "^6.0.0",
                 "through": "^2.3.6",
-                "wrap-ansi": "^7.0.0"
+                "wrap-ansi": "^6.0.1"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -17949,9 +14156,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/ip": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-            "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -18067,9 +14274,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/is-core-module": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-            "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+            "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -18453,10 +14660,10 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/isarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-            "extraneous": true,
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/isbinaryfile": {
@@ -18545,9 +14752,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "extraneous": true,
             "license": "ISC",
             "bin": {
@@ -18586,18 +14793,34 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/istanbul-lib-report": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-            "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "istanbul-lib-coverage": "^3.0.0",
-                "make-dir": "^3.0.0",
+                "make-dir": "^4.0.0",
                 "supports-color": "^7.1.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/istanbul-lib-report/node_modules/make-dir": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@salesforce/cli/node_modules/istanbul-lib-source-maps": {
@@ -18616,9 +14839,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/istanbul-reports": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
-            "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+            "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -18675,6 +14898,16 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/joycon": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+            "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/@salesforce/cli/node_modules/js-tokens": {
@@ -18868,11 +15101,14 @@
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/json-parse-even-better-errors": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
+            "integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
         },
         "node_modules/@salesforce/cli/node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -18926,14 +15162,11 @@
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -18966,16 +15199,22 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/jsonwebtoken": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
-            "integrity": "sha512-K8wx7eJ5TPvEjuiVSkv167EVboBDv9PZdDoF7BgeQnBLVvZWW9clr2PsQHVJDTKaEIH5JBIwHujGcHp7GgI2eg==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+            "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "jws": "^3.2.2",
-                "lodash": "^4.17.21",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
                 "ms": "^2.1.1",
-                "semver": "^7.3.8"
+                "semver": "^7.5.4"
             },
             "engines": {
                 "node": ">=12",
@@ -18994,13 +15233,6 @@
                 "readable-stream": "~2.3.6",
                 "setimmediate": "^1.0.5"
             }
-        },
-        "node_modules/@salesforce/cli/node_modules/jszip/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/jszip/node_modules/readable-stream": {
             "version": "2.3.8",
@@ -19166,29 +15398,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/levn/node_modules/prelude-ls": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/levn/node_modules/type-check": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "prelude-ls": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/lie": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -19289,6 +15498,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@salesforce/cli/node_modules/lodash._reinterpolate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@salesforce/cli/node_modules/lodash.camelcase": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -19331,11 +15547,32 @@
             "extraneous": true,
             "license": "MIT"
         },
+        "node_modules/@salesforce/cli/node_modules/lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@salesforce/cli/node_modules/lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@salesforce/cli/node_modules/lodash.isfunction": {
             "version": "3.0.9",
             "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
             "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
             "extraneous": true,
+            "license": "MIT"
+        },
+        "node_modules/@salesforce/cli/node_modules/lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/lodash.ismatch": {
@@ -19345,10 +15582,24 @@
             "extraneous": true,
             "license": "MIT"
         },
+        "node_modules/@salesforce/cli/node_modules/lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@salesforce/cli/node_modules/lodash.isplainobject": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
             "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@salesforce/cli/node_modules/lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
             "dev": true,
             "license": "MIT"
         },
@@ -19373,6 +15624,13 @@
             "extraneous": true,
             "license": "MIT"
         },
+        "node_modules/@salesforce/cli/node_modules/lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@salesforce/cli/node_modules/lodash.snakecase": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
@@ -19386,6 +15644,27 @@
             "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
             "extraneous": true,
             "license": "MIT"
+        },
+        "node_modules/@salesforce/cli/node_modules/lodash.template": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+            "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.templatesettings": "^4.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/lodash.templatesettings": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+            "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash._reinterpolate": "^3.0.0"
+            }
         },
         "node_modules/@salesforce/cli/node_modules/lodash.throttle": {
             "version": "4.1.1",
@@ -19517,7 +15796,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
             "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "dev": true,
+            "extraneous": true,
             "license": "MIT",
             "dependencies": {
                 "semver": "^6.0.0"
@@ -19530,10 +15809,10 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/make-dir/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "extraneous": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -19573,147 +15852,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/@npmcli/fs": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
-            "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/cacache": {
-            "version": "17.1.3",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.3.tgz",
-            "integrity": "sha512-jAdjGxmPxZh0IipMdR7fK/4sDSrHMLUV0+GvVUsjwyGNKHsh79kW/otg+GkbXwl6Uzvy9wsvHOX4nUoWldeZMg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/fs": "^3.1.0",
-                "fs-minipass": "^3.0.0",
-                "glob": "^10.2.2",
-                "lru-cache": "^7.7.1",
-                "minipass": "^5.0.0",
-                "minipass-collect": "^1.0.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "p-map": "^4.0.0",
-                "ssri": "^10.0.0",
-                "tar": "^6.1.11",
-                "unique-filename": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/foreground-child": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-            "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "cross-spawn": "^7.0.0",
-                "signal-exit": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/fs-minipass": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.2.tgz",
-            "integrity": "sha512-2GAfyfoaCDRrM6jaOS3UsBts8yJ55VioXdWcOL7dK9zdAuKT71+WBA4ifnNYqVjYv+4SsPxjK0JT4yIIn4cA/g==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^5.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/glob": {
-            "version": "10.3.1",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.1.tgz",
-            "integrity": "sha512-9BKYcEeIs7QwlCYs+Y3GBvqAMISufUS0i2ELd11zpZjxI5V9iyRj0HgzB5/cLf2NY4vcYBTYzJ7GIui7j/4DOw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^2.0.3",
-                "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2",
-                "path-scurry": "^1.10.0"
-            },
-            "bin": {
-                "glob": "dist/cjs/src/bin.js"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/glob/node_modules/minipass": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-            "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/minipass": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
@@ -19740,60 +15878,6 @@
             },
             "optionalDependencies": {
                 "encoding": "^0.1.13"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/signal-exit": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-            "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/socks-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^6.0.2",
-                "debug": "^4.3.3",
-                "socks": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/unique-filename": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-            "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "unique-slug": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/make-fetch-happen/node_modules/unique-slug": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-            "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "imurmurhash": "^0.1.4"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/map-obj": {
@@ -20912,6 +16996,72 @@
                 "node": "^12.13 || ^14.13 || >=16"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/node-gyp/node_modules/are-we-there-yet": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+            "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/node-gyp/node_modules/gauge": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+            "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^1.0.3 || ^2.0.0",
+                "color-support": "^1.1.3",
+                "console-control-strings": "^1.1.0",
+                "has-unicode": "^2.0.1",
+                "signal-exit": "^3.0.7",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
+                "wide-align": "^1.1.5"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/node-gyp/node_modules/nopt": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+            "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^1.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/node-gyp/node_modules/npmlog": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+            "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "are-we-there-yet": "^3.0.0",
+                "console-control-strings": "^1.1.0",
+                "gauge": "^4.0.3",
+                "set-blocking": "^2.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/node-preload": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -20931,22 +17081,6 @@
             "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
             "extraneous": true,
             "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/nopt": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
-            "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "^1.0.0"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
         },
         "node_modules/@salesforce/cli/node_modules/normalize-package-data": {
             "version": "3.0.3",
@@ -21020,15 +17154,13 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm": {
-            "version": "8.19.4",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
-            "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
+            "version": "9.6.7",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-9.6.7.tgz",
+            "integrity": "sha512-xwkU1hSZl6Qrkfw3fhxVmMfNWu0A67+aZZs5gz/LoehCeAPkVhQDB90Z2NFoPSI1KpfBWCJ6Bp28wXzv5U5/2g==",
             "bundleDependencies": [
                 "@isaacs/string-locale-compare",
                 "@npmcli/arborist",
-                "@npmcli/ci-detect",
                 "@npmcli/config",
-                "@npmcli/fs",
                 "@npmcli/map-workspaces",
                 "@npmcli/package-json",
                 "@npmcli/run-script",
@@ -21036,7 +17168,7 @@
                 "archy",
                 "cacache",
                 "chalk",
-                "chownr",
+                "ci-info",
                 "cli-columns",
                 "cli-table3",
                 "columnify",
@@ -21064,8 +17196,6 @@
                 "minimatch",
                 "minipass",
                 "minipass-pipeline",
-                "mkdirp",
-                "mkdirp-infer-owner",
                 "ms",
                 "node-gyp",
                 "nopt",
@@ -21077,7 +17207,6 @@
                 "npm-registry-fetch",
                 "npm-user-validate",
                 "npmlog",
-                "opener",
                 "p-map",
                 "pacote",
                 "parse-conflict-json",
@@ -21086,8 +17215,6 @@
                 "read",
                 "read-package-json",
                 "read-package-json-fast",
-                "readdir-scoped-modules",
-                "rimraf",
                 "semver",
                 "ssri",
                 "tar",
@@ -21103,89 +17230,83 @@
             "workspaces": [
                 "docs",
                 "smoke-tests",
+                "mock-registry",
                 "workspaces/*"
             ],
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^5.6.3",
-                "@npmcli/ci-detect": "^2.0.0",
-                "@npmcli/config": "^4.2.1",
-                "@npmcli/fs": "^2.1.0",
-                "@npmcli/map-workspaces": "^2.0.3",
-                "@npmcli/package-json": "^2.0.0",
-                "@npmcli/run-script": "^4.2.1",
-                "abbrev": "~1.1.1",
+                "@npmcli/arborist": "^6.2.9",
+                "@npmcli/config": "^6.1.7",
+                "@npmcli/map-workspaces": "^3.0.4",
+                "@npmcli/package-json": "^3.1.0",
+                "@npmcli/run-script": "^6.0.2",
+                "abbrev": "^2.0.0",
                 "archy": "~1.0.0",
-                "cacache": "^16.1.3",
+                "cacache": "^17.1.2",
                 "chalk": "^4.1.2",
-                "chownr": "^2.0.0",
+                "ci-info": "^3.8.0",
                 "cli-columns": "^4.0.0",
-                "cli-table3": "^0.6.2",
+                "cli-table3": "^0.6.3",
                 "columnify": "^1.6.0",
-                "fastest-levenshtein": "^1.0.12",
-                "fs-minipass": "^2.1.0",
-                "glob": "^8.0.1",
-                "graceful-fs": "^4.2.10",
-                "hosted-git-info": "^5.2.1",
-                "ini": "^3.0.1",
-                "init-package-json": "^3.0.2",
+                "fastest-levenshtein": "^1.0.16",
+                "fs-minipass": "^3.0.2",
+                "glob": "^10.2.4",
+                "graceful-fs": "^4.2.11",
+                "hosted-git-info": "^6.1.1",
+                "ini": "^4.1.0",
+                "init-package-json": "^5.0.0",
                 "is-cidr": "^4.0.2",
-                "json-parse-even-better-errors": "^2.3.1",
-                "libnpmaccess": "^6.0.4",
-                "libnpmdiff": "^4.0.5",
-                "libnpmexec": "^4.0.14",
-                "libnpmfund": "^3.0.5",
-                "libnpmhook": "^8.0.4",
-                "libnpmorg": "^4.0.4",
-                "libnpmpack": "^4.1.3",
-                "libnpmpublish": "^6.0.5",
-                "libnpmsearch": "^5.0.4",
-                "libnpmteam": "^4.0.4",
-                "libnpmversion": "^3.0.7",
-                "make-fetch-happen": "^10.2.0",
-                "minimatch": "^5.1.0",
-                "minipass": "^3.1.6",
+                "json-parse-even-better-errors": "^3.0.0",
+                "libnpmaccess": "^7.0.2",
+                "libnpmdiff": "^5.0.17",
+                "libnpmexec": "^5.0.17",
+                "libnpmfund": "^4.0.17",
+                "libnpmhook": "^9.0.3",
+                "libnpmorg": "^5.0.4",
+                "libnpmpack": "^5.0.17",
+                "libnpmpublish": "^7.2.0",
+                "libnpmsearch": "^6.0.2",
+                "libnpmteam": "^5.0.3",
+                "libnpmversion": "^4.0.2",
+                "make-fetch-happen": "^11.1.1",
+                "minimatch": "^9.0.0",
+                "minipass": "^5.0.0",
                 "minipass-pipeline": "^1.2.4",
-                "mkdirp": "^1.0.4",
-                "mkdirp-infer-owner": "^2.0.0",
                 "ms": "^2.1.2",
-                "node-gyp": "^9.1.0",
-                "nopt": "^6.0.0",
-                "npm-audit-report": "^3.0.0",
-                "npm-install-checks": "^5.0.0",
-                "npm-package-arg": "^9.1.0",
-                "npm-pick-manifest": "^7.0.2",
-                "npm-profile": "^6.2.0",
-                "npm-registry-fetch": "^13.3.1",
-                "npm-user-validate": "^1.0.1",
-                "npmlog": "^6.0.2",
-                "opener": "^1.5.2",
+                "node-gyp": "^9.3.1",
+                "nopt": "^7.1.0",
+                "npm-audit-report": "^4.0.0",
+                "npm-install-checks": "^6.1.1",
+                "npm-package-arg": "^10.1.0",
+                "npm-pick-manifest": "^8.0.1",
+                "npm-profile": "^7.0.1",
+                "npm-registry-fetch": "^14.0.5",
+                "npm-user-validate": "^2.0.0",
+                "npmlog": "^7.0.1",
                 "p-map": "^4.0.0",
-                "pacote": "^13.6.2",
-                "parse-conflict-json": "^2.0.2",
-                "proc-log": "^2.0.1",
+                "pacote": "^15.1.3",
+                "parse-conflict-json": "^3.0.1",
+                "proc-log": "^3.0.0",
                 "qrcode-terminal": "^0.12.0",
-                "read": "~1.0.7",
-                "read-package-json": "^5.0.2",
-                "read-package-json-fast": "^2.0.3",
-                "readdir-scoped-modules": "^1.1.0",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.7",
-                "ssri": "^9.0.1",
-                "tar": "^6.1.11",
+                "read": "^2.1.0",
+                "read-package-json": "^6.0.3",
+                "read-package-json-fast": "^3.0.2",
+                "semver": "^7.5.1",
+                "ssri": "^10.0.4",
+                "tar": "^6.1.14",
                 "text-table": "~0.2.0",
                 "tiny-relative-date": "^1.3.0",
-                "treeverse": "^2.0.0",
-                "validate-npm-package-name": "^4.0.0",
-                "which": "^2.0.2",
-                "write-file-atomic": "^4.0.1"
+                "treeverse": "^3.0.0",
+                "validate-npm-package-name": "^5.0.0",
+                "which": "^3.0.1",
+                "write-file-atomic": "^5.0.1"
             },
             "bin": {
                 "npm": "bin/npm-cli.js",
                 "npx": "bin/npx-cli.js"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm-bundled": {
@@ -21205,12 +17326,41 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/@salesforce/cli/node_modules/npm-install-checks": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.1.1.tgz",
+            "integrity": "sha512-dH3GmQL4vsPtld59cOn8uY0iOqRmqKvV+DLGwNXV/Q7MDgD2QfOADWd/mFXcIE5LVhYYGjA3baz6W9JneqnuCw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "semver": "^7.1.1"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/npm-normalize-package-bin": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
             "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
             "dev": true,
             "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm-package-arg": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-10.1.0.tgz",
+            "integrity": "sha512-uFyyCEmgBfZTtrKk/5xDfHp6+MdrqGotX/VoOyEEl3mBwiEE5FlBaePanazJSVMPT7vKepcjYBY2ztg9A3yPIA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "hosted-git-info": "^6.0.0",
+                "proc-log": "^3.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-name": "^5.0.0"
+            },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
@@ -21226,6 +17376,69 @@
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm-pick-manifest": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-8.0.1.tgz",
+            "integrity": "sha512-mRtvlBjTsJvfCCdmPtiu2bdlx8d/KXtF7yNXNWe7G0Z36qWA9Ny5zXsI2PfBZEv7SXgoxTmNaTzGSbbzDZChoA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-install-checks": "^6.0.0",
+                "npm-normalize-package-bin": "^3.0.0",
+                "npm-package-arg": "^10.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm-registry-fetch": {
+            "version": "14.0.5",
+            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-14.0.5.tgz",
+            "integrity": "sha512-kIDMIo4aBm6xg7jOttupWZamsZRkAqMqwqqbVXnUqstY5+tapvv6bkH/qMR76jdgV+YljEUCyWx3hRYMrJiAgA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "make-fetch-happen": "^11.0.0",
+                "minipass": "^5.0.0",
+                "minipass-fetch": "^3.0.0",
+                "minipass-json-stream": "^1.0.1",
+                "minizlib": "^2.1.2",
+                "npm-package-arg": "^10.0.0",
+                "proc-log": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm-registry-fetch/node_modules/minipass": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm-registry-fetch/node_modules/minipass-fetch": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.3.tgz",
+            "integrity": "sha512-n5ITsTkDqYkYJZjcRWzZt9qnZKCT7nKCosJhHoj7S7zD+BP4jVbWs+odsniw5TA3E0sLomhTKOKjF86wf11PuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^5.0.0",
+                "minipass-sized": "^1.0.3",
+                "minizlib": "^2.1.2"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            },
+            "optionalDependencies": {
+                "encoding": "^0.1.13"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm-run-path": {
@@ -21267,6 +17480,73 @@
             "inBundle": true,
             "license": "MIT"
         },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@isaacs/string-locale-compare": {
             "version": "1.1.0",
             "dev": true,
@@ -21274,86 +17554,72 @@
             "license": "ISC"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "5.6.3",
+            "version": "6.2.9",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/installed-package-contents": "^1.0.7",
-                "@npmcli/map-workspaces": "^2.0.3",
-                "@npmcli/metavuln-calculator": "^3.0.1",
-                "@npmcli/move-file": "^2.0.0",
-                "@npmcli/name-from-folder": "^1.0.1",
-                "@npmcli/node-gyp": "^2.0.0",
-                "@npmcli/package-json": "^2.0.0",
-                "@npmcli/query": "^1.2.0",
-                "@npmcli/run-script": "^4.1.3",
-                "bin-links": "^3.0.3",
-                "cacache": "^16.1.3",
+                "@npmcli/fs": "^3.1.0",
+                "@npmcli/installed-package-contents": "^2.0.2",
+                "@npmcli/map-workspaces": "^3.0.2",
+                "@npmcli/metavuln-calculator": "^5.0.0",
+                "@npmcli/name-from-folder": "^2.0.0",
+                "@npmcli/node-gyp": "^3.0.0",
+                "@npmcli/package-json": "^3.0.0",
+                "@npmcli/query": "^3.0.0",
+                "@npmcli/run-script": "^6.0.0",
+                "bin-links": "^4.0.1",
+                "cacache": "^17.0.4",
                 "common-ancestor-path": "^1.0.1",
-                "hosted-git-info": "^5.2.1",
-                "json-parse-even-better-errors": "^2.3.1",
+                "hosted-git-info": "^6.1.1",
+                "json-parse-even-better-errors": "^3.0.0",
                 "json-stringify-nice": "^1.1.4",
-                "minimatch": "^5.1.0",
-                "mkdirp": "^1.0.4",
-                "mkdirp-infer-owner": "^2.0.0",
-                "nopt": "^6.0.0",
-                "npm-install-checks": "^5.0.0",
-                "npm-package-arg": "^9.0.0",
-                "npm-pick-manifest": "^7.0.2",
-                "npm-registry-fetch": "^13.0.0",
-                "npmlog": "^6.0.2",
-                "pacote": "^13.6.1",
-                "parse-conflict-json": "^2.0.1",
-                "proc-log": "^2.0.0",
+                "minimatch": "^9.0.0",
+                "nopt": "^7.0.0",
+                "npm-install-checks": "^6.0.0",
+                "npm-package-arg": "^10.1.0",
+                "npm-pick-manifest": "^8.0.1",
+                "npm-registry-fetch": "^14.0.3",
+                "npmlog": "^7.0.1",
+                "pacote": "^15.0.8",
+                "parse-conflict-json": "^3.0.0",
+                "proc-log": "^3.0.0",
                 "promise-all-reject-late": "^1.0.0",
-                "promise-call-limit": "^1.0.1",
-                "read-package-json-fast": "^2.0.2",
-                "readdir-scoped-modules": "^1.1.0",
-                "rimraf": "^3.0.2",
+                "promise-call-limit": "^1.0.2",
+                "read-package-json-fast": "^3.0.2",
                 "semver": "^7.3.7",
-                "ssri": "^9.0.0",
-                "treeverse": "^2.0.0",
-                "walk-up-path": "^1.0.0"
+                "ssri": "^10.0.1",
+                "treeverse": "^3.0.0",
+                "walk-up-path": "^3.0.1"
             },
             "bin": {
                 "arborist": "bin/index.js"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/ci-detect": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/config": {
-            "version": "4.2.2",
+            "version": "6.1.7",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/map-workspaces": "^2.0.2",
-                "ini": "^3.0.0",
-                "mkdirp-infer-owner": "^2.0.0",
-                "nopt": "^6.0.0",
-                "proc-log": "^2.0.0",
-                "read-package-json-fast": "^2.0.3",
+                "@npmcli/map-workspaces": "^3.0.2",
+                "ini": "^4.1.0",
+                "nopt": "^7.0.0",
+                "proc-log": "^3.0.0",
+                "read-package-json-fast": "^3.0.2",
                 "semver": "^7.3.5",
-                "walk-up-path": "^1.0.0"
+                "walk-up-path": "^3.0.1"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/disparity-colors": {
-            "version": "2.0.0",
+            "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -21361,95 +17627,84 @@
                 "ansi-styles": "^4.3.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/fs": {
-            "version": "2.1.2",
+            "version": "3.1.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@gar/promisify": "^1.1.3",
                 "semver": "^7.3.5"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/git": {
-            "version": "3.0.2",
+            "version": "4.0.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/promise-spawn": "^3.0.0",
+                "@npmcli/promise-spawn": "^6.0.0",
                 "lru-cache": "^7.4.4",
-                "mkdirp": "^1.0.4",
-                "npm-pick-manifest": "^7.0.0",
-                "proc-log": "^2.0.0",
+                "npm-pick-manifest": "^8.0.0",
+                "proc-log": "^3.0.0",
                 "promise-inflight": "^1.0.1",
                 "promise-retry": "^2.0.1",
                 "semver": "^7.3.5",
-                "which": "^2.0.2"
+                "which": "^3.0.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-            "version": "1.0.7",
+            "version": "2.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "npm-bundled": "^1.1.1",
-                "npm-normalize-package-bin": "^1.0.1"
+                "npm-bundled": "^3.0.0",
+                "npm-normalize-package-bin": "^3.0.0"
             },
             "bin": {
-                "installed-package-contents": "index.js"
+                "installed-package-contents": "lib/index.js"
             },
             "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
-            "version": "1.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-normalize-package-bin": "^1.0.1"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/map-workspaces": {
-            "version": "2.0.4",
+            "version": "3.0.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/name-from-folder": "^1.0.1",
-                "glob": "^8.0.1",
-                "minimatch": "^5.0.1",
-                "read-package-json-fast": "^2.0.3"
+                "@npmcli/name-from-folder": "^2.0.0",
+                "glob": "^10.2.2",
+                "minimatch": "^9.0.0",
+                "read-package-json-fast": "^3.0.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-            "version": "3.1.1",
+            "version": "5.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "cacache": "^16.0.0",
-                "json-parse-even-better-errors": "^2.3.1",
-                "pacote": "^13.0.3",
+                "cacache": "^17.0.0",
+                "json-parse-even-better-errors": "^3.0.0",
+                "pacote": "^15.0.0",
                 "semver": "^7.3.5"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/move-file": {
@@ -21466,72 +17721,95 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/name-from-folder": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/node-gyp": {
             "version": "2.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/node-gyp": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/package-json": {
-            "version": "2.0.0",
+            "version": "3.1.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "json-parse-even-better-errors": "^2.3.1"
+                "glob": "^10.2.2",
+                "json-parse-even-better-errors": "^3.0.0",
+                "normalize-package-data": "^5.0.0",
+                "npm-normalize-package-bin": "^3.0.1"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/promise-spawn": {
+            "version": "6.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "which": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/query": {
             "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "infer-owner": "^1.0.4"
+                "postcss-selector-parser": "^6.0.10"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/query": {
-            "version": "1.2.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-package-arg": "^9.1.0",
-                "postcss-selector-parser": "^6.0.10",
-                "semver": "^7.3.7"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/run-script": {
-            "version": "4.2.1",
+            "version": "6.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/node-gyp": "^2.0.0",
-                "@npmcli/promise-spawn": "^3.0.0",
+                "@npmcli/node-gyp": "^3.0.0",
+                "@npmcli/promise-spawn": "^6.0.0",
                 "node-gyp": "^9.0.0",
-                "read-package-json-fast": "^2.0.3",
-                "which": "^2.0.2"
+                "read-package-json-fast": "^3.0.0",
+                "which": "^3.0.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+            "version": "0.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/@tootallnate/once": {
@@ -21543,11 +17821,48 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/abbrev": {
-            "version": "1.1.1",
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@tufjs/canonical-json": {
+            "version": "1.0.0",
             "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "MIT",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/@tufjs/models": {
+            "version": "1.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tufjs/canonical-json": "1.0.0",
+                "minimatch": "^9.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/abbrev": {
+            "version": "2.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/abort-controller": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
+            }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/agent-base": {
             "version": "6.0.2",
@@ -21562,13 +17877,13 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/agentkeepalive": {
-            "version": "4.2.1",
+            "version": "4.3.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.1.0",
-                "depd": "^1.1.2",
+                "depd": "^2.0.0",
                 "humanize-ms": "^1.2.1"
             },
             "engines": {
@@ -21625,23 +17940,17 @@
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/are-we-there-yet": {
-            "version": "3.0.1",
+            "version": "4.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
+                "readable-stream": "^4.1.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/asap": {
-            "version": "2.0.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/balanced-match": {
             "version": "1.0.2",
@@ -21649,30 +17958,39 @@
             "inBundle": true,
             "license": "MIT"
         },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/base64-js": {
+            "version": "1.5.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "inBundle": true,
+            "license": "MIT"
+        },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/bin-links": {
-            "version": "3.0.3",
+            "version": "4.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "cmd-shim": "^5.0.0",
-                "mkdirp-infer-owner": "^2.0.0",
-                "npm-normalize-package-bin": "^2.0.0",
-                "read-cmd-shim": "^3.0.0",
-                "rimraf": "^3.0.0",
-                "write-file-atomic": "^4.0.0"
+                "cmd-shim": "^6.0.0",
+                "npm-normalize-package-bin": "^3.0.0",
+                "read-cmd-shim": "^4.0.0",
+                "write-file-atomic": "^5.0.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/binary-extensions": {
@@ -21693,6 +18011,30 @@
                 "balanced-match": "^1.0.0"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/buffer": {
+            "version": "6.0.3",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/builtins": {
             "version": "5.0.1",
             "dev": true,
@@ -21703,32 +18045,26 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/cacache": {
-            "version": "16.1.3",
+            "version": "17.1.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/fs": "^2.1.0",
-                "@npmcli/move-file": "^2.0.0",
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.1.0",
-                "glob": "^8.0.1",
-                "infer-owner": "^1.0.4",
+                "@npmcli/fs": "^3.1.0",
+                "fs-minipass": "^3.0.0",
+                "glob": "^10.2.2",
                 "lru-cache": "^7.7.1",
-                "minipass": "^3.1.6",
+                "minipass": "^5.0.0",
                 "minipass-collect": "^1.0.2",
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
-                "mkdirp": "^1.0.4",
                 "p-map": "^4.0.0",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^3.0.2",
-                "ssri": "^9.0.0",
+                "ssri": "^10.0.0",
                 "tar": "^6.1.11",
-                "unique-filename": "^2.0.0"
+                "unique-filename": "^3.0.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/chalk": {
@@ -21754,6 +18090,21 @@
             "license": "ISC",
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/ci-info": {
+            "version": "3.8.0",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/cidr-regex": {
@@ -21791,7 +18142,7 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/cli-table3": {
-            "version": "0.6.2",
+            "version": "0.6.3",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -21815,15 +18166,12 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/cmd-shim": {
-            "version": "5.0.0",
+            "version": "6.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
-            "dependencies": {
-                "mkdirp-infer-owner": "^2.0.0"
-            },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/color-convert": {
@@ -21884,6 +18232,35 @@
             "inBundle": true,
             "license": "ISC"
         },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/cross-spawn/node_modules/which": {
+            "version": "2.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/cssesc": {
             "version": "3.0.0",
             "dev": true,
@@ -21919,22 +18296,16 @@
             "inBundle": true,
             "license": "MIT"
         },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/debuglog": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/defaults": {
-            "version": "1.0.3",
+            "version": "1.0.4",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
                 "clone": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/delegates": {
@@ -21944,22 +18315,12 @@
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/depd": {
-            "version": "1.1.2",
+            "version": "2.0.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/dezalgo": {
-            "version": "1.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
+                "node": ">= 0.8"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/diff": {
@@ -21970,6 +18331,12 @@
             "engines": {
                 "node": ">=0.3.1"
             }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -22002,22 +18369,59 @@
             "inBundle": true,
             "license": "MIT"
         },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/fastest-levenshtein": {
-            "version": "1.0.12",
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/event-target-shim": {
+            "version": "5.0.1",
             "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
         },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/fs-minipass": {
-            "version": "2.1.0",
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/events": {
+            "version": "3.3.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.x"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/fastest-levenshtein": {
+            "version": "1.0.16",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.9.1"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/foreground-child": {
+            "version": "3.1.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "minipass": "^3.0.0"
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^4.0.1"
             },
             "engines": {
-                "node": ">= 8"
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/fs-minipass": {
+            "version": "3.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^5.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/fs.realpath": {
@@ -22033,7 +18437,7 @@
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/gauge": {
-            "version": "4.0.4",
+            "version": "5.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -22042,36 +18446,39 @@
                 "color-support": "^1.1.3",
                 "console-control-strings": "^1.1.0",
                 "has-unicode": "^2.0.1",
-                "signal-exit": "^3.0.7",
+                "signal-exit": "^4.0.1",
                 "string-width": "^4.2.3",
                 "strip-ansi": "^6.0.1",
                 "wide-align": "^1.1.5"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/glob": {
-            "version": "8.0.3",
+            "version": "10.2.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^2.0.3",
+                "minimatch": "^9.0.0",
+                "minipass": "^5.0.0 || ^6.0.0",
+                "path-scurry": "^1.7.0"
+            },
+            "bin": {
+                "glob": "dist/cjs/src/bin.js"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/graceful-fs": {
-            "version": "4.2.10",
+            "version": "4.2.11",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
@@ -22104,7 +18511,7 @@
             "license": "ISC"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/hosted-git-info": {
-            "version": "5.2.1",
+            "version": "6.1.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -22112,7 +18519,7 @@
                 "lru-cache": "^7.5.1"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/http-cache-semantics": {
@@ -22170,16 +18577,36 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/ieee754": {
+            "version": "1.2.1",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "inBundle": true,
+            "license": "BSD-3-Clause"
+        },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/ignore-walk": {
-            "version": "5.0.1",
+            "version": "6.0.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "minimatch": "^5.0.1"
+                "minimatch": "^9.0.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/imurmurhash": {
@@ -22223,30 +18650,30 @@
             "license": "ISC"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/ini": {
-            "version": "3.0.1",
+            "version": "4.1.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/init-package-json": {
-            "version": "3.0.2",
+            "version": "5.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "npm-package-arg": "^9.0.1",
-                "promzard": "^0.3.0",
-                "read": "^1.0.7",
-                "read-package-json": "^5.0.0",
+                "npm-package-arg": "^10.0.0",
+                "promzard": "^1.0.0",
+                "read": "^2.0.0",
+                "read-package-json": "^6.0.0",
                 "semver": "^7.3.5",
                 "validate-npm-package-license": "^3.0.4",
-                "validate-npm-package-name": "^4.0.0"
+                "validate-npm-package-name": "^5.0.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/ip": {
@@ -22277,7 +18704,7 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/is-core-module": {
-            "version": "2.10.0",
+            "version": "2.12.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -22309,11 +18736,32 @@
             "inBundle": true,
             "license": "ISC"
         },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/json-parse-even-better-errors": {
-            "version": "2.3.1",
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/jackspeak": {
+            "version": "2.2.0",
             "dev": true,
             "inBundle": true,
-            "license": "MIT"
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/json-parse-even-better-errors": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/json-stringify-nice": {
             "version": "1.1.4",
@@ -22334,187 +18782,188 @@
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/just-diff": {
-            "version": "5.1.1",
+            "version": "6.0.2",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/just-diff-apply": {
-            "version": "5.4.1",
+            "version": "5.5.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmaccess": {
-            "version": "6.0.4",
+            "version": "7.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "aproba": "^2.0.0",
-                "minipass": "^3.1.1",
-                "npm-package-arg": "^9.0.1",
-                "npm-registry-fetch": "^13.0.0"
+                "npm-package-arg": "^10.1.0",
+                "npm-registry-fetch": "^14.0.3"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmdiff": {
-            "version": "4.0.5",
+            "version": "5.0.17",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/disparity-colors": "^2.0.0",
-                "@npmcli/installed-package-contents": "^1.0.7",
+                "@npmcli/arborist": "^6.2.9",
+                "@npmcli/disparity-colors": "^3.0.0",
+                "@npmcli/installed-package-contents": "^2.0.2",
                 "binary-extensions": "^2.2.0",
                 "diff": "^5.1.0",
-                "minimatch": "^5.0.1",
-                "npm-package-arg": "^9.0.1",
-                "pacote": "^13.6.1",
-                "tar": "^6.1.0"
+                "minimatch": "^9.0.0",
+                "npm-package-arg": "^10.1.0",
+                "pacote": "^15.0.8",
+                "tar": "^6.1.13"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmexec": {
-            "version": "4.0.14",
+            "version": "5.0.17",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^5.6.3",
-                "@npmcli/ci-detect": "^2.0.0",
-                "@npmcli/fs": "^2.1.1",
-                "@npmcli/run-script": "^4.2.0",
+                "@npmcli/arborist": "^6.2.9",
+                "@npmcli/run-script": "^6.0.0",
                 "chalk": "^4.1.0",
-                "mkdirp-infer-owner": "^2.0.0",
-                "npm-package-arg": "^9.0.1",
-                "npmlog": "^6.0.2",
-                "pacote": "^13.6.1",
-                "proc-log": "^2.0.0",
-                "read": "^1.0.7",
-                "read-package-json-fast": "^2.0.2",
+                "ci-info": "^3.7.1",
+                "npm-package-arg": "^10.1.0",
+                "npmlog": "^7.0.1",
+                "pacote": "^15.0.8",
+                "proc-log": "^3.0.0",
+                "read": "^2.0.0",
+                "read-package-json-fast": "^3.0.2",
                 "semver": "^7.3.7",
-                "walk-up-path": "^1.0.0"
+                "walk-up-path": "^3.0.1"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmfund": {
-            "version": "3.0.5",
+            "version": "4.0.17",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^5.6.3"
+                "@npmcli/arborist": "^6.2.9"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmhook": {
-            "version": "8.0.4",
+            "version": "9.0.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "aproba": "^2.0.0",
-                "npm-registry-fetch": "^13.0.0"
+                "npm-registry-fetch": "^14.0.3"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmorg": {
-            "version": "4.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "aproba": "^2.0.0",
-                "npm-registry-fetch": "^13.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmpack": {
-            "version": "4.1.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/run-script": "^4.1.3",
-                "npm-package-arg": "^9.0.1",
-                "pacote": "^13.6.1"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmpublish": {
-            "version": "6.0.5",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "normalize-package-data": "^4.0.0",
-                "npm-package-arg": "^9.0.1",
-                "npm-registry-fetch": "^13.0.0",
-                "semver": "^7.3.7",
-                "ssri": "^9.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmsearch": {
             "version": "5.0.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "npm-registry-fetch": "^13.0.0"
+                "aproba": "^2.0.0",
+                "npm-registry-fetch": "^14.0.3"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmpack": {
+            "version": "5.0.17",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/arborist": "^6.2.9",
+                "@npmcli/run-script": "^6.0.0",
+                "npm-package-arg": "^10.1.0",
+                "pacote": "^15.0.8"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmpublish": {
+            "version": "7.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "ci-info": "^3.6.1",
+                "normalize-package-data": "^5.0.0",
+                "npm-package-arg": "^10.1.0",
+                "npm-registry-fetch": "^14.0.3",
+                "proc-log": "^3.0.0",
+                "semver": "^7.3.7",
+                "sigstore": "^1.4.0",
+                "ssri": "^10.0.1"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmsearch": {
+            "version": "6.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-registry-fetch": "^14.0.3"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmteam": {
-            "version": "4.0.4",
+            "version": "5.0.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "aproba": "^2.0.0",
-                "npm-registry-fetch": "^13.0.0"
+                "npm-registry-fetch": "^14.0.3"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmversion": {
-            "version": "3.0.7",
+            "version": "4.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/git": "^3.0.0",
-                "@npmcli/run-script": "^4.1.3",
-                "json-parse-even-better-errors": "^2.3.1",
-                "proc-log": "^2.0.0",
+                "@npmcli/git": "^4.0.1",
+                "@npmcli/run-script": "^6.0.0",
+                "json-parse-even-better-errors": "^3.0.0",
+                "proc-log": "^3.0.0",
                 "semver": "^7.3.7"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/lru-cache": {
-            "version": "7.13.2",
+            "version": "7.18.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -22523,6 +18972,438 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/make-fetch-happen": {
+            "version": "11.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "agentkeepalive": "^4.2.1",
+                "cacache": "^17.0.0",
+                "http-cache-semantics": "^4.1.1",
+                "http-proxy-agent": "^5.0.0",
+                "https-proxy-agent": "^5.0.0",
+                "is-lambda": "^1.0.1",
+                "lru-cache": "^7.7.1",
+                "minipass": "^5.0.0",
+                "minipass-fetch": "^3.0.0",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^0.6.3",
+                "promise-retry": "^2.0.1",
+                "socks-proxy-agent": "^7.0.0",
+                "ssri": "^10.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minimatch": {
+            "version": "9.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-collect": {
+            "version": "1.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-collect/node_modules/minipass": {
+            "version": "3.3.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-fetch": {
+            "version": "3.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^5.0.0",
+                "minipass-sized": "^1.0.3",
+                "minizlib": "^2.1.2"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            },
+            "optionalDependencies": {
+                "encoding": "^0.1.13"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-flush": {
+            "version": "1.0.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
+            "version": "3.3.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-json-stream": {
+            "version": "1.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "jsonparse": "^1.3.1",
+                "minipass": "^3.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
+            "version": "3.3.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-pipeline": {
+            "version": "1.2.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
+            "version": "3.3.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-sized": {
+            "version": "1.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
+            "version": "3.3.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minizlib": {
+            "version": "2.1.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minizlib/node_modules/minipass": {
+            "version": "3.3.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/mkdirp": {
+            "version": "1.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/ms": {
+            "version": "2.1.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/mute-stream": {
+            "version": "1.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/negotiator": {
+            "version": "0.6.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp": {
+            "version": "9.3.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "env-paths": "^2.2.0",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.6",
+                "make-fetch-happen": "^10.0.3",
+                "nopt": "^6.0.0",
+                "npmlog": "^6.0.0",
+                "rimraf": "^3.0.2",
+                "semver": "^7.3.5",
+                "tar": "^6.1.2",
+                "which": "^2.0.2"
+            },
+            "bin": {
+                "node-gyp": "bin/node-gyp.js"
+            },
+            "engines": {
+                "node": "^12.13 || ^14.13 || >=16"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/fs": {
+            "version": "2.1.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promisify": "^1.1.3",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
+            "version": "1.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/are-we-there-yet": {
+            "version": "3.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^3.6.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/cacache": {
+            "version": "16.1.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/fs": "^2.1.0",
+                "@npmcli/move-file": "^2.0.0",
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.1.0",
+                "glob": "^8.0.1",
+                "infer-owner": "^1.0.4",
+                "lru-cache": "^7.7.1",
+                "minipass": "^3.1.6",
+                "minipass-collect": "^1.0.2",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "mkdirp": "^1.0.4",
+                "p-map": "^4.0.0",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^3.0.2",
+                "ssri": "^9.0.0",
+                "tar": "^6.1.11",
+                "unique-filename": "^2.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/glob": {
+            "version": "8.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/minimatch": {
+            "version": "5.1.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/fs-minipass": {
+            "version": "2.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
+            "version": "4.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^1.0.3 || ^2.0.0",
+                "color-support": "^1.1.3",
+                "console-control-strings": "^1.1.0",
+                "has-unicode": "^2.0.1",
+                "signal-exit": "^3.0.7",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
+                "wide-align": "^1.1.5"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/glob": {
+            "version": "7.2.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
             "version": "10.2.1",
             "dev": true,
             "inBundle": true,
@@ -22549,20 +19430,20 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minimatch": {
-            "version": "5.1.0",
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
+            "version": "3.1.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
-                "node": ">=10"
+                "node": "*"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass": {
-            "version": "3.3.4",
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/minipass": {
+            "version": "3.3.6",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -22573,20 +19454,8 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-collect": {
-            "version": "1.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-fetch": {
-            "version": "2.1.1",
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/minipass-fetch": {
+            "version": "2.1.2",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -22602,194 +19471,7 @@
                 "encoding": "^0.1.13"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-flush": {
-            "version": "1.0.5",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-json-stream": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "jsonparse": "^1.3.1",
-                "minipass": "^3.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-pipeline": {
-            "version": "1.2.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minipass-sized": {
-            "version": "1.0.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/minizlib": {
-            "version": "2.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/mkdirp": {
-            "version": "1.0.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/mkdirp-infer-owner": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "chownr": "^2.0.0",
-                "infer-owner": "^1.0.4",
-                "mkdirp": "^1.0.3"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/ms": {
-            "version": "2.1.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/mute-stream": {
-            "version": "0.0.8",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/negotiator": {
-            "version": "0.6.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp": {
-            "version": "9.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "env-paths": "^2.2.0",
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^10.0.3",
-                "nopt": "^5.0.0",
-                "npmlog": "^6.0.0",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.5",
-                "tar": "^6.1.2",
-                "which": "^2.0.2"
-            },
-            "bin": {
-                "node-gyp": "bin/node-gyp.js"
-            },
-            "engines": {
-                "node": "^12.22 || ^14.13 || >=16"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/glob": {
-            "version": "7.2.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
-            "version": "3.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
-            "version": "5.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "1"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/nopt": {
             "version": "6.0.0",
             "dev": true,
             "inBundle": true,
@@ -22804,176 +19486,7 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/normalize-package-data": {
-            "version": "4.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "hosted-git-info": "^5.0.0",
-                "is-core-module": "^2.8.1",
-                "semver": "^7.3.5",
-                "validate-npm-package-license": "^3.0.4"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-audit-report": {
-            "version": "3.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-bundled": {
-            "version": "2.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-normalize-package-bin": "^2.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-install-checks": {
-            "version": "5.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "semver": "^7.1.1"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-normalize-package-bin": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-package-arg": {
-            "version": "9.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "hosted-git-info": "^5.0.0",
-                "proc-log": "^2.0.1",
-                "semver": "^7.3.5",
-                "validate-npm-package-name": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-packlist": {
-            "version": "5.1.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^8.0.1",
-                "ignore-walk": "^5.0.1",
-                "npm-bundled": "^2.0.0",
-                "npm-normalize-package-bin": "^2.0.0"
-            },
-            "bin": {
-                "npm-packlist": "bin/index.js"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-pick-manifest": {
-            "version": "7.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-install-checks": "^5.0.0",
-                "npm-normalize-package-bin": "^2.0.0",
-                "npm-package-arg": "^9.0.0",
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-profile": {
-            "version": "6.2.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-registry-fetch": "^13.0.1",
-                "proc-log": "^2.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-registry-fetch": {
-            "version": "13.3.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "make-fetch-happen": "^10.0.6",
-                "minipass": "^3.1.6",
-                "minipass-fetch": "^2.0.3",
-                "minipass-json-stream": "^1.0.1",
-                "minizlib": "^2.1.2",
-                "npm-package-arg": "^9.0.1",
-                "proc-log": "^2.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-user-validate": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npmlog": {
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
             "version": "6.0.2",
             "dev": true,
             "inBundle": true,
@@ -22988,6 +19501,249 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/signal-exit": {
+            "version": "3.0.7",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/ssri": {
+            "version": "9.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.1.1"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/unique-filename": {
+            "version": "2.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "unique-slug": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/unique-slug": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "imurmurhash": "^0.1.4"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/node-gyp/node_modules/which": {
+            "version": "2.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/nopt": {
+            "version": "7.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^2.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/normalize-package-data": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^6.0.0",
+                "is-core-module": "^2.8.1",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-audit-report": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "chalk": "^4.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-bundled": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-normalize-package-bin": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-install-checks": {
+            "version": "6.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "semver": "^7.1.1"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-normalize-package-bin": {
+            "version": "3.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-package-arg": {
+            "version": "10.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "hosted-git-info": "^6.0.0",
+                "proc-log": "^3.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-name": "^5.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-packlist": {
+            "version": "7.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "ignore-walk": "^6.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-pick-manifest": {
+            "version": "8.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-install-checks": "^6.0.0",
+                "npm-normalize-package-bin": "^3.0.0",
+                "npm-package-arg": "^10.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-profile": {
+            "version": "7.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-registry-fetch": "^14.0.0",
+                "proc-log": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-registry-fetch": {
+            "version": "14.0.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "make-fetch-happen": "^11.0.0",
+                "minipass": "^5.0.0",
+                "minipass-fetch": "^3.0.0",
+                "minipass-json-stream": "^1.0.1",
+                "minizlib": "^2.1.2",
+                "npm-package-arg": "^10.0.0",
+                "proc-log": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npm-user-validate": {
+            "version": "2.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/npmlog": {
+            "version": "7.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "are-we-there-yet": "^4.0.0",
+                "console-control-strings": "^1.1.0",
+                "gauge": "^5.0.0",
+                "set-blocking": "^2.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/once": {
             "version": "1.4.0",
             "dev": true,
@@ -22995,15 +19751,6 @@
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/opener": {
-            "version": "1.5.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "(WTFPL OR MIT)",
-            "bin": {
-                "opener": "bin/opener-bin.js"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/p-map": {
@@ -23022,52 +19769,49 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/pacote": {
-            "version": "13.6.2",
+            "version": "15.1.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/git": "^3.0.0",
-                "@npmcli/installed-package-contents": "^1.0.7",
-                "@npmcli/promise-spawn": "^3.0.0",
-                "@npmcli/run-script": "^4.1.0",
-                "cacache": "^16.0.0",
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.1.0",
-                "infer-owner": "^1.0.4",
-                "minipass": "^3.1.6",
-                "mkdirp": "^1.0.4",
-                "npm-package-arg": "^9.0.0",
-                "npm-packlist": "^5.1.0",
-                "npm-pick-manifest": "^7.0.0",
-                "npm-registry-fetch": "^13.0.1",
-                "proc-log": "^2.0.0",
+                "@npmcli/git": "^4.0.0",
+                "@npmcli/installed-package-contents": "^2.0.1",
+                "@npmcli/promise-spawn": "^6.0.1",
+                "@npmcli/run-script": "^6.0.0",
+                "cacache": "^17.0.0",
+                "fs-minipass": "^3.0.0",
+                "minipass": "^5.0.0",
+                "npm-package-arg": "^10.0.0",
+                "npm-packlist": "^7.0.0",
+                "npm-pick-manifest": "^8.0.0",
+                "npm-registry-fetch": "^14.0.0",
+                "proc-log": "^3.0.0",
                 "promise-retry": "^2.0.1",
-                "read-package-json": "^5.0.0",
-                "read-package-json-fast": "^2.0.3",
-                "rimraf": "^3.0.2",
-                "ssri": "^9.0.0",
+                "read-package-json": "^6.0.0",
+                "read-package-json-fast": "^3.0.0",
+                "sigstore": "^1.3.0",
+                "ssri": "^10.0.0",
                 "tar": "^6.1.11"
             },
             "bin": {
                 "pacote": "lib/bin.js"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/parse-conflict-json": {
-            "version": "2.0.2",
+            "version": "3.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "json-parse-even-better-errors": "^2.3.1",
-                "just-diff": "^5.0.1",
+                "json-parse-even-better-errors": "^3.0.0",
+                "just-diff": "^6.0.0",
                 "just-diff-apply": "^5.2.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/path-is-absolute": {
@@ -23079,8 +19823,42 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/path-key": {
+            "version": "3.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/path-scurry": {
+            "version": "1.9.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^9.1.1",
+                "minipass": "^5.0.0 || ^6.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "9.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "14 || >=16.14"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/postcss-selector-parser": {
-            "version": "6.0.10",
+            "version": "6.0.13",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -23093,12 +19871,21 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/proc-log": {
-            "version": "2.0.1",
+            "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/process": {
+            "version": "0.11.10",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/promise-all-reject-late": {
@@ -23111,7 +19898,7 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/promise-call-limit": {
-            "version": "1.0.1",
+            "version": "1.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -23139,12 +19926,15 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/promzard": {
-            "version": "0.3.0",
+            "version": "1.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "read": "1"
+                "read": "^2.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/qrcode-terminal": {
@@ -23156,87 +19946,67 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/read": {
-            "version": "1.0.7",
+            "version": "2.1.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "mute-stream": "~0.0.4"
+                "mute-stream": "~1.0.0"
             },
             "engines": {
-                "node": ">=0.8"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/read-cmd-shim": {
-            "version": "3.0.0",
+            "version": "4.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/read-package-json": {
-            "version": "5.0.2",
+            "version": "6.0.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "glob": "^8.0.1",
-                "json-parse-even-better-errors": "^2.3.1",
-                "normalize-package-data": "^4.0.0",
-                "npm-normalize-package-bin": "^2.0.0"
+                "glob": "^10.2.2",
+                "json-parse-even-better-errors": "^3.0.0",
+                "normalize-package-data": "^5.0.0",
+                "npm-normalize-package-bin": "^3.0.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/read-package-json-fast": {
-            "version": "2.0.3",
+            "version": "3.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "json-parse-even-better-errors": "^2.3.0",
-                "npm-normalize-package-bin": "^1.0.1"
+                "json-parse-even-better-errors": "^3.0.0",
+                "npm-normalize-package-bin": "^3.0.0"
             },
             "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/readable-stream": {
-            "version": "3.6.0",
+            "version": "4.4.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10"
             },
             "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/readdir-scoped-modules": {
-            "version": "1.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "graceful-fs": "^4.1.2",
-                "once": "^1.3.0"
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/retry": {
@@ -23306,22 +20076,8 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/safe-buffer": {
-            "version": "5.2.1",
+            "version": "5.1.2",
             "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
             "inBundle": true,
             "license": "MIT"
         },
@@ -23333,7 +20089,7 @@
             "optional": true
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/semver": {
-            "version": "7.3.7",
+            "version": "7.5.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -23365,11 +20121,55 @@
             "inBundle": true,
             "license": "ISC"
         },
-        "node_modules/@salesforce/cli/node_modules/npm/node_modules/signal-exit": {
-            "version": "3.0.7",
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/shebang-command": {
+            "version": "2.0.0",
             "dev": true,
             "inBundle": true,
-            "license": "ISC"
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/signal-exit": {
+            "version": "4.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/sigstore": {
+            "version": "1.5.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.1.0",
+                "make-fetch-happen": "^11.0.1",
+                "tuf-js": "^1.1.3"
+            },
+            "bin": {
+                "sigstore": "bin/sigstore.js"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/smart-buffer": {
             "version": "4.2.0",
@@ -23382,7 +20182,7 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/socks": {
-            "version": "2.7.0",
+            "version": "2.7.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -23410,7 +20210,7 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/spdx-correct": {
-            "version": "3.1.1",
+            "version": "3.2.0",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
@@ -23436,33 +20236,48 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/spdx-license-ids": {
-            "version": "3.0.11",
+            "version": "3.0.13",
             "dev": true,
             "inBundle": true,
             "license": "CC0-1.0"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/ssri": {
-            "version": "9.0.1",
+            "version": "10.0.4",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "minipass": "^3.1.1"
+                "minipass": "^5.0.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/string_decoder": {
-            "version": "1.3.0",
+            "version": "1.1.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "safe-buffer": "~5.2.0"
+                "safe-buffer": "~5.1.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/string-width": {
+            "version": "4.2.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/string-width-cjs": {
+            "name": "string-width",
             "version": "4.2.3",
             "dev": true,
             "inBundle": true,
@@ -23488,6 +20303,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/supports-color": {
             "version": "7.2.0",
             "dev": true,
@@ -23501,20 +20329,44 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/tar": {
-            "version": "6.1.11",
+            "version": "6.1.14",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
-                "minipass": "^3.0.0",
+                "minipass": "^5.0.0",
                 "minizlib": "^2.1.1",
                 "mkdirp": "^1.0.3",
                 "yallist": "^4.0.0"
             },
             "engines": {
-                "node": ">= 10"
+                "node": ">=10"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
+            "version": "2.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
+            "version": "3.3.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/text-table": {
@@ -23530,28 +20382,42 @@
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/treeverse": {
-            "version": "2.0.0",
+            "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/tuf-js": {
+            "version": "1.1.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tufjs/models": "1.0.4",
+                "debug": "^4.3.4",
+                "make-fetch-happen": "^11.1.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/unique-filename": {
-            "version": "2.0.1",
+            "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "unique-slug": "^3.0.0"
+                "unique-slug": "^4.0.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/unique-slug": {
-            "version": "3.0.0",
+            "version": "4.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -23559,7 +20425,7 @@
                 "imurmurhash": "^0.1.4"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/util-deprecate": {
@@ -23579,7 +20445,7 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/validate-npm-package-name": {
-            "version": "4.0.0",
+            "version": "5.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -23587,11 +20453,11 @@
                 "builtins": "^5.0.0"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/walk-up-path": {
-            "version": "1.0.0",
+            "version": "3.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
@@ -23606,7 +20472,7 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/which": {
-            "version": "2.0.2",
+            "version": "3.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -23614,10 +20480,10 @@
                 "isexe": "^2.0.0"
             },
             "bin": {
-                "node-which": "bin/node-which"
+                "node-which": "bin/which.js"
             },
             "engines": {
-                "node": ">= 8"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/wide-align": {
@@ -23629,6 +20495,103 @@
                 "string-width": "^1.0.2 || 2 || 3 || 4"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+            "version": "6.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "5.1.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+            "version": "7.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/wrappy": {
             "version": "1.0.2",
             "dev": true,
@@ -23636,16 +20599,16 @@
             "license": "ISC"
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/write-file-atomic": {
-            "version": "4.0.2",
+            "version": "5.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.7"
+                "signal-exit": "^4.0.1"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/npm/node_modules/yallist": {
@@ -23653,46 +20616,6 @@
             "dev": true,
             "inBundle": true,
             "license": "ISC"
-        },
-        "node_modules/@salesforce/cli/node_modules/npmlog": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-            "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "are-we-there-yet": "^3.0.0",
-                "console-control-strings": "^1.1.0",
-                "gauge": "^4.0.3",
-                "set-blocking": "^2.0.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/npmlog/node_modules/are-we-there-yet": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-            "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/@salesforce/cli/node_modules/nyc": {
             "version": "15.1.0",
@@ -23756,21 +20679,6 @@
             "license": "MIT",
             "dependencies": {
                 "aggregate-error": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/nyc/node_modules/wrap-ansi": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
             },
             "engines": {
                 "node": ">=8"
@@ -23879,6 +20787,37 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/object.fromentries": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
+            "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.20.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/object.groupby": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.0.tgz",
+            "integrity": "sha512-70MWG6NfRH9GnbZOikuhPPYzpUpof9iW2J9E4dW7FXTqPNb6rllE6u39SKwwiNh8lCwX3DDb5OgcKGiEBrTTyw==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.2.0",
+                "es-abstract": "^1.21.2",
+                "get-intrinsic": "^1.2.1"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/object.values": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
@@ -23898,16 +20837,17 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/oclif": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/oclif/-/oclif-3.10.0.tgz",
-            "integrity": "sha512-Kf/nL7GrfezePsZGQytbPJG1EGNFRAG+lC6NhYqPOgeBIGppLuQDg6vO9wz0QRoijSJv/Yf4wCe2URMoCFtBNw==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/oclif/-/oclif-3.15.1.tgz",
+            "integrity": "sha512-3xpR4rOQ1aTJC3Mr+TaguZapJqZ0360gvM+UKKsYBz4B5dqRCfPp75E2qWRmzaUmCjo+LYanMdD/h7Ja/yNPVA==",
             "extraneous": true,
             "license": "MIT",
             "dependencies": {
-                "@oclif/core": "^2.9.4",
+                "@oclif/core": "^2.11.4",
                 "@oclif/plugin-help": "^5.2.14",
                 "@oclif/plugin-not-found": "^2.3.32",
                 "@oclif/plugin-warn-if-update-available": "^2.0.44",
+                "async-retry": "^1.3.3",
                 "aws-sdk": "^2.1231.0",
                 "concurrently": "^7.6.0",
                 "debug": "^4.3.3",
@@ -23921,16 +20861,21 @@
                 "shelljs": "^0.8.5",
                 "tslib": "^2.3.1",
                 "yeoman-environment": "^3.15.1",
-                "yeoman-generator": "^5.8.0",
-                "yosay": "^2.0.2"
+                "yeoman-generator": "^5.8.0"
             },
             "bin": {
-                "oclif": "bin/run",
-                "oclif2": "bin/run"
+                "oclif": "bin/run"
             },
             "engines": {
                 "node": ">=12.0.0"
             }
+        },
+        "node_modules/@salesforce/cli/node_modules/on-exit-leak-free": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+            "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/once": {
             "version": "1.4.0",
@@ -24000,29 +20945,6 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "extraneous": true,
             "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/optionator/node_modules/prelude-ls": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/optionator/node_modules/type-check": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "prelude-ls": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
         },
         "node_modules/@salesforce/cli/node_modules/ora": {
             "version": "5.4.1",
@@ -24178,9 +21100,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/pac-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-t4tRAMx0uphnZrio0S0Jw9zg3oDbz1zVhQ/Vy18FjLfP1XOLNUEjaVxYCYRI6NS+BsMBXKIzV6cTLOkO9AtywA==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
+            "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -24189,9 +21111,9 @@
                 "debug": "^4.3.4",
                 "get-uri": "^6.0.1",
                 "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.2",
                 "pac-resolver": "^7.0.0",
-                "socks-proxy-agent": "^8.0.1"
+                "socks-proxy-agent": "^8.0.2"
             },
             "engines": {
                 "node": ">= 14"
@@ -24225,9 +21147,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -24239,13 +21161,13 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/pac-proxy-agent/node_modules/socks-proxy-agent": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.1.tgz",
-            "integrity": "sha512-59EjPbbgg8U3x62hhKOFVAmySQUcfRQ4C7Q/D5sEHnZTQRrQlNKINks44DMR1gwXp0p4LaVIeccX2KHTTcHVqQ==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
+            "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "agent-base": "^7.0.1",
+                "agent-base": "^7.0.2",
                 "debug": "^4.3.4",
                 "socks": "^2.7.1"
             },
@@ -24267,6 +21189,13 @@
             "engines": {
                 "node": ">= 14"
             }
+        },
+        "node_modules/@salesforce/cli/node_modules/pac-resolver/node_modules/ip": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
+            "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/package-hash": {
             "version": "4.0.0",
@@ -24317,46 +21246,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/@npmcli/fs": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
-            "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/@npmcli/installed-package-contents": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-2.0.2.tgz",
-            "integrity": "sha512-xACzLPhnfD51GKvTOOuNX2/V4G4mz9/1I2MfDoye9kBM3RYe5g2YbscsaGoTlaWqkxeiapBWyseULVKpSVHtKQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-bundled": "^3.0.0",
-                "npm-normalize-package-bin": "^3.0.0"
-            },
-            "bin": {
-                "installed-package-contents": "lib/index.js"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/@npmcli/node-gyp": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-3.0.0.tgz",
-            "integrity": "sha512-gp8pRXC2oOxu0DUE1/M3bYtb1b3/DbJ5aM113+XJBgfXdussRAsX0YOrOhdd8WvnAR6auDBvJomGAkLKA5ydxA==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/pacote/node_modules/@npmcli/promise-spawn": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz",
@@ -24368,64 +21257,6 @@
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/@npmcli/run-script": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-6.0.2.tgz",
-            "integrity": "sha512-NCcr1uQo1k5U+SYlnIrbAh3cxy+OQT1VtqiAbxdymSlptbzBb62AjH2xXgjNCoP073hoa1CfCAcwoZ8k96C4nA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/node-gyp": "^3.0.0",
-                "@npmcli/promise-spawn": "^6.0.0",
-                "node-gyp": "^9.0.0",
-                "read-package-json-fast": "^3.0.0",
-                "which": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/cacache": {
-            "version": "17.1.3",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.3.tgz",
-            "integrity": "sha512-jAdjGxmPxZh0IipMdR7fK/4sDSrHMLUV0+GvVUsjwyGNKHsh79kW/otg+GkbXwl6Uzvy9wsvHOX4nUoWldeZMg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/fs": "^3.1.0",
-                "fs-minipass": "^3.0.0",
-                "glob": "^10.2.2",
-                "lru-cache": "^7.7.1",
-                "minipass": "^5.0.0",
-                "minipass-collect": "^1.0.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "p-map": "^4.0.0",
-                "ssri": "^10.0.0",
-                "tar": "^6.1.11",
-                "unique-filename": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/foreground-child": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-            "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "cross-spawn": "^7.0.0",
-                "signal-exit": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@salesforce/cli/node_modules/pacote/node_modules/fs-minipass": {
@@ -24441,78 +21272,6 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/glob": {
-            "version": "10.3.1",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.1.tgz",
-            "integrity": "sha512-9BKYcEeIs7QwlCYs+Y3GBvqAMISufUS0i2ELd11zpZjxI5V9iyRj0HgzB5/cLf2NY4vcYBTYzJ7GIui7j/4DOw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^2.0.3",
-                "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2",
-                "path-scurry": "^1.10.0"
-            },
-            "bin": {
-                "glob": "dist/cjs/src/bin.js"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/glob/node_modules/minipass": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-            "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/hosted-git-info": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
-            "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^7.5.1"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/json-parse-even-better-errors": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
-            "integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/pacote/node_modules/minipass": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
@@ -24521,186 +21280,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/minipass-fetch": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.3.tgz",
-            "integrity": "sha512-n5ITsTkDqYkYJZjcRWzZt9qnZKCT7nKCosJhHoj7S7zD+BP4jVbWs+odsniw5TA3E0sLomhTKOKjF86wf11PuQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^5.0.0",
-                "minipass-sized": "^1.0.3",
-                "minizlib": "^2.1.2"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            },
-            "optionalDependencies": {
-                "encoding": "^0.1.13"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/normalize-package-data": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-5.0.0.tgz",
-            "integrity": "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "hosted-git-info": "^6.0.0",
-                "is-core-module": "^2.8.1",
-                "semver": "^7.3.5",
-                "validate-npm-package-license": "^3.0.4"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/npm-bundled": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-3.0.0.tgz",
-            "integrity": "sha512-Vq0eyEQy+elFpzsKjMss9kxqb9tG3YHg4dsyWuUENuzvSUWe1TCnW/vV9FkhvBk/brEDoDiVd+M1Btosa6ImdQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-normalize-package-bin": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/npm-install-checks": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.1.1.tgz",
-            "integrity": "sha512-dH3GmQL4vsPtld59cOn8uY0iOqRmqKvV+DLGwNXV/Q7MDgD2QfOADWd/mFXcIE5LVhYYGjA3baz6W9JneqnuCw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "semver": "^7.1.1"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/npm-package-arg": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-10.1.0.tgz",
-            "integrity": "sha512-uFyyCEmgBfZTtrKk/5xDfHp6+MdrqGotX/VoOyEEl3mBwiEE5FlBaePanazJSVMPT7vKepcjYBY2ztg9A3yPIA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "hosted-git-info": "^6.0.0",
-                "proc-log": "^3.0.0",
-                "semver": "^7.3.5",
-                "validate-npm-package-name": "^5.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/npm-pick-manifest": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-8.0.1.tgz",
-            "integrity": "sha512-mRtvlBjTsJvfCCdmPtiu2bdlx8d/KXtF7yNXNWe7G0Z36qWA9Ny5zXsI2PfBZEv7SXgoxTmNaTzGSbbzDZChoA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "npm-install-checks": "^6.0.0",
-                "npm-normalize-package-bin": "^3.0.0",
-                "npm-package-arg": "^10.0.0",
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/npm-registry-fetch": {
-            "version": "14.0.5",
-            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-14.0.5.tgz",
-            "integrity": "sha512-kIDMIo4aBm6xg7jOttupWZamsZRkAqMqwqqbVXnUqstY5+tapvv6bkH/qMR76jdgV+YljEUCyWx3hRYMrJiAgA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "make-fetch-happen": "^11.0.0",
-                "minipass": "^5.0.0",
-                "minipass-fetch": "^3.0.0",
-                "minipass-json-stream": "^1.0.1",
-                "minizlib": "^2.1.2",
-                "npm-package-arg": "^10.0.0",
-                "proc-log": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/read-package-json": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-6.0.4.tgz",
-            "integrity": "sha512-AEtWXYfopBj2z5N5PbkAOeNHRPUg5q+Nen7QLxV8M2zJq1ym6/lCz3fYNTCXe19puu2d06jfHhrP7v/S2PtMMw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^10.2.2",
-                "json-parse-even-better-errors": "^3.0.0",
-                "normalize-package-data": "^5.0.0",
-                "npm-normalize-package-bin": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/read-package-json-fast": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-3.0.2.tgz",
-            "integrity": "sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "json-parse-even-better-errors": "^3.0.0",
-                "npm-normalize-package-bin": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/signal-exit": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-            "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/unique-filename": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-            "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "unique-slug": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/pacote/node_modules/unique-slug": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-            "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "imurmurhash": "^0.1.4"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/pacote/node_modules/which": {
@@ -24718,12 +21297,6 @@
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
-        },
-        "node_modules/@salesforce/cli/node_modules/pad-component": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/pad-component/-/pad-component-0.0.1.tgz",
-            "integrity": "sha512-8EKVBxCRSvLnsX1p2LlSFSH3c2/wuhY9/BXXWu8boL78FbVKqn2L5SpURt1x5iw6Gq8PTqJ7MdPoe5nCtX3I+g==",
-            "extraneous": true
         },
         "node_modules/@salesforce/cli/node_modules/pako": {
             "version": "1.0.11",
@@ -24756,21 +21329,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/parse-conflict-json": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-2.0.2.tgz",
-            "integrity": "sha512-jDbRGb00TAPFsKWCpZZOT93SxVP9nONOSgES3AevqRq/CHvavEBvKAjxX9p5Y5F0RZLxH9Ufd9+RwtCsa+lFDA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "json-parse-even-better-errors": "^2.3.1",
-                "just-diff": "^5.0.1",
-                "just-diff-apply": "^5.2.0"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/parse-json": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -24789,6 +21347,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/@salesforce/cli/node_modules/parse-json/node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/pascal-case": {
             "version": "3.1.2",
@@ -24840,9 +21405,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/password-prompt/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -24934,14 +21499,14 @@
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/path-scurry": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.0.tgz",
-            "integrity": "sha512-tZFEaRQbMLjwrsmidsGJ6wDMv0iazJWk6SfIKnY4Xru8auXgmJkOBa5DUbYFcFD2Rzk2+KDlIiF0GVXNCbgC7g==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+            "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "lru-cache": "^9.1.1 || ^10.0.0",
-                "minipass": "^5.0.0 || ^6.0.2"
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -24961,9 +21526,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/path-scurry/node_modules/minipass": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-            "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+            "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -24979,6 +21544,13 @@
             "dependencies": {
                 "isarray": "0.0.1"
             }
+        },
+        "node_modules/@salesforce/cli/node_modules/path-to-regexp/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+            "extraneous": true,
+            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/path-type": {
             "version": "4.0.0",
@@ -25029,6 +21601,197 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/@salesforce/cli/node_modules/pino": {
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-8.15.0.tgz",
+            "integrity": "sha512-olUADJByk4twxccmAxb1RiGKOSvddHugCV3wkqjyv+3Sooa2KLrmXrKEWOKi0XPCLasRR5jBXxioE1jxUa4KzQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "atomic-sleep": "^1.0.0",
+                "fast-redact": "^3.1.1",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "v1.0.0",
+                "pino-std-serializers": "^6.0.0",
+                "process-warning": "^2.0.0",
+                "quick-format-unescaped": "^4.0.3",
+                "real-require": "^0.2.0",
+                "safe-stable-stringify": "^2.3.1",
+                "sonic-boom": "^3.1.0",
+                "thread-stream": "^2.0.0"
+            },
+            "bin": {
+                "pino": "bin.js"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/pino-abstract-transport": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+            "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "readable-stream": "^4.0.0",
+                "split2": "^4.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/pino-abstract-transport/node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/pino-abstract-transport/node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.x"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/pino-abstract-transport/node_modules/readable-stream": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+            "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/pino-abstract-transport/node_modules/split2": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 10.x"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/pino-pretty": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.2.0.tgz",
+            "integrity": "sha512-tRvpyEmGtc2D+Lr3FulIZ+R1baggQ4S3xD2Ar93KixFEDx6SEAUP3W5aYuEw1C73d6ROrNcB2IXLteW8itlwhA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "colorette": "^2.0.7",
+                "dateformat": "^4.6.3",
+                "fast-copy": "^3.0.0",
+                "fast-safe-stringify": "^2.1.1",
+                "help-me": "^4.0.1",
+                "joycon": "^3.1.1",
+                "minimist": "^1.2.6",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^1.0.0",
+                "pump": "^3.0.0",
+                "readable-stream": "^4.0.0",
+                "secure-json-parse": "^2.4.0",
+                "sonic-boom": "^3.0.0",
+                "strip-json-comments": "^3.1.1"
+            },
+            "bin": {
+                "pino-pretty": "bin.js"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/pino-pretty/node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/pino-pretty/node_modules/dateformat": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+            "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/pino-pretty/node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.x"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/pino-pretty/node_modules/readable-stream": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+            "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/pino-std-serializers": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+            "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/pkg-dir": {
             "version": "4.2.0",
@@ -25135,10 +21898,11 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/prelude-ls": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "extraneous": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -25284,6 +22048,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/process-warning": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+            "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@salesforce/cli/node_modules/progress": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -25348,20 +22119,20 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/proxy-agent": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
-            "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+            "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.0.2",
                 "debug": "^4.3.4",
                 "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.2",
                 "lru-cache": "^7.14.1",
-                "pac-proxy-agent": "^7.0.0",
+                "pac-proxy-agent": "^7.0.1",
                 "proxy-from-env": "^1.1.0",
-                "socks-proxy-agent": "^8.0.1"
+                "socks-proxy-agent": "^8.0.2"
             },
             "engines": {
                 "node": ">= 14"
@@ -25395,9 +22166,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/proxy-agent/node_modules/https-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -25409,13 +22180,13 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/proxy-agent/node_modules/socks-proxy-agent": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.1.tgz",
-            "integrity": "sha512-59EjPbbgg8U3x62hhKOFVAmySQUcfRQ4C7Q/D5sEHnZTQRrQlNKINks44DMR1gwXp0p4LaVIeccX2KHTTcHVqQ==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
+            "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "agent-base": "^7.0.1",
+                "agent-base": "^7.0.2",
                 "debug": "^4.3.4",
                 "socks": "^2.7.1"
             },
@@ -25647,16 +22418,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/qqjs/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "extraneous": true,
-            "license": "MIT",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/qqjs/node_modules/load-json-file": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
@@ -25700,9 +22461,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/qqjs/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "extraneous": true,
             "license": "ISC",
             "bin": {
@@ -25828,6 +22589,13 @@
             ],
             "license": "MIT"
         },
+        "node_modules/@salesforce/cli/node_modules/quick-format-unescaped": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+            "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@salesforce/cli/node_modules/quick-lru": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -25858,52 +22626,130 @@
                 "safe-buffer": "^5.1.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/raw-body": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/read-cmd-shim": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-3.0.1.tgz",
-            "integrity": "sha512-kEmDUoYf/CDy8yZbLTmhB1X9kkjf9Q80PCNsDMb7ufrGd6zZSQA1+UyjrO+pZm5K/S4OXCWJeiIt1JA8kAsa6g==",
+        "node_modules/@salesforce/cli/node_modules/read-package-json": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-6.0.4.tgz",
+            "integrity": "sha512-AEtWXYfopBj2z5N5PbkAOeNHRPUg5q+Nen7QLxV8M2zJq1ym6/lCz3fYNTCXe19puu2d06jfHhrP7v/S2PtMMw==",
             "dev": true,
             "license": "ISC",
+            "dependencies": {
+                "glob": "^10.2.2",
+                "json-parse-even-better-errors": "^3.0.0",
+                "normalize-package-data": "^5.0.0",
+                "npm-normalize-package-bin": "^3.0.0"
+            },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/read-package-json-fast": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.3.tgz",
-            "integrity": "sha512-W/BKtbL+dUjTuRL2vziuYhp76s5HZ9qQhd/dKfWIZveD0O40453QNyZhC0e63lqZrAQ4jiOapVoeJ7JrszenQQ==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-3.0.2.tgz",
+            "integrity": "sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "json-parse-even-better-errors": "^2.3.0",
-                "npm-normalize-package-bin": "^1.0.1"
+                "json-parse-even-better-errors": "^3.0.0",
+                "npm-normalize-package-bin": "^3.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/read-package-json-fast/node_modules/npm-normalize-package-bin": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-            "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+        "node_modules/@salesforce/cli/node_modules/read-package-json/node_modules/foreground-child": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+            "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/read-package-json/node_modules/glob": {
+            "version": "10.3.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+            "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^2.0.3",
+                "minimatch": "^9.0.1",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+                "path-scurry": "^1.10.1"
+            },
+            "bin": {
+                "glob": "dist/cjs/src/bin.js"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/read-package-json/node_modules/minimatch": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/read-package-json/node_modules/minipass": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+            "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/read-package-json/node_modules/normalize-package-data": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-5.0.0.tgz",
+            "integrity": "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "hosted-git-info": "^6.0.0",
+                "is-core-module": "^2.8.1",
+                "semver": "^7.3.5",
+                "validate-npm-package-license": "^3.0.4"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/read-package-json/node_modules/signal-exit": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+            "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/@salesforce/cli/node_modules/read-pkg": {
             "version": "3.0.0",
@@ -25985,9 +22831,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/read-pkg-up/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -26048,9 +22894,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/read-pkg/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "extraneous": true,
             "license": "ISC",
             "bin": {
@@ -26119,6 +22965,16 @@
             },
             "engines": {
                 "node": ">=8.10.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/real-require": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+            "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12.13.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/rechoir": {
@@ -26266,9 +23122,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/require-in-the-middle": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.1.1.tgz",
-            "integrity": "sha512-OScOjQjrrjhAdFpQmnkE/qbIBGCRFhQB/YaJhcC3CPOlmhe7llnW46Ac1J5+EjcNXOTnDdpF96Erw/yedsGksQ==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
+            "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -26295,13 +23151,13 @@
             "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/resolve": {
-            "version": "1.22.2",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-            "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+            "version": "1.22.4",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+            "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.11.0",
+                "is-core-module": "^2.13.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -26460,6 +23316,32 @@
                 "tslib": "^2.1.0"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/safe-array-concat": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
+            "integrity": "sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.0",
+                "has-symbols": "^1.0.3",
+                "isarray": "^2.0.5"
+            },
+            "engines": {
+                "node": ">=0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/safe-array-concat/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "extraneous": true,
+            "license": "MIT"
+        },
         "node_modules/@salesforce/cli/node_modules/safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -26518,7 +23400,7 @@
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
             "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -26554,6 +23436,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/@salesforce/cli/node_modules/secure-json-parse": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+            "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/@salesforce/cli/node_modules/semver": {
             "version": "7.5.4",
@@ -26629,13 +23518,6 @@
             "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/setprototypeof": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-            "extraneous": true,
-            "license": "ISC"
         },
         "node_modules/@salesforce/cli/node_modules/sha.js": {
             "version": "2.4.11",
@@ -26920,28 +23802,29 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/socks-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+            "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true,
             "dependencies": {
                 "agent-base": "^6.0.2",
-                "debug": "4",
-                "socks": "^2.3.3"
+                "debug": "^4.3.3",
+                "socks": "^2.6.2"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 10"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/socks/node_modules/ip": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+        "node_modules/@salesforce/cli/node_modules/sonic-boom": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
+            "integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "atomic-sleep": "^1.0.0"
+            }
         },
         "node_modules/@salesforce/cli/node_modules/sort-keys": {
             "version": "4.2.0",
@@ -27274,16 +24157,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/string_decoder": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -27407,26 +24280,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/strip-ansi/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/strip-bom": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -27514,7 +24367,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "extraneous": true,
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -27610,17 +24463,6 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "extraneous": true,
             "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/taketalk": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/taketalk/-/taketalk-1.0.0.tgz",
-            "integrity": "sha512-kS7E53It6HA8S1FVFBWP7HDwgTiJtkmYk7TsowGlizzVrivR1Mf9mgjXHY1k7rOfozRVMZSfwjB3bevO4QEqpg==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-stdin": "^4.0.1",
-                "minimist": "^1.1.0"
-            }
         },
         "node_modules/@salesforce/cli/node_modules/tar": {
             "version": "6.1.15",
@@ -27732,6 +24574,16 @@
                 "url": "https://bevry.me/fund"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/thread-stream": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.3.0.tgz",
+            "integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "real-require": "^0.2.0"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -27783,16 +24635,6 @@
             },
             "engines": {
                 "node": ">=8.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/toidentifier": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.6"
             }
         },
         "node_modules/@salesforce/cli/node_modules/tough-cookie": {
@@ -27975,9 +24817,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/ts-retry-promise": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/ts-retry-promise/-/ts-retry-promise-0.7.0.tgz",
-            "integrity": "sha512-x6yWZXC4BfXy4UyMweOFvbS1yJ/Y5biSz/mEPiILtJZLrqD3ZxIpzVOGGgifHHdaSe3WxzFRtsRbychI6zofOg==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/ts-retry-promise/-/ts-retry-promise-0.7.1.tgz",
+            "integrity": "sha512-NhHOCZ2AQORvH42hOPO5UZxShlcuiRtm7P2jIq2L2RY3PBxw2mLnUsEdHrIslVBFya1v5aZmrR55lWkzo13LrQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -28011,9 +24853,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/tslib": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
             "dev": true,
             "license": "0BSD"
         },
@@ -28069,13 +24911,13 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/type-check": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-            "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "extraneous": true,
             "license": "MIT",
             "dependencies": {
-                "prelude-ls": "~1.1.2"
+                "prelude-ls": "^1.2.1"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -28099,6 +24941,60 @@
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/typed-array-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
+            "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.2.1",
+                "is-typed-array": "^1.1.10"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/typed-array-byte-length": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
+            "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "has-proto": "^1.0.1",
+                "is-typed-array": "^1.1.10"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/typed-array-byte-offset": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
+            "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "for-each": "^0.3.3",
+                "has-proto": "^1.0.1",
+                "is-typed-array": "^1.1.10"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/@salesforce/cli/node_modules/typed-array-length": {
@@ -28224,6 +25120,32 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/unique-filename": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+            "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "unique-slug": "^4.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/unique-slug": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+            "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "imurmurhash": "^0.1.4"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/universal-user-agent": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
@@ -28239,16 +25161,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/unpipe": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "node_modules/@salesforce/cli/node_modules/untildify": {
@@ -28279,13 +25191,6 @@
                 "readable-stream": "~2.3.6",
                 "setimmediate": "~1.0.4"
             }
-        },
-        "node_modules/@salesforce/cli/node_modules/unzipper/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/unzipper/node_modules/readable-stream": {
             "version": "2.3.8",
@@ -28534,23 +25439,6 @@
                 "node": ">=0.8"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/vm2": {
-            "version": "3.9.19",
-            "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
-            "integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.7.0",
-                "acorn-walk": "^8.2.0"
-            },
-            "bin": {
-                "vm2": "bin/vm2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/vscode-oniguruma": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
@@ -28564,13 +25452,6 @@
             "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
             "extraneous": true,
             "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/walk-up-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-1.0.0.tgz",
-            "integrity": "sha512-hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/@salesforce/cli/node_modules/wcwidth": {
             "version": "1.0.1",
@@ -28680,9 +25561,9 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/which-typed-array": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
-            "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+            "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
             "extraneous": true,
             "license": "MIT",
             "dependencies": {
@@ -28690,8 +25571,7 @@
                 "call-bind": "^1.0.2",
                 "for-each": "^0.3.3",
                 "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0",
-                "is-typed-array": "^1.1.10"
+                "has-tostringtag": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -28723,16 +25603,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/word-wrap": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
-            "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -28748,9 +25618,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@salesforce/cli/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+            "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -28759,10 +25629,7 @@
                 "strip-ansi": "^6.0.0"
             },
             "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+                "node": ">=8"
             }
         },
         "node_modules/@salesforce/cli/node_modules/wrap-ansi-cjs": {
@@ -28864,13 +25731,6 @@
             "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
             "dev": true,
             "license": "Apache-2.0"
-        },
-        "node_modules/@salesforce/cli/node_modules/xregexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-            "integrity": "sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==",
-            "extraneous": true,
-            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/xtend": {
             "version": "4.0.2",
@@ -29151,6 +26011,72 @@
                 "which": "^2.0.2"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/@npmcli/installed-package-contents": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz",
+            "integrity": "sha512-9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-bundled": "^1.1.1",
+                "npm-normalize-package-bin": "^1.0.1"
+            },
+            "bin": {
+                "installed-package-contents": "index.js"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/@npmcli/map-workspaces": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-2.0.4.tgz",
+            "integrity": "sha512-bMo0aAfwhVwqoVM5UzX1DJnlvVvzDCHae821jv48L1EsrYwfOZChlqWYXEtto/+BkBXetPbEWgau++/brh4oVg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/name-from-folder": "^1.0.1",
+                "glob": "^8.0.1",
+                "minimatch": "^5.0.1",
+                "read-package-json-fast": "^2.0.3"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/@npmcli/map-workspaces/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/@npmcli/metavuln-calculator": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-2.0.0.tgz",
@@ -29191,13 +26117,41 @@
             }
         },
         "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 10"
+                "node": ">= 6"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/bin-links": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-3.0.3.tgz",
+            "integrity": "sha512-zKdnMPWEdh4F5INR07/eBrodC7QrF5JKvqskjz/ZZRXg5YSAZIbn8zGhbhUrElzHBZ2fvEQdOU59RHcTG3GiwA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cmd-shim": "^5.0.0",
+                "mkdirp-infer-owner": "^2.0.0",
+                "npm-normalize-package-bin": "^2.0.0",
+                "read-cmd-shim": "^3.0.0",
+                "rimraf": "^3.0.0",
+                "write-file-atomic": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-2.0.0.tgz",
+            "integrity": "sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/buffer": {
@@ -29260,6 +26214,19 @@
             },
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/cmd-shim": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-5.0.0.tgz",
+            "integrity": "sha512-qkCtZ59BidfEwHltnJwkyVZn+XQojdAySM1D1gSeh11Z4pW1Kpolkyo53L5noc0nrxmIvyFwTmJRo4xs7FFLPw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "mkdirp-infer-owner": "^2.0.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/dateformat": {
@@ -29333,21 +26300,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/ignore-walk": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-4.0.1.tgz",
@@ -29360,6 +26312,13 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/locate-path": {
             "version": "6.0.0",
@@ -29599,16 +26558,6 @@
             },
             "engines": {
                 "node": ">= 10.12.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/node-gyp/node_modules/@tootallnate/once": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/node-gyp/node_modules/are-we-there-yet": {
@@ -29914,12 +26863,51 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16"
             }
         },
+        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/parse-conflict-json": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-2.0.2.tgz",
+            "integrity": "sha512-jDbRGb00TAPFsKWCpZZOT93SxVP9nONOSgES3AevqRq/CHvavEBvKAjxX9p5Y5F0RZLxH9Ufd9+RwtCsa+lFDA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "json-parse-even-better-errors": "^2.3.1",
+                "just-diff": "^5.0.1",
+                "just-diff-apply": "^5.2.0"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
         "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/proc-log": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-1.0.0.tgz",
             "integrity": "sha512-aCk8AO51s+4JyuYGg3Q/a6gnrlDO09NpVWePtjp7xwphcoQ04x5WAfCyugcsbLooWcMJ87CLkD4+604IckEdhg==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/read-cmd-shim": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-3.0.1.tgz",
+            "integrity": "sha512-kEmDUoYf/CDy8yZbLTmhB1X9kkjf9Q80PCNsDMb7ufrGd6zZSQA1+UyjrO+pZm5K/S4OXCWJeiIt1JA8kAsa6g==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/read-package-json-fast": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.3.tgz",
+            "integrity": "sha512-W/BKtbL+dUjTuRL2vziuYhp76s5HZ9qQhd/dKfWIZveD0O40453QNyZhC0e63lqZrAQ4jiOapVoeJ7JrszenQQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "json-parse-even-better-errors": "^2.3.0",
+                "npm-normalize-package-bin": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/readable-stream": {
             "version": "4.4.2",
@@ -29936,21 +26924,6 @@
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/socks-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^6.0.2",
-                "debug": "^4.3.3",
-                "socks": "^2.6.2"
-            },
-            "engines": {
-                "node": ">= 10"
             }
         },
         "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/ssri": {
@@ -30001,6 +26974,27 @@
             "license": "ISC",
             "dependencies": {
                 "builtins": "^1.0.3"
+            }
+        },
+        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/walk-up-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-1.0.0.tgz",
+            "integrity": "sha512-hwj/qMDUEjCU5h0xr90KGCf0tg0/LgJbmOWgrWKYlcJZM7XvquvUJZ0G/HMGr7F7OQMOUuPHWP9JpriinkAlkg==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/@salesforce/cli/node_modules/yeoman-environment/node_modules/write-file-atomic": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+            "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.7"
+            },
+            "engines": {
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/yeoman-generator": {
@@ -30059,209 +27053,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/yosay/-/yosay-2.0.2.tgz",
-            "integrity": "sha512-avX6nz2esp7IMXGag4gu6OyQBsMh/SEn+ZybGu3yKPlOTE6z9qJrzG/0X5vCq/e0rPFy0CUYCze0G5hL310ibA==",
-            "extraneous": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "ansi-regex": "^2.0.0",
-                "ansi-styles": "^3.0.0",
-                "chalk": "^1.0.0",
-                "cli-boxes": "^1.0.0",
-                "pad-component": "0.0.1",
-                "string-width": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "taketalk": "^1.0.0",
-                "wrap-ansi": "^2.0.0"
-            },
-            "bin": {
-                "yosay": "cli.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/chalk": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/chalk/node_modules/ansi-styles": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "extraneous": true,
-            "license": "MIT"
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/is-fullwidth-code-point": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/string-width": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/string-width/node_modules/ansi-regex": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-            "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/string-width/node_modules/strip-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-            "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/supports-color": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-            "extraneous": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/wrap-ansi": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-            "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@salesforce/cli/node_modules/yosay/node_modules/wrap-ansi/node_modules/string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/@salesforce/cli/node_modules/zip-stream": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.11.5",
+    "version": "4.11.6",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
         "@ljharb/eslint-config": "latest",
         "@lwc/eslint-plugin-lwc": "latest",
         "@prettier/plugin-xml": "latest",
-        "@salesforce/cli": "^2.0.0",
+        "@salesforce/cli": "^2.9.8",
         "@salesforce/eslint-config-lwc": "latest",
         "@salesforce/eslint-plugin-lightning": "latest",
         "@salesforce/sfdx-lwc-jest": "^1.3.0",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -153,6 +153,7 @@
         "Nebula Logger - Core@4.11.3-bugfix-for-unhandled-email-exception": "04t5Y000001HZd0QAG",
         "Nebula Logger - Core@4.11.4-removed-chatter-dependencies": "04t5Y000001HZdPQAW",
         "Nebula Logger - Core@4.11.5-custom-index-for-log-retention-date": "04t5Y000001HZdZQAW",
+        "Nebula Logger - Core@4.11.6-new-method-logger.setasynccontext()": "04t5Y000001HZfGQAW",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -13,9 +13,9 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.11.5.NEXT",
-            "versionName": "Custom Index for Log Retention Date",
-            "versionDescription": "Added a custom index to Log__c.LogRetentionDate__c to help speed up the job LogBatchPurger in orgs with large data volumes (LDV)",
+            "versionNumber": "4.11.6.NEXT",
+            "versionName": "New Method Logger.setAsyncContext()",
+            "versionDescription": "Added a method Logger.setAsyncContext + new fields on LogEntryEvent__e and Log__c to track the current transacation's async context",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"


### PR DESCRIPTION
### Core Unlocked Package Changes

- Added new global method (and overloads) `Logger.setAsyncContext()`. There are 4 overloads
   ```apex
    void setAsyncContext(Database.BatchableContext batchableContext) {}
    void setAsyncContext(System.FinalizerContext finalizerContext) {}
    void setAsyncContext(System.QueueableContext queueableContext) {}
    void setAsyncContext(System.SchedulableContext schedulableContext) {}
    ```
- Added new fields on `LogEntryEvent__e` and `Log__c`
  | New Fields | Description |
  | ----------- | ----------- |
  |`LogEntryEvent__e.AsyncContextType__c` and `Log__c.AsyncContextType__c` | The interface of the platform-provided context. Current values are `Database.BatchableContext`, `System.FinalizerContext`, `System.QueueableContext`, and `System.SchedulableContext`. |
  |`LogEntryEvent__e.AsyncContextParentJobId__c` and `Log__c.AsyncContextParentJobId__c` | The ID of the parent job (`Schema.AsyncApexJob`) that initiated the async transaction. Used for `Database.Batchable`, `System.FinalizerContext`, and `System.QueueableContext`. |
  |`LogEntryEvent__e.AsyncContextChildJobId__c` and `Log__c.AsyncContextChildJobId__c` | The ID of the child job (`Schema.AsyncApexJob`) that initiated the async transaction. Used for `Database.Batchable`. |
  |`LogEntryEvent__e.AsyncContextTriggerId__c` and `Log__c.AsyncContextTriggerId__c` | The ID of the cron trigger (`Schema.CronTrigger`) that initiated the async transaction. |
- Updated FlexiPage `LogRecordPage` to conditionally show a new page section, "Async Context Details", which _also_ conditionally shows the 4 new fields

![image](https://github.com/jongpie/NebulaLogger/assets/1267157/9d5617fa-a105-4782-93b4-b8c6aaea8d16)

- Updated several async classes to leverage the new method `Logger.setAsyncContext()`
- Eliminated the helper method `LoggerMockDataCreator.createBatchableContext()` - the underlying mock batchable context class, as well as some new similar mocks for `Finalizer`, `Queueable, and `Schedulable`, are now public and can be instantiated directly
  - Having the extra static methods was adding a lot of unnecessary complication & redundant code to expose static methods for each constructor

### Pipeline Changes

- Upgraded `sf` cli (again) to try to resolve some packaging issues in the pipeline (again)