### PR TITLE
Store HttpResponse header values

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.11.8
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZfaQAG)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZfaQAG)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001Oig9QAC)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001Oig9QAC)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001HZfaQAG`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001Oig9QAC`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001HZfaQAG`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001Oig9QAC`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.11.7
+## Unlocked Package - v4.11.8
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZfaQAG)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001HZfaQAG)

--- a/config/experience-cloud/classes/MyProfilePageControllerTest.cls
+++ b/config/experience-cloud/classes/MyProfilePageControllerTest.cls
@@ -19,7 +19,7 @@ public with sharing class MyProfilePageControllerTest {
             // System.Assert.areEqual(currentUser.Id, controller.getUser().Id, 'Did not successfully load the current user');
             // System.Assert.isTrue(controller.getIsEdit() == false, 'isEdit should default to false');
             controller.edit();
-            // System.Assert.isTrue(controller.getIsEdit() == true);
+            // System.Assert.isTrue(controller.getIsEdit());
             controller.cancel();
             // System.Assert.isTrue(controller.getIsEdit() == false);
 
@@ -41,7 +41,7 @@ public with sharing class MyProfilePageControllerTest {
                 // System.Assert.areEqual(existingPortalUser.Id, controller.getUser().Id, 'Did not successfully load the current user');
                 // System.Assert.isTrue(controller.getIsEdit() == false, 'isEdit should default to false');
                 controller.edit();
-                // System.Assert.isTrue(controller.getIsEdit() == true);
+                // System.Assert.isTrue(controller.getIsEdit());
 
                 controller.cancel();
                 // System.Assert.isTrue(controller.getIsEdit() == false);

--- a/docs/apex/Configuration/LoggerParameter.md
+++ b/docs/apex/Configuration/LoggerParameter.md
@@ -90,6 +90,10 @@ Indicates if Nebula Logger queries `User` data is queried synchronously &amp; po
 
 Indicates if Nebula Logger will send an error email notification if any internal exceptions occur. Controlled by the custom metadata record `LoggerParameter.SendErrorEmailNotifications`, or `true` as the default
 
+#### `STORE_HTTP_RESPONSE_HEADER_VALUES` → `Boolean`
+
+Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpResponse`. Controlled by the custom metadata record `LoggerParameter.StoreHttpResponseHeaderValues`, or `true` as the default. Regardless of how this parameter is configured, Nebula Logger will still log the header keys of any instance of `System.HttpResponse` that is logged - this parameter only controls if the header values are stored.
+
 #### `SYSTEM_DEBUG_MESSAGE_FORMAT` → `String`
 
 The merge-field syntax to use when calling System.debug(). Controlled by the custom metadata record `LoggerParameter.SystebugMessageFormat`, or `{OriginLocation__c}\n{Message__c}` as the default

--- a/docs/apex/Configuration/LoggerPlugin.md
+++ b/docs/apex/Configuration/LoggerPlugin.md
@@ -43,7 +43,7 @@ The list of matching `LoggerPlugin_t` records
 
 #### `getPluginConfigurations()` → `List<LoggerPlugin_t>`
 
-Returns all enabled `LoggerPlugin_t` records, based on `IsEnabled__c == true`
+Returns all enabled `LoggerPlugin_t` records (where `IsEnabled__c` is set to `true`)
 
 ##### Return
 

--- a/docs/apex/Logger-Engine/FlowLogger.md
+++ b/docs/apex/Logger-Engine/FlowLogger.md
@@ -76,7 +76,7 @@ Boolean used to determine if logs are saved to Salesforce
 
 ###### `saveMethodName` → `String`
 
-String name of the instance of Logger.SaveMethod to use when &apos;Save Log&apos; == true
+String name of the instance of Logger.SaveMethod to use when &apos;Save Log&apos; is set to `true`
 
 ###### `scenario` → `String`
 

--- a/docs/apex/Logger-Engine/Logger.md
+++ b/docs/apex/Logger-Engine/Logger.md
@@ -4738,7 +4738,7 @@ Boolean
 
 #### `newEntry(System.LoggingLevel loggingLevel, LogMessage logMessage, Boolean shouldSave)` → `LogEntryEventBuilder`
 
-Adds a new instance of LogEntryEventBuilder to Logger&apos;s buffer, if shouldSave == true
+Adds a new instance of LogEntryEventBuilder to Logger&apos;s buffer, when `shouldSave` is `true`
 
 ##### Parameters
 

--- a/docs/apex/Test-Utilities/LoggerMockDataCreator.md
+++ b/docs/apex/Test-Utilities/LoggerMockDataCreator.md
@@ -76,9 +76,9 @@ Creates a mock instance of `Database.DeleteResult` - a mock is used instead of a
 
 ##### Parameters
 
-| Param       | Description                                                     |
-| ----------- | --------------------------------------------------------------- |
-| `isSuccess` | Indicates if the generated mock should have `isSuccess` == true |
+| Param       | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `isSuccess` | Indicates if the generated mock should have `isSuccess` |
 
 ##### Return
 
@@ -96,10 +96,10 @@ Creates a mock instance of `Database.DeleteResult` - a mock is used instead of a
 
 ##### Parameters
 
-| Param       | Description                                                     |
-| ----------- | --------------------------------------------------------------- |
-| `isSuccess` | Indicates if the generated mock should have `isSuccess` == true |
-| `recordId`  | The record ID to use within the mock result                     |
+| Param       | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `isSuccess` | Indicates if the generated mock should have `isSuccess` |
+| `recordId`  | The record ID to use within the mock result             |
 
 ##### Return
 
@@ -117,9 +117,9 @@ Creates a mock instance of `Database.LeadConvertResult` - a mock is used instead
 
 ##### Parameters
 
-| Param       | Description                                                     |
-| ----------- | --------------------------------------------------------------- |
-| `isSuccess` | Indicates if the generated mock should have `isSuccess` == true |
+| Param       | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `isSuccess` | Indicates if the generated mock should have `isSuccess` |
 
 ##### Return
 
@@ -137,10 +137,10 @@ Creates a mock instance of `Database.LeadConvertResult` - a mock is used instead
 
 ##### Parameters
 
-| Param       | Description                                                     |
-| ----------- | --------------------------------------------------------------- |
-| `isSuccess` | Indicates if the generated mock should have `isSuccess` == true |
-| `recordId`  | The record ID to use within the mock result                     |
+| Param       | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `isSuccess` | Indicates if the generated mock should have `isSuccess` |
+| `recordId`  | The record ID to use within the mock result             |
 
 ##### Return
 
@@ -158,9 +158,9 @@ Creates a mock instance of `Database.MergeResult` - a mock is used instead of an
 
 ##### Parameters
 
-| Param       | Description                                                     |
-| ----------- | --------------------------------------------------------------- |
-| `isSuccess` | Indicates if the generated mock should have `isSuccess` == true |
+| Param       | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `isSuccess` | Indicates if the generated mock should have `isSuccess` |
 
 ##### Return
 
@@ -178,10 +178,10 @@ Creates a mock instance of `Database.MergeResult` - a mock is used instead of an
 
 ##### Parameters
 
-| Param       | Description                                                     |
-| ----------- | --------------------------------------------------------------- |
-| `isSuccess` | Indicates if the generated mock should have `isSuccess` == true |
-| `recordId`  | The record ID to use within the mock result                     |
+| Param       | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `isSuccess` | Indicates if the generated mock should have `isSuccess` |
+| `recordId`  | The record ID to use within the mock result             |
 
 ##### Return
 
@@ -199,9 +199,9 @@ Creates a mock instance of `Database.SaveResult` - a mock is used instead of an 
 
 ##### Parameters
 
-| Param       | Description                                                     |
-| ----------- | --------------------------------------------------------------- |
-| `isSuccess` | Indicates if the generated mock should have `isSuccess` == true |
+| Param       | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `isSuccess` | Indicates if the generated mock should have `isSuccess` |
 
 ##### Return
 
@@ -219,10 +219,10 @@ Creates a mock instance of `Database.SaveResult` - a mock is used instead of an 
 
 ##### Parameters
 
-| Param       | Description                                                     |
-| ----------- | --------------------------------------------------------------- |
-| `isSuccess` | Indicates if the generated mock should have `isSuccess` == true |
-| `recordId`  | The record ID to use within the mock result                     |
+| Param       | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `isSuccess` | Indicates if the generated mock should have `isSuccess` |
+| `recordId`  | The record ID to use within the mock result             |
 
 ##### Return
 
@@ -240,9 +240,9 @@ Creates a mock instance of `Database.UndeleteResult` - a mock is used instead of
 
 ##### Parameters
 
-| Param       | Description                                                     |
-| ----------- | --------------------------------------------------------------- |
-| `isSuccess` | Indicates if the generated mock should have `isSuccess` == true |
+| Param       | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `isSuccess` | Indicates if the generated mock should have `isSuccess` |
 
 ##### Return
 
@@ -260,10 +260,10 @@ Creates a mock instance of `Database.UndeleteResult` - a mock is used instead of
 
 ##### Parameters
 
-| Param       | Description                                                     |
-| ----------- | --------------------------------------------------------------- |
-| `isSuccess` | Indicates if the generated mock should have `isSuccess` == true |
-| `recordId`  | The record ID to use within the mock result                     |
+| Param       | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `isSuccess` | Indicates if the generated mock should have `isSuccess` |
+| `recordId`  | The record ID to use within the mock result             |
 
 ##### Return
 
@@ -281,10 +281,10 @@ Creates a mock instance of `Database.UpsertResult` - a mock is used instead of a
 
 ##### Parameters
 
-| Param       | Description                                                     |
-| ----------- | --------------------------------------------------------------- |
-| `isSuccess` | Indicates if the generated mock should have `isSuccess` == true |
-| `isCreated` | Indicates if the generated mock should have `isCreated` == true |
+| Param       | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `isSuccess` | Indicates if the generated mock should have `isSuccess` |
+| `isCreated` | Indicates if the generated mock should have `isCreated` |
 
 ##### Return
 
@@ -302,11 +302,11 @@ Creates a mock instance of `Database.UpsertResult` - a mock is used instead of a
 
 ##### Parameters
 
-| Param       | Description                                                     |
-| ----------- | --------------------------------------------------------------- |
-| `isSuccess` | Indicates if the generated mock should have `isSuccess` == true |
-| `isCreated` | Indicates if the generated mock should have `isCreated` == true |
-| `recordId`  | The record ID to use within the mock result                     |
+| Param       | Description                                             |
+| ----------- | ------------------------------------------------------- |
+| `isSuccess` | Indicates if the generated mock should have `isSuccess` |
+| `isCreated` | Indicates if the generated mock should have `isCreated` |
+| `recordId`  | The record ID to use within the mock result             |
 
 ##### Return
 

--- a/docs/apex/Test-Utilities/LoggerMockDataCreator.md
+++ b/docs/apex/Test-Utilities/LoggerMockDataCreator.md
@@ -550,6 +550,8 @@ A new copy of the original `SObject` record that has the specified read-only fie
 
 ##### Constructors
 
+###### `MockBatchableContext()`
+
 ###### `MockBatchableContext(Id jobId)`
 
 ###### `MockBatchableContext(Id jobId, Id childJobId)`
@@ -569,6 +571,8 @@ A new copy of the original `SObject` record that has the specified read-only fie
 ---
 
 ##### Constructors
+
+###### `MockFinalizerContext()`
 
 ###### `MockFinalizerContext(Id asyncApexJobId)`
 
@@ -628,6 +632,8 @@ A new copy of the original `SObject` record that has the specified read-only fie
 
 ##### Constructors
 
+###### `MockQueueableContext()`
+
 ###### `MockQueueableContext(Id jobId)`
 
 ---
@@ -643,6 +649,8 @@ A new copy of the original `SObject` record that has the specified read-only fie
 ---
 
 ##### Constructors
+
+###### `MockSchedulableContext()`
 
 ###### `MockSchedulableContext(Id triggerId)`
 

--- a/docs/apex/Test-Utilities/LoggerTestConfigurator.md
+++ b/docs/apex/Test-Utilities/LoggerTestConfigurator.md
@@ -148,11 +148,11 @@ Loads the mock `LogStatus_t` during test execution
 
 #### `setupMockSObjectHandlerConfigurations()` → `void`
 
-Creates mock instances of `LoggerSObjectHandler_t` for each `SObjectType` used by Nebula Logger, with each `LoggerSObjectHandler_t` automatically set to `IsEnabled__c == true`
+Creates mock instances of `LoggerSObjectHandler_t` for each `SObjectType` used by Nebula Logger, with `IsEnabled__c` set to `true` on each `LoggerSObjectHandler_t` record
 
 #### `setupMockSObjectHandlerConfigurations(Boolean isEnabled)` → `void`
 
-Creates mock instances of `LoggerSObjectHandler_t` for each `SObjectType` used by Nebula Logger, with each `LoggerSObjectHandler_t` enabled/disabled based on the provided boolean
+Creates mock instances of `LoggerSObjectHandler_t` for each `SObjectType` used by Nebula Logger, with `IsEnabled__c` set based on the provided boolean on each `LoggerSObjectHandler_t` record
 
 ##### Parameters
 

--- a/nebula-logger/core/main/configuration/classes/LoggerCache.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerCache.cls
@@ -220,7 +220,7 @@ public without sharing class LoggerCache {
         public void put(String key, Object value) {
             this.transactionCache.put(key, value);
 
-            if (LoggerParameter.USE_PLATFORM_CACHE == true && this.cachePartitionDelegate.isAvailable() == true) {
+            if (LoggerParameter.USE_PLATFORM_CACHE && this.cachePartitionDelegate.isAvailable()) {
                 // Platform cache does not support storing null values, so a predefined value is used as a substitute
                 if (value == null) {
                     value = PLATFORM_CACHE_NULL_VALUE;
@@ -232,7 +232,7 @@ public without sharing class LoggerCache {
         public void remove(String key) {
             this.transactionCache.remove(key);
 
-            if (LoggerParameter.USE_PLATFORM_CACHE == true && this.cachePartitionDelegate.isAvailable() == true) {
+            if (LoggerParameter.USE_PLATFORM_CACHE && this.cachePartitionDelegate.isAvailable()) {
                 this.cachePartitionDelegate.remove(key);
             }
         }

--- a/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
@@ -647,7 +647,7 @@ public class LoggerParameter {
     public static List<LoggerParameter__mdt> matchOnPrefix(String developerNamePrefix) {
         List<LoggerParameter__mdt> matchingParameters = new List<LoggerParameter__mdt>();
         for (String parameterDeveloperName : DEVELOPER_NAME_TO_RECORD.keySet()) {
-            if (parameterDeveloperName.startsWith(developerNamePrefix) == true) {
+            if (parameterDeveloperName.startsWith(developerNamePrefix)) {
                 matchingParameters.add(DEVELOPER_NAME_TO_RECORD.get(parameterDeveloperName));
             }
         }
@@ -656,13 +656,13 @@ public class LoggerParameter {
 
     private static Map<String, LoggerParameter__mdt> loadRecords() {
         Map<String, LoggerParameter__mdt> parameters = LoggerParameter__mdt.getAll().clone();
-        if (System.Test.isRunningTest() == true) {
+        if (System.Test.isRunningTest()) {
             // Keep a copy of any records that *should* be loaded during tests
             // Currently, only the record `SystemDebugMessageFormat` has a use case for this functionality,
             // but others can be easily added if other use cases are found
             Map<String, LoggerParameter__mdt> parametersToLoadDuringTests = new Map<String, LoggerParameter__mdt>();
             for (String testContextParameterName : PARAMETERS_TO_LOAD_DURING_TESTS) {
-                if (parameters.containsKey(testContextParameterName) == true) {
+                if (parameters.containsKey(testContextParameterName)) {
                     parametersToLoadDuringTests.put(testContextParameterName, parameters.get(testContextParameterName));
                 }
             }
@@ -674,7 +674,7 @@ public class LoggerParameter {
 
     @TestVisible
     private static void setMock(LoggerParameter__mdt parameter) {
-        if (String.isBlank(parameter.DeveloperName) == true) {
+        if (String.isBlank(parameter.DeveloperName)) {
             throw new System.IllegalArgumentException('DeveloperName is required on `LoggerParameter__mdt: \n' + JSON.serializePretty(parameter));
         }
 

--- a/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
@@ -318,6 +318,22 @@ public class LoggerParameter {
     }
 
     /**
+     * @description Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpResponse`.
+     *              Controlled by the custom metadata record `LoggerParameter.StoreHttpResponseHeaderValues`, or `true` as the default.
+     *              Regardless of how this parameter is configured, Nebula Logger will still log the header keys of any instance of
+     *              `System.HttpResponse` that is logged - this parameter only controls if the header values are stored.
+     */
+    public static final Boolean STORE_HTTP_RESPONSE_HEADER_VALUES {
+        get {
+            if (STORE_HTTP_RESPONSE_HEADER_VALUES == null) {
+                STORE_HTTP_RESPONSE_HEADER_VALUES = getBoolean('StoreHttpResponseHeaderValues', true);
+            }
+            return STORE_HTTP_RESPONSE_HEADER_VALUES;
+        }
+        private set;
+    }
+
+    /**
      * @description The merge-field syntax to use when calling System.debug().
      *              Controlled by the custom metadata record `LoggerParameter.SystemDebugMessageFormat`, or `{OriginLocation__c}\n{Message__c}` as the default
      */

--- a/nebula-logger/core/main/configuration/classes/LoggerPlugin.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerPlugin.cls
@@ -30,7 +30,7 @@ public without sharing class LoggerPlugin {
     }
 
     /**
-     * @description Returns all enabled `LoggerPlugin__mdt` records, based on `IsEnabled__c == true`
+     * @description Returns all enabled `LoggerPlugin__mdt` records (where `IsEnabled__c` is set to `true`)
      * @return      The list of enabled `LoggerPlugin__mdt` records
      */
     public static List<LoggerPlugin__mdt> getPluginConfigurations() {
@@ -54,7 +54,7 @@ public without sharing class LoggerPlugin {
                     break;
                 }
             }
-            if (matchesFilterFields == true) {
+            if (matchesFilterFields) {
                 matchingPluginConfigurationSorters.add(
                     new PluginConfigurationSorter(pluginConfiguration).sortBy(sortByField).sortBy(Schema.LoggerPlugin__mdt.DeveloperName)
                 );
@@ -105,11 +105,11 @@ public without sharing class LoggerPlugin {
     private static Map<String, LoggerPlugin__mdt> loadEnabledRecords() {
         Map<String, LoggerPlugin__mdt> pluginDeveloperNameToConfiguration = new Map<String, LoggerPlugin__mdt>();
         for (LoggerPlugin__mdt pluginConfiguration : LoggerPlugin__mdt.getAll().values()) {
-            if (pluginConfiguration.IsEnabled__c == true) {
+            if (pluginConfiguration.IsEnabled__c) {
                 pluginDeveloperNameToConfiguration.put(pluginConfiguration.DeveloperName, pluginConfiguration);
             }
         }
-        if (System.Test.isRunningTest() == true) {
+        if (System.Test.isRunningTest()) {
             pluginDeveloperNameToConfiguration.clear();
         }
         return pluginDeveloperNameToConfiguration;
@@ -117,10 +117,10 @@ public without sharing class LoggerPlugin {
 
     @TestVisible
     private static void setMock(LoggerPlugin__mdt pluginConfiguration) {
-        if (String.isBlank(pluginConfiguration.DeveloperName) == true) {
+        if (String.isBlank(pluginConfiguration.DeveloperName)) {
             throw new System.IllegalArgumentException('DeveloperName is required on mock LoggerPlugin__mdt: \n' + JSON.serializePretty(pluginConfiguration));
         }
-        if (pluginConfiguration.IsEnabled__c == true) {
+        if (pluginConfiguration.IsEnabled__c) {
             DEVELOPER_NAME_TO_RECORD.put(pluginConfiguration.DeveloperName, pluginConfiguration);
         }
     }
@@ -154,7 +154,7 @@ public without sharing class LoggerPlugin {
                 // Now, the actual comparisons
                 if (this.pluginConfiguration.get(field) == that.pluginConfiguration.get(field)) {
                     continue;
-                } else if (this.pluginConfiguration.get(field) == null && that.pluginConfiguration.get(field) != null || thisIsGreaterThanThat == true) {
+                } else if (this.pluginConfiguration.get(field) == null && that.pluginConfiguration.get(field) != null || thisIsGreaterThanThat) {
                     return 1;
                 } else {
                     return -1;

--- a/nebula-logger/core/main/configuration/classes/LoggerScenarioRule.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerScenarioRule.cls
@@ -33,11 +33,11 @@ public without sharing class LoggerScenarioRule {
 
     @TestVisible
     private static void setMock(LoggerScenarioRule__mdt scenarioRule) {
-        if (String.isBlank(scenarioRule.Scenario__c) == true) {
+        if (String.isBlank(scenarioRule.Scenario__c)) {
             throw new System.IllegalArgumentException('Scenario__c is required on `LoggerScenarioRule__mdt: \n' + JSON.serializePretty(scenarioRule));
         }
 
-        if (isValid(scenarioRule) == true) {
+        if (isValid(scenarioRule)) {
             SCENARIO_NAME_TO_SCENARIO_RULE.put(scenarioRule.Scenario__c, scenarioRule);
         }
     }
@@ -45,12 +45,12 @@ public without sharing class LoggerScenarioRule {
     private static Map<String, LoggerScenarioRule__mdt> loadLogScenarioRules() {
         Map<String, LoggerScenarioRule__mdt> scenarioRules = new Map<String, LoggerScenarioRule__mdt>();
         for (LoggerScenarioRule__mdt scenarioRule : LoggerScenarioRule__mdt.getAll().values()) {
-            if (isValid(scenarioRule) == true) {
+            if (isValid(scenarioRule)) {
                 scenarioRules.put(scenarioRule.Scenario__c, scenarioRule);
             }
         }
 
-        if (System.Test.isRunningTest() == true) {
+        if (System.Test.isRunningTest()) {
             scenarioRules.clear();
         }
 
@@ -59,12 +59,12 @@ public without sharing class LoggerScenarioRule {
 
     private static Boolean isValid(LoggerScenarioRule__mdt scenarioRule) {
         Boolean isValid = false;
-        if (scenarioRule.IsEnabled__c == true) {
+        if (scenarioRule.IsEnabled__c) {
             Datetime currentTime = System.now();
             Boolean startTimeIsValid = scenarioRule.StartTime__c == null || scenarioRule.StartTime__c <= currentTime;
             Boolean endTimeIsValid = scenarioRule.EndTime__c == null || scenarioRule.EndTime__c >= currentTime;
 
-            isValid = startTimeIsValid == true && endTimeIsValid == true;
+            isValid = startTimeIsValid && endTimeIsValid;
         }
         return isValid;
     }

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreHttpResponseHeaderValues.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreHttpResponseHeaderValues.md-meta.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomMetadata
+    xmlns="http://soap.sforce.com/2006/04/metadata"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+>
+    <label>Store Http Response Header Values</label>
+    <protected>false</protected>
+    <values>
+        <field>Description__c</field>
+        <value
+            xsi:type="xsd:string"
+        >When set to &apos;true&apos; (default), Nebula Logger will store the header values of any instance of an HttpResponse that is logged using the instance method LogEntryEventBuilder.setHttpResponseDetails().
+
+When set to &apos;false&apos;, the header values are not stored or referenced by Nebula Logger.
+
+Regardless of how this parameter is configured, Nebula Logger will still log the header keys of any instance of an HttpResponse that is logged - this parameter only controls if the header values are stored.</value>
+    </values>
+    <values>
+        <field>Value__c</field>
+        <value xsi:type="xsd:string">true</value>
+    </values>
+</CustomMetadata>

--- a/nebula-logger/core/main/log-management/classes/LogBatchPurgeController.cls
+++ b/nebula-logger/core/main/log-management/classes/LogBatchPurgeController.cls
@@ -23,8 +23,7 @@ public with sharing class LogBatchPurgeController {
      */
     @AuraEnabled
     public static Boolean canUserRunLogBatchPurger() {
-        return Schema.Log__c.SObjectType.getDescribe().isDeletable() == true ||
-            System.FeatureManagement.checkPermission(CAN_EXECUTE_LOG_BATCH_PURGER_PERMISSION) == true;
+        return Schema.Log__c.SObjectType.getDescribe().isDeletable() || System.FeatureManagement.checkPermission(CAN_EXECUTE_LOG_BATCH_PURGER_PERMISSION);
     }
 
     /**

--- a/nebula-logger/core/main/log-management/classes/LogBatchPurgeScheduler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogBatchPurgeScheduler.cls
@@ -38,7 +38,7 @@ global with sharing class LogBatchPurgeScheduler implements System.Schedulable {
      */
     global void execute(System.SchedulableContext schedulableContext) {
         Logger.setAsyncContext(schedulableContext);
-        if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+        if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
             LogMessage logMessage = new LogMessage(SCHEDULER_SYSTEM_MESSAGE_TEMPLATE, schedulableContext);
             Logger.info(logMessage);
             Logger.saveLog();

--- a/nebula-logger/core/main/log-management/classes/LogBatchPurger.cls
+++ b/nebula-logger/core/main/log-management/classes/LogBatchPurger.cls
@@ -52,7 +52,7 @@ global with sharing class LogBatchPurger implements Database.Batchable<SObject>,
             Schema.LoggerPlugin__mdt.BatchPurgerExecutionOrder__c
         );
 
-        if (System.Test.isRunningTest() == true) {
+        if (System.Test.isRunningTest()) {
             for (BatchableMethod method : BatchableMethod.values()) {
                 this.methodToExecutedApexPlugins.put(method, new List<LoggerPlugin.Batchable>());
                 this.methodToExecutedFlowPlugins.put(method, new List<Flow.Interview>());
@@ -85,7 +85,7 @@ global with sharing class LogBatchPurger implements Database.Batchable<SObject>,
         this.executePlugins(BatchableMethod.START, input, null);
         this.currentSObjectType = input.sobjectType;
 
-        if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+        if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
             Logger.info('Logger - Starting LogBatchPurger job for SObject type: ' + this.currentSObjectType);
         }
         Logger.saveLog();
@@ -123,7 +123,7 @@ global with sharing class LogBatchPurger implements Database.Batchable<SObject>,
             LoggerDataStore.getDatabase().hardDeleteRecords(scopeRecords);
             Logger.saveLog();
         } catch (System.Exception apexException) {
-            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
                 Logger.error('Logger - Error deleting logs', apexException);
             }
             Logger.saveLog();
@@ -147,7 +147,7 @@ global with sharing class LogBatchPurger implements Database.Batchable<SObject>,
             nextBatchJobId = Database.executeBatch(this, this.chainedBatchSize);
         }
 
-        if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+        if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
             Logger.info(
                 new LogMessage(
                     'Logger - Finished LogBatchPurger job for {0}, {1} total log records processed',
@@ -251,17 +251,17 @@ global with sharing class LogBatchPurger implements Database.Batchable<SObject>,
 
     private void executePlugins(BatchableMethod method, LoggerBatchableContext input, List<SObject> scopeRecords) {
         for (LoggerPlugin__mdt pluginConfiguration : this.pluginConfigurations) {
-            if (String.isNotBlank(pluginConfiguration.BatchPurgerApexClass__c) == true) {
+            if (String.isNotBlank(pluginConfiguration.BatchPurgerApexClass__c)) {
                 this.executeApexPlugin(method, pluginConfiguration, input, scopeRecords);
             }
-            if (String.isNotBlank(pluginConfiguration.BatchPurgerFlowName__c) == true) {
+            if (String.isNotBlank(pluginConfiguration.BatchPurgerFlowName__c)) {
                 this.executeFlowPlugin(method, pluginConfiguration, input, scopeRecords);
             }
         }
     }
 
     private void executeApexPlugin(BatchableMethod method, LoggerPlugin__mdt pluginConfiguration, LoggerBatchableContext input, List<SObject> scopeRecords) {
-        if (String.isBlank(pluginConfiguration.BatchPurgerApexClass__c) == true) {
+        if (String.isBlank(pluginConfiguration.BatchPurgerApexClass__c)) {
             return;
         }
 
@@ -279,18 +279,18 @@ global with sharing class LogBatchPurger implements Database.Batchable<SObject>,
                 }
             }
 
-            if (System.Test.isRunningTest() == true && apexPlugin != null) {
+            if (System.Test.isRunningTest() && apexPlugin != null) {
                 this.methodToExecutedApexPlugins.get(method).add(apexPlugin);
             }
         } catch (TypeException ex) {
-            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
                 Logger.warn('Unknown Apex class ' + pluginConfiguration.BatchPurgerApexClass__c + ', skipping plugin execution', pluginConfiguration, ex);
             }
         }
     }
 
     private void executeFlowPlugin(BatchableMethod method, LoggerPlugin__mdt pluginConfiguration, LoggerBatchableContext input, List<SObject> scopeRecords) {
-        if (String.isBlank(pluginConfiguration.BatchPurgerFlowName__c) == true) {
+        if (String.isBlank(pluginConfiguration.BatchPurgerFlowName__c)) {
             return;
         }
 
@@ -305,11 +305,11 @@ global with sharing class LogBatchPurger implements Database.Batchable<SObject>,
             Flow.Interview flowPlugin = Flow.Interview.createInterview(pluginConfiguration.BatchPurgerFlowName__c, flowInputs);
             flowPlugin.start();
 
-            if (System.Test.isRunningTest() == true && flowPlugin != null) {
+            if (System.Test.isRunningTest() && flowPlugin != null) {
                 this.methodToExecutedFlowPlugins.get(method).add(flowPlugin);
             }
         } catch (TypeException ex) {
-            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
                 Logger.warn('Unknown Flow ' + pluginConfiguration.BatchPurgerFlowName__c + ', skipping plugin execution', pluginConfiguration, ex);
             }
         }

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
@@ -72,7 +72,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
 
             // Apply logger scenario rules
             String platformEventStorageLocation = loggingUserSettings.DefaultPlatformEventStorageLocation__c;
-            if (logEntryEvent.TransactionScenario__c != null && LoggerScenarioRule.getAll().containsKey(logEntryEvent.TransactionScenario__c) == true) {
+            if (logEntryEvent.TransactionScenario__c != null && LoggerScenarioRule.getAll().containsKey(logEntryEvent.TransactionScenario__c)) {
                 LoggerScenarioRule__mdt scenarioRule = LoggerScenarioRule.getInstance(logEntryEvent.TransactionScenario__c);
                 if (scenarioRule.IsPlatformEventStorageLocationEnabled__c == trueString) {
                     platformEventStorageLocation = scenarioRule.PlatformEventStorageLocation__c;
@@ -82,7 +82,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
             if (platformEventStorageLocation == DEFAULT_STORAGE_LOCATION_NAME) {
                 // Then filter further based on storage logging level
                 String userStorageLoggingLevelName = loggingUserSettings.DefaultPlatformEventStorageLoggingLevel__c;
-                if (String.isBlank(userStorageLoggingLevelName) == true) {
+                if (String.isBlank(userStorageLoggingLevelName)) {
                     userStorageLoggingLevelName = loggingUserSettings.LoggingLevel__c;
                 }
                 System.LoggingLevel userStorageLoggingLevel = System.LoggingLevel.valueOf(userStorageLoggingLevelName);
@@ -104,9 +104,9 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
             for (Schema.SObjectField scenarioField : scenarioFields) {
                 String scenario = (String) logEntryEvent.get(scenarioField);
 
-                if (String.isBlank(scenario) == true || SCENARIO_UNIQUE_ID_TO_SCENARIO.containsKey(scenario)) {
+                if (String.isBlank(scenario) || SCENARIO_UNIQUE_ID_TO_SCENARIO.containsKey(scenario)) {
                     continue;
-                } else if (LoggerParameter.NORMALIZE_SCENARIO_DATA == true) {
+                } else if (LoggerParameter.NORMALIZE_SCENARIO_DATA) {
                     LoggerScenario__c loggerScenario = new LoggerScenario__c(Name = scenario, UniqueId__c = scenario);
                     loggerScenario.setOptions(DML_OPTIONS);
                     SCENARIO_UNIQUE_ID_TO_SCENARIO.put(loggerScenario.UniqueId__c, loggerScenario);
@@ -136,7 +136,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
         for (LogEntryEvent__e logEntryEvent : this.logEntryEvents) {
             // The LogEntryEvent__e object stores a denormalized version of Log__c & LogEntry__c data
             // In case the list contains entries tied to multiple transactions, use the TRANSACTION_ID_TO_LOG map to create 1 Log__c per transaction ID
-            if (TRANSACTION_ID_TO_LOG.containsKey(logEntryEvent.TransactionId__c) == true) {
+            if (TRANSACTION_ID_TO_LOG.containsKey(logEntryEvent.TransactionId__c)) {
                 continue;
             }
 
@@ -209,10 +209,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
                 log.TransactionScenarioName__c = logEntryEvent.TransactionScenario__c;
             }
 
-            if (
-                String.isNotBlank(logEntryEvent.TransactionScenario__c) == true &&
-                SCENARIO_UNIQUE_ID_TO_SCENARIO.containsKey(logEntryEvent.TransactionScenario__c) == true
-            ) {
+            if (String.isNotBlank(logEntryEvent.TransactionScenario__c) && SCENARIO_UNIQUE_ID_TO_SCENARIO.containsKey(logEntryEvent.TransactionScenario__c)) {
                 log.TransactionScenario__c = SCENARIO_UNIQUE_ID_TO_SCENARIO.get(logEntryEvent.TransactionScenario__c).Id;
             }
 
@@ -234,7 +231,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
         String apexClassName = LogEntryEventHandler.class.getName();
         List<String> jobStatuses = new List<String>{ 'Holding', 'Queued', 'Preparing', 'Processing' };
         if (
-            LoggerParameter.CALL_STATUS_API == true &&
+            LoggerParameter.CALL_STATUS_API &&
             recentLogWithApiReleaseDetails == null &&
             LogManagementDataSelector.getInstance().getCountOfAsyncApexJobs(apexClassName, null, jobStatuses) == 0
         ) {
@@ -248,7 +245,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
             // Use the string value of timestamp to set the actual datetime field as a workaround
             // See https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_events_api_considerations.htm
             Datetime timestamp = logEntryEvent.Timestamp__c;
-            if (String.isNotBlank(logEntryEvent.TimestampString__c) == true) {
+            if (String.isNotBlank(logEntryEvent.TimestampString__c)) {
                 timestamp = Datetime.valueOf(Long.valueOf(logEntryEvent.TimestampString__c));
             }
 
@@ -338,15 +335,15 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
                 UniqueId__c = logEntryEvent.TransactionId__c + '-' + logEntryEvent.TransactionEntryNumber__c
             );
 
-            if (String.isNotBlank(logEntryEvent.EntryScenario__c) == true) {
-                if (LoggerParameter.NORMALIZE_SCENARIO_DATA == true && SCENARIO_UNIQUE_ID_TO_SCENARIO.containsKey(logEntryEvent.EntryScenario__c) == true) {
+            if (String.isNotBlank(logEntryEvent.EntryScenario__c)) {
+                if (LoggerParameter.NORMALIZE_SCENARIO_DATA && SCENARIO_UNIQUE_ID_TO_SCENARIO.containsKey(logEntryEvent.EntryScenario__c)) {
                     logEntry.EntryScenario__c = SCENARIO_UNIQUE_ID_TO_SCENARIO.get(logEntryEvent.EntryScenario__c).Id;
                 } else {
                     logEntry.EntryScenarioName__c = logEntryEvent.EntryScenario__c;
                 }
             }
 
-            if (String.isNotBlank(logEntryEvent.Tags__c) == true && LoggerParameter.NORMALIZE_TAG_DATA == false) {
+            if (String.isNotBlank(logEntryEvent.Tags__c) && LoggerParameter.NORMALIZE_TAG_DATA == false) {
                 logEntry.Tags__c = logEntryEvent.Tags__c;
             }
 
@@ -365,17 +362,17 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
     }
 
     private void appendRuleBasedTags() {
-        if (LoggerParameter.ENABLE_TAGGING == false || TAG_ASSIGNMENT_RULES.isEmpty() == true) {
+        if (LoggerParameter.ENABLE_TAGGING == false || TAG_ASSIGNMENT_RULES.isEmpty()) {
             return;
         }
 
         for (LogEntry__c logEntry : this.logEntries) {
             for (LogEntryTagRule__mdt rule : TAG_ASSIGNMENT_RULES) {
-                if (isRuleCriteriaMet(logEntry, rule) == true) {
+                if (isRuleCriteriaMet(logEntry, rule)) {
                     List<String> configuredTagNames = getTagNames(rule.Tags__c);
                     this.tagNames.addAll(configuredTagNames);
                     List<String> logEntryTags = new List<String>();
-                    if (this.logEntryEventCompositeKeyToTagNames.containsKey(logEntry.UniqueId__c) == true) {
+                    if (this.logEntryEventCompositeKeyToTagNames.containsKey(logEntry.UniqueId__c)) {
                         logEntryTags = this.logEntryEventCompositeKeyToTagNames.get(logEntry.UniqueId__c);
                     }
 
@@ -392,12 +389,12 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
     }
 
     private void upsertLogEntryTags() {
-        if (LoggerParameter.ENABLE_TAGGING == false || LoggerParameter.NORMALIZE_TAG_DATA == false || this.tagNames.isEmpty() == true) {
+        if (LoggerParameter.ENABLE_TAGGING == false || LoggerParameter.NORMALIZE_TAG_DATA == false || this.tagNames.isEmpty()) {
             return;
         }
 
         // Orgs can be configured to either use LoggerTag__c & LogEntryTag__c (default), or use Topic & TopicAssignment
-        Schema.SObjectType tagSObjectType = LoggerParameter.USE_TOPICS_FOR_TAGS == true ? Topic.SObjectType : LoggerTag__c.SObjectType;
+        Schema.SObjectType tagSObjectType = LoggerParameter.USE_TOPICS_FOR_TAGS ? Topic.SObjectType : LoggerTag__c.SObjectType;
         Map<String, Id> tagNameToId = getTagNameToId(tagSObjectType);
         this.tagNames.addAll(tagNameToId.keySet());
 
@@ -412,7 +409,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
             List<String> logEntryTagNames = this.logEntryEventCompositeKeyToTagNames.get(logEntry.UniqueId__c);
 
             for (String tagName : logEntryTagNames) {
-                if (LoggerParameter.USE_TOPICS_FOR_TAGS == true) {
+                if (LoggerParameter.USE_TOPICS_FOR_TAGS) {
                     // Add TopicAssignment records for both the LogEntry__c & the parent Log__c
                     tagAssignmentSObjectType = Schema.TopicAssignment.SObjectType;
                     tagAssignments.add(new TopicAssignment(EntityId = logEntry.Id, TopicId = tagNameToId.get(tagName)));
@@ -448,15 +445,15 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
         Id logOwnerId = logEntryEvent.LoggedById__c;
 
         LoggerSettings__c loggingUserSettings = Logger.getUserSettings(new User(Id = logEntryEvent.LoggedById__c, ProfileId = logEntryEvent.ProfileId__c));
-        if (logEntryEvent.UserType__c == GUEST_USER_TYPE || String.isBlank(logOwnerId) == true || loggingUserSettings.IsAnonymousModeEnabled__c == true) {
+        if (logEntryEvent.UserType__c == GUEST_USER_TYPE || String.isBlank(logOwnerId) || loggingUserSettings.IsAnonymousModeEnabled__c) {
             logOwnerId = System.UserInfo.getUserId();
         }
 
-        if (logEntryEvent.TransactionScenario__c != null && LoggerScenarioRule.getAll().containsKey(logEntryEvent.TransactionScenario__c) == true) {
+        if (logEntryEvent.TransactionScenario__c != null && LoggerScenarioRule.getAll().containsKey(logEntryEvent.TransactionScenario__c)) {
             LoggerScenarioRule__mdt scenarioRule = LoggerScenarioRule.getInstance(logEntryEvent.TransactionScenario__c);
             if (
                 scenarioRule.IsLogAssignmentEnabled__c == String.valueOf(true) &&
-                SCENARIO_UNIQUE_ID_TO_SCENARIO.containsKey(logEntryEvent.TransactionScenario__c) == true
+                SCENARIO_UNIQUE_ID_TO_SCENARIO.containsKey(logEntryEvent.TransactionScenario__c)
             ) {
                 logOwnerId = SCENARIO_UNIQUE_ID_TO_SCENARIO.get(logEntryEvent.TransactionScenario__c).OwnerId;
             }
@@ -548,7 +545,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
         List<String> cleanedTagNames = new List<String>();
 
         for (String tagName : tagsString.split(NEW_LINE_DELIMITER)) {
-            if (String.isNotBlank(tagName) == true) {
+            if (String.isNotBlank(tagName)) {
                 cleanedTagNames.add(tagName.trim());
             }
         }
@@ -558,7 +555,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
 
     private static List<LogEntryTagRule__mdt> getTagAssignmentRules() {
         List<LogEntryTagRule__mdt> tagAssignmentRules = LoggerEngineDataSelector.getInstance().getCachedTagAssignmentRules();
-        if (System.Test.isRunningTest() == true) {
+        if (System.Test.isRunningTest()) {
             // During tests, only use mock records - tests can add mock records using LogEntryEventHandler.TAG_ASSIGNMENT_RULES.add()
             tagAssignmentRules.clear();
         }
@@ -566,7 +563,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
     }
 
     private static void setQueriedAuthSessionDetails(List<Log__c> logs) {
-        if (LoggerParameter.QUERY_AUTH_SESSION_DATA_SYNCHRONOUSLY == true) {
+        if (LoggerParameter.QUERY_AUTH_SESSION_DATA_SYNCHRONOUSLY) {
             return;
         }
 
@@ -601,7 +598,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
     }
 
     private static void setQueriedNetworkDetails(List<Log__c> logs) {
-        if (LoggerParameter.QUERY_NETWORK_DATA_SYNCHRONOUSLY == true) {
+        if (LoggerParameter.QUERY_NETWORK_DATA_SYNCHRONOUSLY) {
             return;
         }
 
@@ -612,7 +609,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
             }
         }
 
-        if (networkIds.isEmpty() == true) {
+        if (networkIds.isEmpty()) {
             return;
         }
 
@@ -636,7 +633,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
     }
 
     private static void setQueriedOrganizationDetails(List<Log__c> logs) {
-        if (LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY == true) {
+        if (LoggerParameter.QUERY_ORGANIZATION_DATA_SYNCHRONOUSLY) {
             return;
         }
 
@@ -655,7 +652,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
     }
 
     private static void setQueriedUserDetails(List<Log__c> logs) {
-        if (LoggerParameter.QUERY_USER_DATA_SYNCHRONOUSLY == true) {
+        if (LoggerParameter.QUERY_USER_DATA_SYNCHRONOUSLY) {
             return;
         }
 

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
@@ -277,6 +277,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
                 HttpResponseBody__c = logEntryEvent.HttpResponseBody__c,
                 HttpResponseBodyMasked__c = logEntryEvent.HttpResponseBodyMasked__c,
                 HttpResponseHeaderKeys__c = logEntryEvent.HttpResponseHeaderKeys__c,
+                HttpResponseHeaders__c = logEntryEvent.HttpResponseHeaders__c,
                 HttpResponseStatus__c = logEntryEvent.HttpResponseStatus__c,
                 HttpResponseStatusCode__c = logEntryEvent.HttpResponseStatusCode__c,
                 LimitsAggregateQueriesMax__c = logEntryEvent.LimitsAggregateQueriesMax__c,

--- a/nebula-logger/core/main/log-management/classes/LogEntryHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryHandler.cls
@@ -68,7 +68,7 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
             }
         }
 
-        if (apexClassNames.isEmpty() == true) {
+        if (apexClassNames.isEmpty()) {
             return;
         }
 
@@ -77,7 +77,7 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
             classNameToApexClass.put(apexClass.Name, apexClass);
         }
 
-        if (classNameToApexClass.isEmpty() == true) {
+        if (classNameToApexClass.isEmpty()) {
             return;
         }
 
@@ -125,7 +125,7 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
             }
         }
 
-        if (flowApiNames.isEmpty() == true) {
+        if (flowApiNames.isEmpty()) {
             return;
         }
 
@@ -134,7 +134,7 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
             flowApiNameToDefinition.put(flowDefinition.ApiName, flowDefinition);
         }
 
-        if (flowApiNameToDefinition.isEmpty() == true) {
+        if (flowApiNameToDefinition.isEmpty()) {
             return;
         }
 
@@ -168,7 +168,7 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
             }
         }
 
-        if (flowActiveVersionIds.isEmpty() == true) {
+        if (flowActiveVersionIds.isEmpty()) {
             return;
         }
 
@@ -180,7 +180,7 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
             }
         }
 
-        if (flowDurableIdToFlowVersionView.isEmpty() == true) {
+        if (flowDurableIdToFlowVersionView.isEmpty()) {
             return;
         }
 
@@ -272,7 +272,7 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
     }
 
     private String getDisplayFieldApiName(Schema.SObjectType sobjectType) {
-        if (SOBJECT_TYPE_TO_DISPLAY_FIELD_NAME.containsKey(sobjectType) == true) {
+        if (SOBJECT_TYPE_TO_DISPLAY_FIELD_NAME.containsKey(sobjectType)) {
             return SOBJECT_TYPE_TO_DISPLAY_FIELD_NAME.get(sobjectType);
         }
 
@@ -316,7 +316,7 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
 
             Schema.DescribeFieldResult fieldDescribe = field.getDescribe();
 
-            if (fieldDescribe.isNameField() == true) {
+            if (fieldDescribe.isNameField()) {
                 displayFieldApiName = fieldDescribe.getName();
                 break;
             } else {
@@ -328,7 +328,7 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
         // For example, EmailMessage doesn't have a true display field, but it has a 'Subject' field. If one (and only one)
         // of the educated guess-fields exists on the object - and the object does not have a display field - then use the
         // educated guess-field as the fallback for the display field.
-        if (String.isBlank(displayFieldApiName) == true && fallbackFieldApiNames.size() == 1) {
+        if (String.isBlank(displayFieldApiName) && fallbackFieldApiNames.size() == 1) {
             displayFieldApiName = fallbackFieldApiNames.get(0);
         }
 

--- a/nebula-logger/core/main/log-management/classes/LogHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogHandler.cls
@@ -88,7 +88,7 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
         for (Log__c log : this.logs) {
             String loggingUserDefaultLogOwner = getLoggingUserSettings(log).DefaultLogOwner__c;
 
-            if (String.isBlank(loggingUserDefaultLogOwner) == true) {
+            if (String.isBlank(loggingUserDefaultLogOwner)) {
                 continue;
             } else if (loggingUserDefaultLogOwner instanceof Id) {
                 log.OwnerId = Id.valueOf(loggingUserDefaultLogOwner);
@@ -98,7 +98,7 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
             }
         }
 
-        if (logsToUpdate.isEmpty() == true) {
+        if (logsToUpdate.isEmpty()) {
             return;
         }
 
@@ -118,12 +118,12 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
     private void setParentLog() {
         List<String> parentLogTransactionIds = new List<String>();
         for (Log__c log : this.logs) {
-            if (String.isNotBlank(log.ParentLogTransactionId__c) == true) {
+            if (String.isNotBlank(log.ParentLogTransactionId__c)) {
                 parentLogTransactionIds.add(log.ParentLogTransactionId__c);
             }
         }
 
-        if (parentLogTransactionIds.isEmpty() == true) {
+        if (parentLogTransactionIds.isEmpty()) {
             return;
         }
 
@@ -133,7 +133,7 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
         }
 
         for (Log__c log : this.logs) {
-            if (String.isNotBlank(log.ParentLogTransactionId__c) == true) {
+            if (String.isNotBlank(log.ParentLogTransactionId__c)) {
                 log.ParentLog__c = parentLogTransactionIdToRecordId.get(log.ParentLogTransactionId__c);
             }
         }
@@ -232,12 +232,12 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
     private static Map<String, LogStatus__mdt> loadActiveLogStatuses() {
         Map<String, LogStatus__mdt> logStatusNameToStatus = new Map<String, LogStatus__mdt>();
         for (LogStatus__mdt logStatus : LogStatus__mdt.getAll().values()) {
-            if (logStatus.IsActive__c == true) {
+            if (logStatus.IsActive__c) {
                 logStatusNameToStatus.put(logStatus.MasterLabel, logStatus);
             }
         }
 
-        if (System.Test.isRunningTest() == true) {
+        if (System.Test.isRunningTest()) {
             logStatusNameToStatus.clear();
             logStatusNameToStatus.putAll(MOCK_LOG_STATUS_TO_STATUS);
         }
@@ -255,7 +255,7 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
 
         Map<Id, LoggerScenario__c> loggerScenariosById = new Map<Id, LoggerScenario__c>();
 
-        if (loggerScenarioIds.isEmpty() == true) {
+        if (loggerScenarioIds.isEmpty()) {
             return loggerScenariosById;
         }
 

--- a/nebula-logger/core/main/log-management/classes/LogManagementDataSelector.cls
+++ b/nebula-logger/core/main/log-management/classes/LogManagementDataSelector.cls
@@ -72,7 +72,7 @@ public without sharing virtual class LogManagementDataSelector {
      */
     public virtual List<ApexEmailNotification> getCachedApexEmailNotifications() {
         String cacheKey = 'ApexEmailNotifications';
-        if (LoggerCache.getOrganizationCache().contains(cacheKey) == true) {
+        if (LoggerCache.getOrganizationCache().contains(cacheKey)) {
             return (List<ApexEmailNotification>) LoggerCache.getOrganizationCache().get(cacheKey);
         }
 
@@ -88,7 +88,7 @@ public without sharing virtual class LogManagementDataSelector {
      */
     public Log__c getCachedRecentLogWithApiReleaseDetails() {
         String cacheKey = 'RecentLogWithApiReleaseDetails';
-        if (LoggerCache.getOrganizationCache().contains(cacheKey) == true) {
+        if (LoggerCache.getOrganizationCache().contains(cacheKey)) {
             return (Log__c) LoggerCache.getOrganizationCache().get(cacheKey);
         }
 
@@ -104,7 +104,7 @@ public without sharing virtual class LogManagementDataSelector {
             ORDER BY CreatedDate DESC
             LIMIT 1
         ];
-        Log__c log = logs.isEmpty() == true ? null : logs.get(0);
+        Log__c log = logs.isEmpty() ? null : logs.get(0);
         LoggerCache.getOrganizationCache().put(cacheKey, log);
         return log;
     }
@@ -324,7 +324,7 @@ public without sharing virtual class LogManagementDataSelector {
      * @return            The list of matching `User` records
      */
     public virtual List<User> getUsersByNameSearch(String searchTerm) {
-        if (String.isBlank(searchTerm) == true) {
+        if (String.isBlank(searchTerm)) {
             return new List<User>();
         }
 

--- a/nebula-logger/core/main/log-management/classes/LoggerEmailSender.cls
+++ b/nebula-logger/core/main/log-management/classes/LoggerEmailSender.cls
@@ -53,7 +53,7 @@ public without sharing class LoggerEmailSender {
      *                     If no errors are found in the provided list, then no email will be sent.
      */
     public static void sendErrorEmail(Schema.SObjectType sobjectType, List<Database.SaveResult> saveResults) {
-        if (LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS == false || saveResults == null || saveResults.isEmpty() == true) {
+        if (LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS == false || saveResults == null || saveResults.isEmpty()) {
             return;
         }
 
@@ -69,7 +69,7 @@ public without sharing class LoggerEmailSender {
      *                     If no errors are found in the provided list, then no email will be sent.
      */
     public static void sendErrorEmail(Schema.SObjectType sobjectType, List<Database.UpsertResult> upsertResults) {
-        if (LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS == false || upsertResults == null || upsertResults.isEmpty() == true) {
+        if (LoggerParameter.SEND_ERROR_EMAIL_NOTIFICATIONS == false || upsertResults == null || upsertResults.isEmpty()) {
             return;
         }
 
@@ -78,12 +78,12 @@ public without sharing class LoggerEmailSender {
     }
 
     private static void sendErrorEmail(Schema.SObjectType sobjectType, List<String> errorMessages) {
-        if (errorMessages.isEmpty() == true) {
+        if (errorMessages.isEmpty()) {
             return;
         }
 
-        if (CACHED_APEX_ERROR_RECIPIENTS.isEmpty() == true) {
-            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+        if (CACHED_APEX_ERROR_RECIPIENTS.isEmpty()) {
+            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
                 Logger.info('Logger - no Apex email recipients configured, skipping sending email');
             }
             return;
@@ -122,13 +122,13 @@ public without sharing class LoggerEmailSender {
 
     private static void sendEmail(Messaging.SingleEmailMessage message) {
         SENT_EMAILS.add(message);
-        if (IS_EMAIL_DELIVERABILITY_AVAILABLE == true) {
+        if (IS_EMAIL_DELIVERABILITY_AVAILABLE) {
             List<Messaging.SingleEmailMessage> messages = new List<Messaging.SingleEmailMessage>{ message };
             List<Messaging.SendEmailResult> emailResults = Messaging.sendEmail(messages);
 
             if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == false) {
                 return;
-            } else if (emailResults.get(0).success == true) {
+            } else if (emailResults.get(0).success) {
                 Logger.info('Logger - The email was sent successfully');
             } else {
                 Logger.warn('Logger - The email failed to send: ' + emailResults.get(0).errors.get(0).message);
@@ -161,7 +161,7 @@ public without sharing class LoggerEmailSender {
     private static List<String> queryApexErrrorRecipients() {
         List<String> apexErrrorRecipients = new List<String>();
         List<ApexEmailNotification> notifications = LogManagementDataSelector.getInstance().getCachedApexEmailNotifications();
-        if (System.Test.isRunningTest() == true) {
+        if (System.Test.isRunningTest()) {
             notifications.clear();
             notifications.addAll(MOCK_NOTIFICATIONS);
         }
@@ -169,7 +169,7 @@ public without sharing class LoggerEmailSender {
         for (ApexEmailNotification notification : notifications) {
             if (notification.UserId != null) {
                 apexErrrorRecipients.add(notification.UserId);
-            } else if (String.isNotBlank(notification.Email) == true) {
+            } else if (String.isNotBlank(notification.Email)) {
                 apexErrrorRecipients.addAll(notification.Email.split(';'));
             }
         }

--- a/nebula-logger/core/main/log-management/classes/LoggerHomeHeaderController.cls
+++ b/nebula-logger/core/main/log-management/classes/LoggerHomeHeaderController.cls
@@ -17,7 +17,7 @@ public without sharing class LoggerHomeHeaderController {
         Organization organization = LoggerEngineDataSelector.getInstance().getCachedOrganization();
 
         Environment environment = new Environment();
-        environment.loggerNamespacePrefix = String.isNotBlank(Logger.getNamespacePrefix()) == true ? Logger.getNamespacePrefix() : '(none)';
+        environment.loggerNamespacePrefix = String.isNotBlank(Logger.getNamespacePrefix()) ? Logger.getNamespacePrefix() : '(none)';
         environment.loggerVersionNumber = Logger.getVersionNumber();
         environment.organizationApiVersion = Logger.getOrganizationApiVersion();
         environment.organizationCreatedByUsername = organization.CreatedBy.Username;

--- a/nebula-logger/core/main/log-management/classes/LoggerSObjectMetadata.cls
+++ b/nebula-logger/core/main/log-management/classes/LoggerSObjectMetadata.cls
@@ -16,7 +16,7 @@ public without sharing class LoggerSObjectMetadata {
     @AuraEnabled(cacheable=true)
     public static SObjectSchema getSchemaForName(String sobjectApiName) {
         String namespacePrefix = getNamespacePrefix();
-        String qualifiedApiName = String.isBlank(namespacePrefix) == true ? sobjectApiName : namespacePrefix + '__' + sobjectApiName;
+        String qualifiedApiName = String.isBlank(namespacePrefix) ? sobjectApiName : namespacePrefix + '__' + sobjectApiName;
         System.Type apexType = System.Type.forName(qualifiedApiName) != null ? System.Type.forName(qualifiedApiName) : System.Type.forName(sobjectApiName);
         Schema.SObjectType sobjectType = ((SObject) apexType.newInstance()).getSObjectType();
         return getSchema(sobjectType);

--- a/nebula-logger/core/main/log-management/classes/LoggerSettingsController.cls
+++ b/nebula-logger/core/main/log-management/classes/LoggerSettingsController.cls
@@ -28,8 +28,7 @@ public without sharing class LoggerSettingsController {
      */
     @AuraEnabled(cacheable=true)
     public static Boolean canUserModifyLoggerSettings() {
-        return Schema.LoggerSettings__c.SObjectType.getDescribe().isUpdateable() == true ||
-            System.FeatureManagement.checkPermission('CanModifyLoggerSettings') == true;
+        return Schema.LoggerSettings__c.SObjectType.getDescribe().isUpdateable() || System.FeatureManagement.checkPermission('CanModifyLoggerSettings');
     }
 
     /**
@@ -70,7 +69,7 @@ public without sharing class LoggerSettingsController {
 
         Map<Id, String> setupOwnerIdToName = querySetupOwnerNames(setupOwnerIds);
         for (SettingsRecordResult settingsRecordResult : settingsRecordResults) {
-            if (setupOwnerIdToName.containsKey((settingsRecordResult.record.SetupOwnerId)) == true) {
+            if (setupOwnerIdToName.containsKey((settingsRecordResult.record.SetupOwnerId))) {
                 settingsRecordResult.setupOwnerName = setupOwnerIdToName.get(settingsRecordResult.record.SetupOwnerId);
             }
         }
@@ -101,7 +100,7 @@ public without sharing class LoggerSettingsController {
     @AuraEnabled
     public static void saveRecord(LoggerSettings__c settingsRecord) {
         try {
-            if (canUserModifyLoggerSettings() == true) {
+            if (canUserModifyLoggerSettings()) {
                 LoggerDataStore.getDatabase().upsertRecord(settingsRecord, Schema.LoggerSettings__c.Id);
             }
         } catch (System.Exception ex) {
@@ -116,7 +115,7 @@ public without sharing class LoggerSettingsController {
     @AuraEnabled
     public static void deleteRecord(LoggerSettings__c settingsRecord) {
         try {
-            if (canUserModifyLoggerSettings() == true) {
+            if (canUserModifyLoggerSettings()) {
                 LoggerDataStore.getDatabase().deleteRecord(settingsRecord);
             }
         } catch (System.Exception ex) {

--- a/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
@@ -602,6 +602,16 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
+                <fieldItem>Record.HttpResponseHeaders__c</fieldItem>
+                <identifier>RecordHttpResponseHeaders_cField1</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.HttpResponseBody__c</fieldItem>
                 <identifier>RecordHttpResponseBody_cField1</identifier>
             </fieldInstance>

--- a/nebula-logger/core/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
+++ b/nebula-logger/core/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
@@ -383,6 +383,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
+                <field>HttpResponseHeaders__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
                 <field>HttpResponseBody__c</field>
             </layoutItems>
         </layoutColumns>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HttpResponseHeaders__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HttpResponseHeaders__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HttpResponseHeaders__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <externalId>false</externalId>
+    <label>HTTP Response Headers</label>
+    <length>5000</length>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -420,6 +420,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.HttpResponseHeaders__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.HttpResponseStatusCode__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -344,6 +344,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.HttpResponseHeaders__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.HttpResponseStatusCode__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/logger-engine/classes/ComponentLogger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/ComponentLogger.cls
@@ -52,7 +52,7 @@ public inherited sharing class ComponentLogger {
                 setComponentErrorDetails(logEntryEventBuilder, componentLogEntry.error);
                 setStackTraceDetails(logEntryEventBuilder, componentLogEntry.stack);
             }
-            if (String.isNotBlank(saveMethodName) == true) {
+            if (String.isNotBlank(saveMethodName)) {
                 saveMethod = Logger.SaveMethod.valueOf(saveMethodName);
             }
             Logger.saveLog(saveMethod);
@@ -89,7 +89,7 @@ public inherited sharing class ComponentLogger {
         String originLocation;
         Boolean isAuraComponent = false;
 
-        if (String.isNotBlank(stackTraceString) == true) {
+        if (String.isNotBlank(stackTraceString)) {
             String loggerComponentReferenceToIgnore = '/c/logger.js';
             String auraComponentContent = '/n/components/';
             String lwcModuleContent = '/n/modules/';
@@ -97,27 +97,27 @@ public inherited sharing class ComponentLogger {
 
             List<String> stackTraceLines = new List<String>();
             for (String currentStackTraceLine : stackTraceString.split('\n')) {
-                if (currentStackTraceLine.contains(loggerComponentReferenceToIgnore) == true) {
+                if (currentStackTraceLine.contains(loggerComponentReferenceToIgnore)) {
                     continue;
-                } else if (parentComponentFound == false && currentStackTraceLine.contains(auraComponentContent) == true) {
+                } else if (parentComponentFound == false && currentStackTraceLine.contains(auraComponentContent)) {
                     isAuraComponent = true;
                     parentComponentFound = true;
-                } else if (parentComponentFound == false && currentStackTraceLine.contains(lwcModuleContent) == true) {
+                } else if (parentComponentFound == false && currentStackTraceLine.contains(lwcModuleContent)) {
                     parentComponentFound = true;
                 }
 
-                if (parentComponentFound == true) {
+                if (parentComponentFound) {
                     stackTraceLines.add(currentStackTraceLine);
                 }
             }
 
             stackTraceString = String.join(stackTraceLines, '\n');
-            if (String.isNotBlank(stackTraceString) == true) {
-                String componentContent = isAuraComponent == true ? auraComponentContent : lwcModuleContent;
+            if (String.isNotBlank(stackTraceString)) {
+                String componentContent = isAuraComponent ? auraComponentContent : lwcModuleContent;
                 String componentName;
                 String componentFunction;
                 for (String currentStackTraceLine : stackTraceString.split('\n')) {
-                    if (currentStackTraceLine.trim().startsWith('at eval') == true) {
+                    if (currentStackTraceLine.trim().startsWith('at eval')) {
                         continue;
                     }
 
@@ -129,7 +129,7 @@ public inherited sharing class ComponentLogger {
             }
         }
 
-        logEntryEventBuilder.getLogEntryEvent().ComponentType__c = isAuraComponent == true ? 'Aura' : 'LWC';
+        logEntryEventBuilder.getLogEntryEvent().ComponentType__c = isAuraComponent ? 'Aura' : 'LWC';
         logEntryEventBuilder.getLogEntryEvent().OriginType__c = 'Component';
         logEntryEventBuilder.getLogEntryEvent().OriginLocation__c = originLocation;
         logEntryEventBuilder.getLogEntryEvent().StackTrace__c = truncateFieldValue(Schema.LogEntryEvent__e.StackTrace__c, stackTraceString);

--- a/nebula-logger/core/main/logger-engine/classes/FlowCollectionLogEntry.cls
+++ b/nebula-logger/core/main/logger-engine/classes/FlowCollectionLogEntry.cls
@@ -49,7 +49,7 @@ global inherited sharing class FlowCollectionLogEntry {
      * @description Optionally rollback Database operations executed until Apex action was called and save the log entry.
      */
     @InvocableVariable(required=false label='(Optional) Throw FlowException for Fault Error Message')
-    global Boolean shouldThrowFaultMessageException;
+    global Boolean shouldThrowFaultMessageException = false;
 
     /**
      * @description Optionally choose to save any pending log entries
@@ -101,7 +101,7 @@ global inherited sharing class FlowCollectionLogEntry {
         for (FlowCollectionLogEntry flowCollectionLogEntry : flowCollectionLogEntries) {
             FlowLogger.LogEntry shadowLogEntry = (FlowLogger.LogEntry) JSON.deserialize(JSON.serialize(flowCollectionLogEntry), FlowLogger.LogEntry.class);
             LogEntryEventBuilder builder = shadowLogEntry.addToLoggerBuffer()?.setRecord(flowCollectionLogEntry.records);
-            if (builder.shouldSave() == true && flowCollectionLogEntry.records?.size() > 0) {
+            if (builder.shouldSave() && flowCollectionLogEntry.records?.size() > 0) {
                 builder.getLogEntryEvent().RecordSObjectType__c = flowCollectionLogEntry.records.get(0).getSObjectType().getDescribe().getName();
             }
 

--- a/nebula-logger/core/main/logger-engine/classes/FlowLogEntry.cls
+++ b/nebula-logger/core/main/logger-engine/classes/FlowLogEntry.cls
@@ -43,13 +43,13 @@ global inherited sharing class FlowLogEntry {
      * @description Optionally rollback Database operations executed until Apex action was called and save the log entry.
      */
     @InvocableVariable(required=false label='(Optional) Throw FlowException for Fault Error Message')
-    global Boolean shouldThrowFaultMessageException;
+    global Boolean shouldThrowFaultMessageException = false;
 
     /**
      * @description Optionally choose to save any pending log entries
      */
     @InvocableVariable(required=false label='(Optional) Save Log')
-    global Boolean saveLog;
+    global Boolean saveLog = false;
 
     /**
      * @description Optionally choose the save method to use when 'Save Log' is true

--- a/nebula-logger/core/main/logger-engine/classes/FlowLogger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/FlowLogger.cls
@@ -56,7 +56,7 @@ public inherited sharing class FlowLogger {
         /**
          * @description Optionally throws an exception when value is set to True (Use it on Fault connectors of your flow).
          */
-        public Boolean shouldThrowFaultMessageException;
+        public Boolean shouldThrowFaultMessageException = false;
 
         /**
          * @description Optionally specify the scenario to use for the current transaction
@@ -80,7 +80,7 @@ public inherited sharing class FlowLogger {
         public Boolean saveLog = false;
 
         /**
-         * @description String name of the instance of Logger.SaveMethod to use when 'Save Log' == true
+         * @description String name of the instance of Logger.SaveMethod to use when 'Save Log' is set to `true`
          */
         public String saveMethodName;
 
@@ -155,27 +155,27 @@ public inherited sharing class FlowLogger {
         for (LogEntry flowEntry : flowEntries) {
             flowEntry.addToLoggerBuffer();
 
-            if (flowEntry.saveLog == true) {
+            if (flowEntry.saveLog) {
                 saveLog = flowEntry.saveLog;
-                if (String.isNotBlank(flowEntry.saveMethodName) == true) {
+                if (String.isNotBlank(flowEntry.saveMethodName)) {
                     saveMethod = Logger.SaveMethod.valueOf(flowEntry.saveMethodName);
                 }
             }
-            if (String.isNotBlank(flowEntry.faultMessage) == true) {
+            if (String.isNotBlank(flowEntry.faultMessage)) {
                 faultMessage = flowEntry.faultMessage;
             }
-            if (flowEntry.shouldThrowFaultMessageException == true) {
+            if (flowEntry.shouldThrowFaultMessageException) {
                 shouldThrowFaultMessageException = flowEntry.shouldThrowFaultMessageException;
             }
         }
 
-        if (saveLog == true) {
+        if (saveLog) {
             Logger.saveLog(saveMethod);
         }
 
         // Here we throw an exception so we stop synchronous database updates from happening,
         // avoiding inconsistencies in the data
-        if (shouldThrowFaultMessageException == true) {
+        if (shouldThrowFaultMessageException) {
             Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
             throw new System.FlowException(faultMessage);
         }

--- a/nebula-logger/core/main/logger-engine/classes/FlowRecordLogEntry.cls
+++ b/nebula-logger/core/main/logger-engine/classes/FlowRecordLogEntry.cls
@@ -49,7 +49,7 @@ global inherited sharing class FlowRecordLogEntry {
      * @description Optionally rollback Database operations executed until Apex action was called and save the log entry.
      */
     @InvocableVariable(required=false label='(Optional) Throw FlowException for Fault Error Message')
-    global Boolean shouldThrowFaultMessageException;
+    global Boolean shouldThrowFaultMessageException = false;
 
     /**
      * @description Optionally choose to save any pending log entries

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -147,7 +147,7 @@ global with sharing class LogEntryEventBuilder {
      */
     global LogEntryEventBuilder setMessage(String message) {
         // To help with debugging unit tests, always run System.debug statement in a test context
-        if ((this.shouldSave() == true || System.Test.isRunningTest() == true) && this.logEntryEvent != null) {
+        if ((this.shouldSave() || System.Test.isRunningTest()) && this.logEntryEvent != null) {
             String cleanedMessage = applyDataMaskRules(message);
             Boolean messageMasked = cleanedMessage != message;
             String truncatedMessage = truncateFieldValue(Schema.LogEntryEvent__e.Message__c, cleanedMessage);
@@ -176,7 +176,7 @@ global with sharing class LogEntryEventBuilder {
         this.logEntryEvent.ExceptionType__c = apexException.getTypeName();
 
         // Stack traces are not returned for managed packages
-        if (isValidStackTrace(apexException.getStackTraceString()) == true) {
+        if (isValidStackTrace(apexException.getStackTraceString())) {
             this.logEntryEvent.ExceptionStackTrace__c = apexException.getStackTraceString();
         }
 
@@ -585,7 +585,7 @@ global with sharing class LogEntryEventBuilder {
         Boolean responseBodyMasked = cleanedResponseBody != response.getBody();
 
         String formattedHeadersString;
-        if (LoggerParameter.STORE_HTTP_RESPONSE_HEADER_VALUES == true) {
+        if (LoggerParameter.STORE_HTTP_RESPONSE_HEADER_VALUES) {
             List<String> headers = new List<String>();
             for (String headerKey : response.getHeaderKeys()) {
                 headers.add(String.format(HTTP_HEADER_FORMAT, new List<String>{ headerKey, response.getHeader(headerKey) }));
@@ -622,7 +622,7 @@ global with sharing class LogEntryEventBuilder {
      * @return The same instance of `LogEntryEventBuilder`, useful for chaining methods
      */
     global LogEntryEventBuilder addTags(List<String> tags) {
-        if (tags == null || tags.isEmpty() == true) {
+        if (tags == null || tags.isEmpty()) {
             return this;
         }
 
@@ -789,7 +789,7 @@ global with sharing class LogEntryEventBuilder {
     }
 
     private void setTagsDetails() {
-        if (this.tags.isEmpty() == true || this.tagDetailsAreSet == true) {
+        if (this.tags.isEmpty() || this.tagDetailsAreSet) {
             return;
         }
 
@@ -848,7 +848,7 @@ global with sharing class LogEntryEventBuilder {
     }
 
     private static void setQueriedNetworkDetails(LogEntryEvent__e logEntryEvent, LoggerSettings__c userSettings) {
-        if (userSettings.IsEnabled__c == false || LoggerParameter.QUERY_NETWORK_DATA_SYNCHRONOUSLY == false || String.isBlank(networkId) == true) {
+        if (userSettings.IsEnabled__c == false || LoggerParameter.QUERY_NETWORK_DATA_SYNCHRONOUSLY == false || String.isBlank(networkId)) {
             return;
         }
 
@@ -919,12 +919,12 @@ global with sharing class LogEntryEventBuilder {
     }
 
     private String applyDataMaskRules(String dataInput) {
-        if (this.userSettings.IsDataMaskingEnabled__c == false || String.isBlank(dataInput) == true) {
+        if (this.userSettings.IsDataMaskingEnabled__c == false || String.isBlank(dataInput)) {
             return dataInput;
         }
 
         for (LogEntryDataMaskRule__mdt dataMaskRule : CACHED_DATA_MASK_RULES.values()) {
-            if (dataMaskRule.IsEnabled__c == true) {
+            if (dataMaskRule.IsEnabled__c) {
                 dataInput = dataInput.replaceAll(dataMaskRule.SensitiveDataRegEx__c, dataMaskRule.ReplacementRegEx__c);
             }
         }
@@ -980,9 +980,9 @@ global with sharing class LogEntryEventBuilder {
         String cachedOrganizationEnvironmentType;
         if (cachedOrganization == null) {
             cachedOrganizationEnvironmentType = '';
-        } else if (cachedOrganization.IsSandbox == true && cachedOrganization.TrialExpirationDate != null) {
+        } else if (cachedOrganization.IsSandbox && cachedOrganization.TrialExpirationDate != null) {
             cachedOrganizationEnvironmentType = 'Scratch Org';
-        } else if (cachedOrganization.IsSandbox == true) {
+        } else if (cachedOrganization.IsSandbox) {
             cachedOrganizationEnvironmentType = 'Sandbox';
         } else {
             cachedOrganizationEnvironmentType = 'Production';
@@ -1080,7 +1080,7 @@ global with sharing class LogEntryEventBuilder {
     } */
 
     private static Boolean isValidStackTrace(String stackTraceString) {
-        if (String.isBlank(stackTraceString) == true || stackTraceString == '()' || stackTraceString == '(' + NAMESPACE_PREFIX + ')') {
+        if (String.isBlank(stackTraceString) || stackTraceString == '()' || stackTraceString == '(' + NAMESPACE_PREFIX + ')') {
             return false;
         }
 
@@ -1090,11 +1090,11 @@ global with sharing class LogEntryEventBuilder {
     private static Map<String, LogEntryDataMaskRule__mdt> loadDataMaskRules() {
         Map<String, LogEntryDataMaskRule__mdt> activeDataMaskRules = new Map<String, LogEntryDataMaskRule__mdt>();
         for (LogEntryDataMaskRule__mdt dataMaskRule : LogEntryDataMaskRule__mdt.getAll().values()) {
-            if (dataMaskRule.IsEnabled__c == true) {
+            if (dataMaskRule.IsEnabled__c) {
                 activeDataMaskRules.put(dataMaskRule.DeveloperName, dataMaskRule);
             }
         }
-        if (System.Test.isRunningTest() == true) {
+        if (System.Test.isRunningTest()) {
             // Tests shouldn't rely on the actual CMDT rules in the org
             // Clear the org's loaded records during tests, and mock via setMockDataMaskRule()
             activeDataMaskRules.clear();
@@ -1103,7 +1103,7 @@ global with sharing class LogEntryEventBuilder {
     }
 
     private static List<SObject> stripInaccessible(List<SObject> records) {
-        if (records == null || records.isEmpty() == true || records.get(0).getSObjectType() == Schema.AggregateResult.SObjectType) {
+        if (records == null || records.isEmpty() || records.get(0).getSObjectType() == Schema.AggregateResult.SObjectType) {
             return records;
         }
 

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -584,14 +584,18 @@ global with sharing class LogEntryEventBuilder {
         String cleanedResponseBody = applyDataMaskRules(response.getBody());
         Boolean responseBodyMasked = cleanedResponseBody != response.getBody();
 
-        List<String> headers = new List<String>();
-        for (String headerKey : response.getHeaderKeys()) {
-            headers.add(String.format(HTTP_HEADER_FORMAT, new List<String>{ headerKey, response.getHeader(headerKey) }));
+        String formattedHeadersString;
+        if (LoggerParameter.STORE_HTTP_RESPONSE_HEADER_VALUES == true) {
+            List<String> headers = new List<String>();
+            for (String headerKey : response.getHeaderKeys()) {
+                headers.add(String.format(HTTP_HEADER_FORMAT, new List<String>{ headerKey, response.getHeader(headerKey) }));
+            }
+            formattedHeadersString = String.join(headers, NEW_LINE_DELIMITER);
         }
         this.logEntryEvent.HttpResponseBody__c = cleanedResponseBody;
         this.logEntryEvent.HttpResponseBodyMasked__c = responseBodyMasked;
         this.logEntryEvent.HttpResponseHeaderKeys__c = String.join(response.getHeaderKeys(), NEW_LINE_DELIMITER);
-        this.logEntryEvent.HttpResponseHeaders__c = String.join(headers, NEW_LINE_DELIMITER);
+        this.logEntryEvent.HttpResponseHeaders__c = formattedHeadersString;
         this.logEntryEvent.HttpResponseStatus__c = response.getStatus();
         this.logEntryEvent.HttpResponseStatusCode__c = response.getStatusCode();
         return this;

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -14,6 +14,7 @@
 global with sharing class LogEntryEventBuilder {
     private static final Map<String, String> CACHED_SOBJECT_NAME_TO_CLASSIFICATION = new Map<String, String>();
     private static final User CURRENT_USER = new User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
+    private static final String HTTP_HEADER_FORMAT = '{0}: {1}';
     private static final String NEW_LINE_DELIMITER = '\n';
 
     private static String cachedOrganizationEnvironmentType;
@@ -583,9 +584,14 @@ global with sharing class LogEntryEventBuilder {
         String cleanedResponseBody = applyDataMaskRules(response.getBody());
         Boolean responseBodyMasked = cleanedResponseBody != response.getBody();
 
+        List<String> headers = new List<String>();
+        for (String headerKey : response.getHeaderKeys()) {
+            headers.add(String.format(HTTP_HEADER_FORMAT, new List<String>{ headerKey, response.getHeader(headerKey) }));
+        }
         this.logEntryEvent.HttpResponseBody__c = cleanedResponseBody;
         this.logEntryEvent.HttpResponseBodyMasked__c = responseBodyMasked;
         this.logEntryEvent.HttpResponseHeaderKeys__c = String.join(response.getHeaderKeys(), NEW_LINE_DELIMITER);
+        this.logEntryEvent.HttpResponseHeaders__c = String.join(headers, NEW_LINE_DELIMITER);
         this.logEntryEvent.HttpResponseStatus__c = response.getStatus();
         this.logEntryEvent.HttpResponseStatusCode__c = response.getStatusCode();
         return this;

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.11.7';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.11.8';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final Set<String> IGNORED_APEX_CLASSES = initializeIgnoredApexClasses();
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -344,7 +344,7 @@ global with sharing class Logger {
         // First, check for User-level settings
         if (loggingUser.Id != null && LoggerSettings__c.getValues(loggingUser.Id) != null) {
             LoggerSettings__c userSettings = LoggerSettings__c.getValues(loggingUser.Id);
-            if (hasValidStartAndEndTimes(userSettings) == true) {
+            if (hasValidStartAndEndTimes(userSettings)) {
                 loggingUserSettings = userSettings;
             }
         }
@@ -352,7 +352,7 @@ global with sharing class Logger {
         // Next, check for Profile-level settings
         if (loggingUserSettings == null && loggingUser.ProfileId != null && LoggerSettings__c.getValues(loggingUser.ProfileId) != null) {
             LoggerSettings__c profileSettings = LoggerSettings__c.getValues(loggingUser.ProfileId);
-            if (hasValidStartAndEndTimes(profileSettings) == true) {
+            if (hasValidStartAndEndTimes(profileSettings)) {
                 loggingUserSettings = profileSettings;
             }
         }
@@ -360,7 +360,7 @@ global with sharing class Logger {
         // Next, use the org defaults (if configured)
         if (loggingUserSettings == null && loggingUser.Id != null && LoggerSettings__c.getOrgDefaults().Id != null) {
             LoggerSettings__c orgDefaults = LoggerSettings__c.getOrgDefaults();
-            if (hasValidStartAndEndTimes(orgDefaults) == true) {
+            if (hasValidStartAndEndTimes(orgDefaults)) {
                 loggingUserSettings = orgDefaults;
             }
         }
@@ -2823,7 +2823,7 @@ global with sharing class Logger {
             }
         }
 
-        Boolean shouldSave = resultsToLog.isEmpty() == false && isEnabled(loggingLevel) == true;
+        Boolean shouldSave = resultsToLog.isEmpty() == false && isEnabled(loggingLevel);
         return newEntry(loggingLevel, message, shouldSave).setDatabaseResult(resultsToLog);
     }
 
@@ -2853,7 +2853,7 @@ global with sharing class Logger {
             }
         }
 
-        Boolean shouldSave = resultsToLog.isEmpty() == false && isEnabled(loggingLevel) == true;
+        Boolean shouldSave = resultsToLog.isEmpty() == false && isEnabled(loggingLevel);
         return newEntry(loggingLevel, message, shouldSave).setDatabaseResult(resultsToLog);
     }
 
@@ -2883,7 +2883,7 @@ global with sharing class Logger {
             }
         }
 
-        Boolean shouldSave = resultsToLog.isEmpty() == false && isEnabled(loggingLevel) == true;
+        Boolean shouldSave = resultsToLog.isEmpty() == false && isEnabled(loggingLevel);
         return newEntry(loggingLevel, message, shouldSave).setDatabaseResult(resultsToLog);
     }
 
@@ -2913,7 +2913,7 @@ global with sharing class Logger {
             }
         }
 
-        Boolean shouldSave = resultsToLog.isEmpty() == false && isEnabled(loggingLevel) == true;
+        Boolean shouldSave = resultsToLog.isEmpty() == false && isEnabled(loggingLevel);
         return newEntry(loggingLevel, message, shouldSave).setDatabaseResult(resultsToLog);
     }
 
@@ -2943,7 +2943,7 @@ global with sharing class Logger {
             }
         }
 
-        Boolean shouldSave = resultsToLog.isEmpty() == false && isEnabled(loggingLevel) == true;
+        Boolean shouldSave = resultsToLog.isEmpty() == false && isEnabled(loggingLevel);
         return newEntry(loggingLevel, message, shouldSave).setDatabaseResult(resultsToLog);
     }
 
@@ -2977,12 +2977,12 @@ global with sharing class Logger {
             }
         }
 
-        Boolean shouldSave = resultsToLog.isEmpty() == false && isEnabled(loggingLevel) == true;
+        Boolean shouldSave = resultsToLog.isEmpty() == false && isEnabled(loggingLevel);
         return newEntry(loggingLevel, message, shouldSave).setDatabaseResult(resultsToLog);
     }
 
     /**
-     * @description Adds a new instance of LogEntryEventBuilder to Logger's buffer, if shouldSave == true
+     * @description Adds a new instance of LogEntryEventBuilder to Logger's buffer, when `shouldSave` is `true`
      * @param  loggingLevel The logging level enum value for the new entry
      * @param  logMessage   The instance of LogMessage to use as the entry's message
      * @param  shouldSave   Controls if the new entry will be saved. This can be used to save entries, even if the entry's logging level does not meet the user's logging level
@@ -3039,16 +3039,16 @@ global with sharing class Logger {
      */
     @SuppressWarnings('PMD.NcssMethodCount')
     global static void setScenario(String scenario) {
-        if (LoggerParameter.USE_FIRST_SCENARIO_FOR_TRANSACTION == false || String.isBlank(transactionScenario) == true) {
+        if (LoggerParameter.USE_FIRST_SCENARIO_FOR_TRANSACTION == false || String.isBlank(transactionScenario)) {
             transactionScenario = scenario;
             // One of few limited places in the codebase (except tests) that should use System.debug()
             // The rest of the codebase should use a method in Logger.cls
-            if (String.isNotBlank(transactionScenario) == true) {
+            if (String.isNotBlank(transactionScenario)) {
                 System.debug(System.LoggingLevel.INFO, 'Nebula Logger - Transaction Scenario: ' + transactionScenario);
             }
         }
 
-        if (String.isNotBlank(scenario) == true && scenario == currentEntryScenario) {
+        if (String.isNotBlank(scenario) && scenario == currentEntryScenario) {
             return;
         }
 
@@ -3056,37 +3056,37 @@ global with sharing class Logger {
         orderedScenarios.add(scenario);
         // One of few limited places in the codebase (except tests) that should use System.debug()
         // The rest of the codebase should use a method in Logger.cls
-        if (String.isNotBlank(transactionScenario) == true) {
+        if (String.isNotBlank(transactionScenario)) {
             System.debug(System.LoggingLevel.INFO, 'Nebula Logger - Entry Scenario: ' + currentEntryScenario);
         }
         LoggerScenarioRule__mdt matchingScenarioRule = LoggerScenarioRule.getInstance(scenario);
         if (matchingScenarioRule != null) {
             LoggerSettings__c userSettings = getUserSettings();
-            if (String.isNotBlank(matchingScenarioRule.IsLoggerEnabled__c) == true) {
+            if (String.isNotBlank(matchingScenarioRule.IsLoggerEnabled__c)) {
                 userSettings.IsEnabled__c = Boolean.valueOf(matchingScenarioRule.IsLoggerEnabled__c);
             }
-            if (String.isNotBlank(matchingScenarioRule.IsAnonymousModeEnabled__c) == true) {
+            if (String.isNotBlank(matchingScenarioRule.IsAnonymousModeEnabled__c)) {
                 userSettings.IsAnonymousModeEnabled__c = Boolean.valueOf(matchingScenarioRule.IsAnonymousModeEnabled__c);
             }
-            if (String.isNotBlank(matchingScenarioRule.IsApexSystemDebugLoggingEnabled__c) == true) {
+            if (String.isNotBlank(matchingScenarioRule.IsApexSystemDebugLoggingEnabled__c)) {
                 userSettings.IsApexSystemDebugLoggingEnabled__c = Boolean.valueOf(matchingScenarioRule.IsApexSystemDebugLoggingEnabled__c);
             }
-            if (String.isNotBlank(matchingScenarioRule.IsDataMaskingEnabled__c) == true) {
+            if (String.isNotBlank(matchingScenarioRule.IsDataMaskingEnabled__c)) {
                 userSettings.IsDataMaskingEnabled__c = Boolean.valueOf(matchingScenarioRule.IsDataMaskingEnabled__c);
             }
-            if (String.isNotBlank(matchingScenarioRule.IsJavaScriptConsoleLoggingEnabled__c) == true) {
+            if (String.isNotBlank(matchingScenarioRule.IsJavaScriptConsoleLoggingEnabled__c)) {
                 userSettings.IsJavaScriptConsoleLoggingEnabled__c = Boolean.valueOf(matchingScenarioRule.IsJavaScriptConsoleLoggingEnabled__c);
             }
-            if (String.isNotBlank(matchingScenarioRule.IsRecordFieldStrippingEnabled__c) == true) {
+            if (String.isNotBlank(matchingScenarioRule.IsRecordFieldStrippingEnabled__c)) {
                 userSettings.IsRecordFieldStrippingEnabled__c = Boolean.valueOf(matchingScenarioRule.IsRecordFieldStrippingEnabled__c);
             }
-            if (String.isNotBlank(matchingScenarioRule.IsSavingEnabled__c) == true) {
+            if (String.isNotBlank(matchingScenarioRule.IsSavingEnabled__c)) {
                 userSettings.IsSavingEnabled__c = Boolean.valueOf(matchingScenarioRule.IsSavingEnabled__c);
             }
-            if (String.isNotBlank(matchingScenarioRule.SaveMethod__c) == true) {
+            if (String.isNotBlank(matchingScenarioRule.SaveMethod__c)) {
                 setSaveMethod(matchingScenarioRule.SaveMethod__c);
             }
-            if (String.isNotBlank(matchingScenarioRule.UserLoggingLevel__c) == true) {
+            if (String.isNotBlank(matchingScenarioRule.UserLoggingLevel__c)) {
                 userSettings.LoggingLevel__c = matchingScenarioRule.UserLoggingLevel__c;
             }
         }
@@ -3098,7 +3098,7 @@ global with sharing class Logger {
      * @param  scenario The name of the scenario to end
      */
     global static void endScenario(String scenario) {
-        if (String.isBlank(scenario) == true || scenario != currentEntryScenario || orderedScenarios.isEmpty() == true) {
+        if (String.isBlank(scenario) || scenario != currentEntryScenario || orderedScenarios.isEmpty()) {
             return;
         }
 
@@ -3109,7 +3109,7 @@ global with sharing class Logger {
             Integer previousScenarioIndex = orderedScenarios.size() - 1;
             previousScenario = orderedScenarios.remove(previousScenarioIndex);
         }
-        if (String.isBlank(previousScenario) == true) {
+        if (String.isBlank(previousScenario)) {
             currentEntryScenario = null;
         }
 
@@ -3173,21 +3173,21 @@ global with sharing class Logger {
             return;
         }
 
-        if (suspendSaving == true) {
-            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+        if (suspendSaving) {
+            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
                 finest(getSuspendSavingLogSystemMessage());
             }
 
             return;
         }
 
-        if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+        if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
             finest(getSavingLogSystemMessage(saveMethodName));
         }
 
         List<LogEntryEvent__e> logEntryEvents = new List<LogEntryEvent__e>();
         for (LogEntryEventBuilder logEntryEventBuilder : LOG_ENTRIES_BUFFER) {
-            if (logEntryEventBuilder.shouldSave() == true) {
+            if (logEntryEventBuilder.shouldSave()) {
                 finalizeEntry(logEntryEventBuilder);
                 logEntryEvents.add(logEntryEventBuilder.getLogEntryEvent());
             }
@@ -3222,7 +3222,7 @@ global with sharing class Logger {
             when REST {
                 // If the user doesn't have a session ID (e.g., site guest user), the REST API call will fail
                 // To avoid that, use the EventBus instead (even though REST was specified)
-                if (String.isBlank(USER_SESSION_ID) == true) {
+                if (String.isBlank(USER_SESSION_ID)) {
                     saveLog(Logger.SaveMethod.EVENT_BUS);
                 } else {
                     new RestApiSaver().insertRecords(logEntryEvents);
@@ -3252,7 +3252,7 @@ global with sharing class Logger {
         try {
             return System.LoggingLevel.valueOf(loggingLevelName?.trim().toUpperCase());
         } catch (NoSuchElementException ex) {
-            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
                 LogMessage logMessage = new LogMessage(
                     'Logger - Unknown logging level {0} specified, using {1}',
                     loggingLevelName,
@@ -3300,7 +3300,7 @@ global with sharing class Logger {
             StatusApiResponse statusApiResponse = (StatusApiResponse) JSON.deserialize(response.getBody(), StatusApiResponse.class);
             return statusApiResponse;
         } catch (Exception ex) {
-            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
                 finest('Callout to api.status.salesforce.com failed').setExceptionDetails(ex);
             }
             return null;
@@ -3342,7 +3342,7 @@ global with sharing class Logger {
 
     private static LogEntryEventBuilder newEntry(System.LoggingLevel loggingLevel, Boolean shouldSave) {
         LogEntryEventBuilder logEntryEventBuilder = new LogEntryEventBuilder(getUserSettings(), loggingLevel, shouldSave, IGNORED_APEX_CLASSES);
-        if (logEntryEventBuilder.shouldSave() == true) {
+        if (logEntryEventBuilder.shouldSave()) {
             LogEntryEvent__e logEntryEvent = logEntryEventBuilder.getLogEntryEvent();
             logEntryEvent.ApiVersion__c = getOrganizationApiVersion();
             logEntryEvent.EntryScenario__c = currentEntryScenario;
@@ -3390,7 +3390,7 @@ global with sharing class Logger {
         // from an Auth Provider class (that implements Auth.RegistrationHandler). As a workaround,
         // skip calling System.Request.getCurrent() if there is no user session.
         // TODO: see if there is a better approach for this long term (or hopefully Salesforce fixes the gack error)
-        if (String.isNotBlank(USER_SESSION_ID) == true) {
+        if (String.isNotBlank(USER_SESSION_ID)) {
             return System.Request.getCurrent().getQuiddity();
         } else {
             return null;
@@ -3403,7 +3403,7 @@ global with sharing class Logger {
     }
 
     private static SaveMethod getSaveMethod(String saveMethodName) {
-        if (SAVE_METHOD_NAME_TO_SAVE_METHOD.isEmpty() == true) {
+        if (SAVE_METHOD_NAME_TO_SAVE_METHOD.isEmpty()) {
             for (SaveMethod method : SaveMethod.values()) {
                 SAVE_METHOD_NAME_TO_SAVE_METHOD.put(method.name(), method);
             }

--- a/nebula-logger/core/main/logger-engine/classes/LoggerEngineDataSelector.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerEngineDataSelector.cls
@@ -71,12 +71,12 @@ public without sharing virtual class LoggerEngineDataSelector {
     public virtual LoggerSObjectProxy.AuthSession getCachedAuthSessionProxy() {
         Id userId = System.UserInfo.getUserId();
         String cacheKey = 'AuthSession' + userId;
-        if (LoggerCache.getSessionCache().contains(cacheKey) == true) {
+        if (LoggerCache.getSessionCache().contains(cacheKey)) {
             return (LoggerSObjectProxy.AuthSession) LoggerCache.getSessionCache().get(cacheKey);
         }
 
         LoggerSObjectProxy.AuthSession authSession;
-        if (LoggerParameter.QUERY_AUTH_SESSION_DATA == true) {
+        if (LoggerParameter.QUERY_AUTH_SESSION_DATA) {
             authSession = getAuthSessionProxies(new List<Id>{ userId }).get(userId);
             LoggerCache.getSessionCache().put(cacheKey, authSession);
         }
@@ -90,7 +90,7 @@ public without sharing virtual class LoggerEngineDataSelector {
      */
     public virtual List<LoggerSObjectHandler__mdt> getCachedLoggerSObjectHandlers() {
         String cacheKey = 'EnabledLoggerSObjectHandlers';
-        if (LoggerCache.getOrganizationCache().contains(cacheKey) == true) {
+        if (LoggerCache.getOrganizationCache().contains(cacheKey)) {
             return (List<LoggerSObjectHandler__mdt>) LoggerCache.getOrganizationCache().get(cacheKey);
         }
 
@@ -115,12 +115,12 @@ public without sharing virtual class LoggerEngineDataSelector {
         }
 
         String cacheKey = 'Network' + networkId;
-        if (LoggerCache.getOrganizationCache().contains(cacheKey) == true) {
+        if (LoggerCache.getOrganizationCache().contains(cacheKey)) {
             return (LoggerSObjectProxy.Network) LoggerCache.getOrganizationCache().get(cacheKey);
         }
 
         LoggerSObjectProxy.Network networkProxy;
-        if (LoggerParameter.QUERY_NETWORK_DATA == true) {
+        if (LoggerParameter.QUERY_NETWORK_DATA) {
             networkProxy = getNetworkProxies(new List<Id>{ networkId }).get(networkId);
             LoggerCache.getOrganizationCache().put(cacheKey, networkProxy);
         }
@@ -133,12 +133,12 @@ public without sharing virtual class LoggerEngineDataSelector {
      */
     public virtual Organization getCachedOrganization() {
         String cacheKey = 'Organization';
-        if (LoggerCache.getOrganizationCache().contains(cacheKey) == true) {
+        if (LoggerCache.getOrganizationCache().contains(cacheKey)) {
             return (Organization) LoggerCache.getOrganizationCache().get(cacheKey);
         }
 
         Organization organization;
-        if (LoggerParameter.QUERY_ORGANIZATION_DATA == true) {
+        if (LoggerParameter.QUERY_ORGANIZATION_DATA) {
             organization = [
                 SELECT
                     Id,
@@ -166,12 +166,12 @@ public without sharing virtual class LoggerEngineDataSelector {
      */
     public virtual List<LogEntryTagRule__mdt> getCachedTagAssignmentRules() {
         String cacheKey = 'TagAssignmentRules';
-        if (LoggerCache.getOrganizationCache().contains(cacheKey) == true) {
+        if (LoggerCache.getOrganizationCache().contains(cacheKey)) {
             return (List<LogEntryTagRule__mdt>) LoggerCache.getOrganizationCache().get(cacheKey);
         }
 
         List<LogEntryTagRule__mdt> tagAssignmentRules = new List<LogEntryTagRule__mdt>();
-        if (LogEntryTagRule__mdt.getAll().isEmpty() == false || System.Test.isRunningTest() == true) {
+        if (LogEntryTagRule__mdt.getAll().isEmpty() == false || System.Test.isRunningTest()) {
             for (LogEntryTagRule__mdt rule : [
                 SELECT Id, SObjectField__r.QualifiedApiName, ComparisonType__c, ComparisonValue__c, Tags__c
                 FROM LogEntryTagRule__mdt
@@ -192,12 +192,12 @@ public without sharing virtual class LoggerEngineDataSelector {
     public virtual User getCachedUser() {
         Id userId = System.UserInfo.getUserId();
         String cacheKey = 'User' + userId;
-        if (LoggerCache.getSessionCache().contains(cacheKey) == true) {
+        if (LoggerCache.getSessionCache().contains(cacheKey)) {
             return (User) LoggerCache.getSessionCache().get(cacheKey);
         }
 
         User user;
-        if (LoggerParameter.QUERY_USER_DATA == true) {
+        if (LoggerParameter.QUERY_USER_DATA) {
             user = getUsers(new List<Id>{ userId }).get(userId);
             LoggerCache.getSessionCache().put(cacheKey, user);
         }

--- a/nebula-logger/core/main/logger-engine/classes/LoggerSObjectHandler.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerSObjectHandler.cls
@@ -99,11 +99,11 @@ public without sharing abstract class LoggerSObjectHandler {
      * @description Runs the handler class's logic, as well as any configured plugins
      */
     public void execute() {
-        if (System.Test.isRunningTest() == true && SOBJECT_TYPE_TO_EXECUTED_HANDLERS.containsKey(this.getSObjectType()) == false) {
+        if (System.Test.isRunningTest() && SOBJECT_TYPE_TO_EXECUTED_HANDLERS.containsKey(this.getSObjectType()) == false) {
             SOBJECT_TYPE_TO_EXECUTED_HANDLERS.put(this.getSObjectType(), new List<LoggerSObjectHandler>());
         }
 
-        Boolean shouldExecute = isEnabled && (this.handlerConfiguration == null || this.handlerConfiguration.IsEnabled__c == true);
+        Boolean shouldExecute = isEnabled && (this.handlerConfiguration == null || this.handlerConfiguration.IsEnabled__c);
         if (shouldExecute == false) {
             return;
         }
@@ -138,7 +138,7 @@ public without sharing abstract class LoggerSObjectHandler {
 
         this.executePlugins();
 
-        if (System.Test.isRunningTest() == true) {
+        if (System.Test.isRunningTest()) {
             SOBJECT_TYPE_TO_EXECUTED_HANDLERS.get(this.getSObjectType()).add(this);
         }
     }
@@ -169,7 +169,7 @@ public without sharing abstract class LoggerSObjectHandler {
     }
 
     private void executePlugins() {
-        if (this.pluginConfigurations == null || this.pluginConfigurations.isEmpty() == true) {
+        if (this.pluginConfigurations == null || this.pluginConfigurations.isEmpty()) {
             return;
         }
 
@@ -187,7 +187,7 @@ public without sharing abstract class LoggerSObjectHandler {
         LoggerPlugin.Triggerable apexPlugin = LoggerPlugin.newTriggerableInstance(configuration.SObjectHandlerApexClass__c);
         apexPlugin?.execute(configuration, this.input);
 
-        if (System.Test.isRunningTest() == true && apexPlugin != null) {
+        if (System.Test.isRunningTest() && apexPlugin != null) {
             this.executedApexPlugins.add(apexPlugin);
         }
     }
@@ -210,11 +210,11 @@ public without sharing abstract class LoggerSObjectHandler {
                     this.input.triggerNewMap.putAll(new Map<Id, SObject>(updatedTriggerNew));
                 }
             }
-            if (System.Test.isRunningTest() == true && flowPlugin != null) {
+            if (System.Test.isRunningTest() && flowPlugin != null) {
                 this.executedFlowPlugins.add(flowPlugin);
             }
         } catch (TypeException ex) {
-            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
                 Logger.warn('Unknown Flow ' + configuration.SObjectHandlerFlowName__c + ', skipping plugin execution', configuration, ex);
             }
         }
@@ -250,7 +250,7 @@ public without sharing abstract class LoggerSObjectHandler {
             sobjectTypeToHandlerConfiguration.put(sobjectType, handlerConfiguration);
         }
 
-        if (System.Test.isRunningTest() == true) {
+        if (System.Test.isRunningTest()) {
             sobjectTypeToHandlerConfiguration.clear();
         }
 
@@ -258,7 +258,7 @@ public without sharing abstract class LoggerSObjectHandler {
     }
 
     private static Schema.SObjectType prepHandlerType(LoggerSObjectHandler__mdt handlerConfiguration) {
-        if (String.isNotBlank(handlerConfiguration.SObjectTypeOverride__c) == true) {
+        if (String.isNotBlank(handlerConfiguration.SObjectTypeOverride__c)) {
             handlerConfiguration.SObjectType__c = handlerConfiguration.SObjectTypeOverride__c;
         }
 

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
@@ -6,7 +6,7 @@
 import { LightningElement, api } from 'lwc';
 import { createLoggerService } from './loggerService';
 
-const CURRENT_VERSION_NUMBER = 'v4.11.7';
+const CURRENT_VERSION_NUMBER = 'v4.11.8';
 
 export default class Logger extends LightningElement {
     #loggerService = createLoggerService();

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/HttpResponseHeaders__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/HttpResponseHeaders__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HttpResponseHeaders__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>HTTP Response Headers</label>
+    <length>5000</length>
+    <securityClassification>Confidential</securityClassification>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
@@ -251,6 +251,17 @@ private class LoggerParameter_Tests {
     }
 
     @IsTest
+    static void it_should_return_constant_value_for_store_http_response_header_values() {
+        Boolean mockValue = false;
+        LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'StoreHttpResponseHeaderValues', Value__c = JSON.serialize(mockValue));
+        LoggerParameter.setMock(mockParameter);
+
+        Boolean returnedValue = LoggerParameter.STORE_HTTP_RESPONSE_HEADER_VALUES;
+
+        System.Assert.areEqual(mockValue, returnedValue);
+    }
+
+    @IsTest
     static void it_should_return_constant_value_for_system_debug_message_format() {
         // The constant LoggerParameter.SYSTEM_DEBUG_MESSAGE_FORMAT is unique - its value should always be
         // loaded from LoggerParameter__mdt, even in a test context so that orgs can control the output of debug

--- a/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
+++ b/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
@@ -35,7 +35,7 @@ public class LoggerMockDataCreator {
      * @description Creates a mock instance of `Database.LeadConvertResult` - a mock is used instead of an actual instance
      *              to help speed up tests, and to support writing unit tests (instead of integration tests). A fake
      *              record ID is automatically included.
-     * @param  isSuccess Indicates if the generated mock should have `isSuccess` == true
+     * @param  isSuccess Indicates if the generated mock should have `isSuccess`
      * @return   The mock instance of `Database.LeadConvertResult`
      */
     public static Database.LeadConvertResult createDatabaseLeadConvertResult(Boolean isSuccess) {
@@ -45,12 +45,12 @@ public class LoggerMockDataCreator {
     /**
      * @description Creates a mock instance of `Database.LeadConvertResult` - a mock is used instead of an actual instance
      *              to help speed up tests, and to support writing unit tests (instead of integration tests)
-     * @param  isSuccess Indicates if the generated mock should have `isSuccess` == true
+     * @param  isSuccess Indicates if the generated mock should have `isSuccess`
      * @param  recordId  The record ID to use within the mock result
      * @return   The mock instance of `Database.LeadConvertResult`
      */
     public static Database.LeadConvertResult createDatabaseLeadConvertResult(Boolean isSuccess, Id recordId) {
-        if (isSuccess == true) {
+        if (isSuccess) {
             return (Database.LeadConvertResult) JSON.deserialize('{"success": true, "leadid": "' + recordId + '"}', Database.LeadConvertResult.class);
         } else {
             return (Database.LeadConvertResult) JSON.deserialize(
@@ -66,7 +66,7 @@ public class LoggerMockDataCreator {
      * @description Creates a mock instance of `Database.DeleteResult` - a mock is used instead of an actual instance
      *              to help speed up tests, and to support writing unit tests (instead of integration tests). A fake
      *              record ID is automatically included.
-     * @param  isSuccess Indicates if the generated mock should have `isSuccess` == true
+     * @param  isSuccess Indicates if the generated mock should have `isSuccess`
      * @return   The mock instance of `Database.DeleteResult`
      */
     public static Database.DeleteResult createDatabaseDeleteResult(Boolean isSuccess) {
@@ -76,12 +76,12 @@ public class LoggerMockDataCreator {
     /**
      * @description Creates a mock instance of `Database.DeleteResult` - a mock is used instead of an actual instance
      *              to help speed up tests, and to support writing unit tests (instead of integration tests)
-     * @param  isSuccess Indicates if the generated mock should have `isSuccess` == true
+     * @param  isSuccess Indicates if the generated mock should have `isSuccess`
      * @param  recordId  The record ID to use within the mock result
      * @return   The mock instance of `Database.DeleteResult`
      */
     public static Database.DeleteResult createDatabaseDeleteResult(Boolean isSuccess, Id recordId) {
-        if (isSuccess == true) {
+        if (isSuccess) {
             return (Database.DeleteResult) JSON.deserialize('{"success": true, "id": "' + recordId + '"}', Database.DeleteResult.class);
         } else {
             return (Database.DeleteResult) JSON.deserialize(
@@ -95,7 +95,7 @@ public class LoggerMockDataCreator {
      * @description Creates a mock instance of `Database.MergeResult` - a mock is used instead of an actual instance
      *              to help speed up tests, and to support writing unit tests (instead of integration tests). A fake
      *              record ID is automatically included.
-     * @param  isSuccess Indicates if the generated mock should have `isSuccess` == true
+     * @param  isSuccess Indicates if the generated mock should have `isSuccess`
      * @return   The mock instance of `Database.MergeResult`
      */
     public static Database.MergeResult createDatabaseMergeResult(Boolean isSuccess) {
@@ -105,12 +105,12 @@ public class LoggerMockDataCreator {
     /**
      * @description Creates a mock instance of `Database.MergeResult` - a mock is used instead of an actual instance
      *              to help speed up tests, and to support writing unit tests (instead of integration tests)
-     * @param  isSuccess Indicates if the generated mock should have `isSuccess` == true
+     * @param  isSuccess Indicates if the generated mock should have `isSuccess`
      * @param  recordId  The record ID to use within the mock result
      * @return   The mock instance of `Database.MergeResult`
      */
     public static Database.MergeResult createDatabaseMergeResult(Boolean isSuccess, Id recordId) {
-        if (isSuccess == true) {
+        if (isSuccess) {
             return (Database.MergeResult) JSON.deserialize('{"success": true, "id": "' + recordId + '"}', Database.MergeResult.class);
         } else {
             return (Database.MergeResult) JSON.deserialize(
@@ -124,7 +124,7 @@ public class LoggerMockDataCreator {
      * @description Creates a mock instance of `Database.SaveResult` - a mock is used instead of an actual instance
      *              to help speed up tests, and to support writing unit tests (instead of integration tests). A fake
      *              record ID is automatically included.
-     * @param  isSuccess Indicates if the generated mock should have `isSuccess` == true
+     * @param  isSuccess Indicates if the generated mock should have `isSuccess`
      * @return   The mock instance of `Database.SaveResult`
      */
     public static Database.SaveResult createDatabaseSaveResult(Boolean isSuccess) {
@@ -134,12 +134,12 @@ public class LoggerMockDataCreator {
     /**
      * @description Creates a mock instance of `Database.SaveResult` - a mock is used instead of an actual instance
      *              to help speed up tests, and to support writing unit tests (instead of integration tests)
-     * @param  isSuccess Indicates if the generated mock should have `isSuccess` == true
+     * @param  isSuccess Indicates if the generated mock should have `isSuccess`
      * @param  recordId  The record ID to use within the mock result
      * @return   The mock instance of `Database.SaveResult`
      */
     public static Database.SaveResult createDatabaseSaveResult(Boolean isSuccess, Id recordId) {
-        if (isSuccess == true) {
+        if (isSuccess) {
             return (Database.SaveResult) JSON.deserialize('{"success": true, "id": "' + recordId + '"}', Database.SaveResult.class);
         } else {
             return (Database.SaveResult) JSON.deserialize(
@@ -153,7 +153,7 @@ public class LoggerMockDataCreator {
      * @description Creates a mock instance of `Database.UndeleteResult` - a mock is used instead of an actual instance
      *              to help speed up tests, and to support writing unit tests (instead of integration tests). A fake
      *              record ID is automatically included.
-     * @param  isSuccess Indicates if the generated mock should have `isSuccess` == true
+     * @param  isSuccess Indicates if the generated mock should have `isSuccess`
      * @return   The mock instance of `Database.UndeleteResult`
      */
     public static Database.UndeleteResult createDatabaseUndeleteResult(Boolean isSuccess) {
@@ -163,12 +163,12 @@ public class LoggerMockDataCreator {
     /**
      * @description Creates a mock instance of `Database.UndeleteResult` - a mock is used instead of an actual instance
      *              to help speed up tests, and to support writing unit tests (instead of integration tests)
-     * @param  isSuccess Indicates if the generated mock should have `isSuccess` == true
+     * @param  isSuccess Indicates if the generated mock should have `isSuccess`
      * @param  recordId  The record ID to use within the mock result
      * @return   The mock instance of `Database.UndeleteResult`
      */
     public static Database.UndeleteResult createDatabaseUndeleteResult(Boolean isSuccess, Id recordId) {
-        if (isSuccess == true) {
+        if (isSuccess) {
             return (Database.UndeleteResult) JSON.deserialize('{"success": true, "id": "' + recordId + '"}', Database.UndeleteResult.class);
         } else {
             return (Database.UndeleteResult) JSON.deserialize(
@@ -182,8 +182,8 @@ public class LoggerMockDataCreator {
      * @description Creates a mock instance of `Database.UpsertResult` - a mock is used instead of an actual instance
      *              to help speed up tests, and to support writing unit tests (instead of integration tests). A fake
      *              record ID is automatically included.
-     * @param  isSuccess Indicates if the generated mock should have `isSuccess` == true
-     * @param  isCreated Indicates if the generated mock should have `isCreated` == true
+     * @param  isSuccess Indicates if the generated mock should have `isSuccess`
+     * @param  isCreated Indicates if the generated mock should have `isCreated`
      * @return   The mock instance of `Database.UpsertResult`
      */
     public static Database.UpsertResult createDatabaseUpsertResult(Boolean isSuccess, Boolean isCreated) {
@@ -193,13 +193,13 @@ public class LoggerMockDataCreator {
     /**
      * @description Creates a mock instance of `Database.UpsertResult` - a mock is used instead of an actual instance
      *              to help speed up tests, and to support writing unit tests (instead of integration tests)
-     * @param  isSuccess Indicates if the generated mock should have `isSuccess` == true
-     * @param  isCreated Indicates if the generated mock should have `isCreated` == true
+     * @param  isSuccess Indicates if the generated mock should have `isSuccess`
+     * @param  isCreated Indicates if the generated mock should have `isCreated`
      * @param  recordId  The record ID to use within the mock result
      * @return   The mock instance of `Database.UpsertResult`
      */
     public static Database.UpsertResult createDatabaseUpsertResult(Boolean isSuccess, Boolean isCreated, Id recordId) {
-        if (isSuccess == true) {
+        if (isSuccess) {
             return (Database.UpsertResult) JSON.deserialize(
                 '{"success": ' + isSuccess + ', "created": ' + isCreated + ', "id": "' + recordId + '"}',
                 Database.UpsertResult.class
@@ -336,9 +336,9 @@ public class LoggerMockDataCreator {
         Organization organization = getOrganization();
 
         String orgEnvironmentType;
-        if (organization.IsSandbox == true && organization.TrialExpirationDate != null) {
+        if (organization.IsSandbox && organization.TrialExpirationDate != null) {
             orgEnvironmentType = 'Scratch Org';
-        } else if (organization.IsSandbox == true) {
+        } else if (organization.IsSandbox) {
             orgEnvironmentType = 'Sandbox';
         } else {
             orgEnvironmentType = 'Production';
@@ -540,11 +540,11 @@ public class LoggerMockDataCreator {
             this.request = request;
 
             this.response = new System.HttpResponse();
-            if (String.isNotBlank(this.responseBody) == true) {
+            if (String.isNotBlank(this.responseBody)) {
                 response.setBody(this.responseBody);
             }
             response.setStatusCode(this.statusCode);
-            if (String.isNotBlank(this.statusMessage) == true) {
+            if (String.isNotBlank(this.statusMessage)) {
                 response.setStatus(this.statusMessage);
             }
             return response;
@@ -620,7 +620,7 @@ public class LoggerMockDataCreator {
         }
 
         private void loadFields() {
-            if (SOBJECT_TYPE_TO_ALL_FIELDS.containsKey(this.sobjectType) == true && SOBJECT_TYPE_TO_REQUIRED_FIELDS.containsKey(this.sobjectType) == true) {
+            if (SOBJECT_TYPE_TO_ALL_FIELDS.containsKey(this.sobjectType) && SOBJECT_TYPE_TO_REQUIRED_FIELDS.containsKey(this.sobjectType)) {
                 return;
             }
 

--- a/nebula-logger/core/tests/log-management/classes/LogBatchPurgeScheduler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogBatchPurgeScheduler_Tests.cls
@@ -66,7 +66,7 @@ private class LogBatchPurgeScheduler_Tests {
         Boolean foundExpectedMessage = false;
         String expectedMessage = new LogMessage(LogBatchPurgeScheduler.SCHEDULER_SYSTEM_MESSAGE_TEMPLATE, (System.SchedulableContext) null).getMessage();
         for (LogEntry__c logEntry : logEntries) {
-            if (logEntry.Message__c.contains(expectedMessage) == true) {
+            if (logEntry.Message__c.contains(expectedMessage)) {
                 foundExpectedMessage = true;
             }
         }

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -1180,7 +1180,7 @@ private class LogEntryEventHandler_Tests {
         System.Assert.areEqual(1, [SELECT COUNT() FROM Log__c], '1 matching Log__c record should have been generated');
         System.Assert.areEqual(
             1,
-            [SELECT COUNT() FROM LogEntry__c WHERE LoggingLevel__c = :System.LoggingLevel.INFO.name()],
+            [SELECT COUNT() FROM LogEntry__c WHERE LoggingLevel__c = :builder.getLogEntryEvent().LoggingLevel__c],
             '1 matching LogEntry__c record should have been generated'
         );
         System.Assert.areEqual(1, [SELECT COUNT() FROM LoggerTag__c WHERE Name = :exampleTag], '1 matching LoggerTag__c record should have been generated');
@@ -1311,6 +1311,7 @@ private class LogEntryEventHandler_Tests {
                         HttpResponseBody__c,
                         HttpResponseBodyMasked__c,
                         HttpResponseHeaderKeys__c,
+                        HttpResponseHeaders__c,
                         HttpResponseStatus__c,
                         HttpResponseStatusCode__c,
                         LimitsAggregateQueriesMax__c,
@@ -1522,6 +1523,7 @@ private class LogEntryEventHandler_Tests {
             logEntry.HttpResponseHeaderKeys__c,
             'logEntry.HttpResponseHeaderKeys__c was not properly set'
         );
+        System.Assert.areEqual(logEntryEvent.HttpResponseHeaders__c, logEntry.HttpResponseHeaders__c, 'logEntry.HttpResponseHeaders__c was not properly set');
         System.Assert.areEqual(logEntryEvent.HttpResponseStatus__c, logEntry.HttpResponseStatus__c, 'logEntry.HttpResponseStatus__c was not properly set');
         System.Assert.areEqual(
             logEntryEvent.HttpResponseStatusCode__c,

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -1381,9 +1381,9 @@ private class LogEntryEventHandler_Tests {
     private static void validateLogFields(LogEntryEvent__e logEntryEvent, Log__c log) {
         Organization org = [SELECT Id, Name, InstanceName, IsSandbox, NamespacePrefix, OrganizationType, TrialExpirationDate FROM Organization];
         String orgEnvironmentType;
-        if (org.IsSandbox == true && org.TrialExpirationDate != null) {
+        if (org.IsSandbox && org.TrialExpirationDate != null) {
             orgEnvironmentType = 'Scratch Org';
-        } else if (org.IsSandbox == true) {
+        } else if (org.IsSandbox) {
             orgEnvironmentType = 'Sandbox';
         } else {
             orgEnvironmentType = 'Production';

--- a/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
@@ -457,7 +457,7 @@ private class LogEntryHandler_Tests {
         // FIXME the implementation does not seem to properly handle classes with a namespace prefix
         // (including when both the managed & unlocked packages are installed in an org), so skip the tests for now,
         // but revisit this test + implementation
-        if (String.isNotBlank(Logger.getNamespacePrefix()) == true) {
+        if (String.isNotBlank(Logger.getNamespacePrefix())) {
             return;
         }
 
@@ -509,7 +509,7 @@ private class LogEntryHandler_Tests {
         // FIXME the implementation does not seem to properly handle classes with a namespace prefix
         // (including when both the managed & unlocked packages are installed in an org), so skip the tests for now,
         // but revisit this test + implementation
-        if (String.isNotBlank(Logger.getNamespacePrefix()) == true) {
+        if (String.isNotBlank(Logger.getNamespacePrefix())) {
             return;
         }
 

--- a/nebula-logger/core/tests/log-management/classes/LoggerEmailSender_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerEmailSender_Tests.cls
@@ -83,7 +83,7 @@ private class LoggerEmailSender_Tests {
             LoggerEmailSender.SENT_EMAILS.get(0).getHtmlBody().contains(saveResultsWithErrors.get(0).errors.get(0).getMessage()),
             'Email message should contain SaveResult error message'
         );
-        if (LoggerEmailSender.IS_EMAIL_DELIVERABILITY_AVAILABLE == true) {
+        if (LoggerEmailSender.IS_EMAIL_DELIVERABILITY_AVAILABLE) {
             System.Assert.areEqual(1, System.Limits.getEmailInvocations(), 'Email should have been sent');
         } else {
             System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'Deliverability is not currently enabled');
@@ -134,7 +134,7 @@ private class LoggerEmailSender_Tests {
             LoggerEmailSender.SENT_EMAILS.get(0).getHtmlBody().contains(upsertResultsWithErrors.get(0).errors.get(0).getMessage()),
             'Email message should contain UpsertResult error message'
         );
-        if (LoggerEmailSender.IS_EMAIL_DELIVERABILITY_AVAILABLE == true) {
+        if (LoggerEmailSender.IS_EMAIL_DELIVERABILITY_AVAILABLE) {
             System.Assert.areEqual(1, System.Limits.getEmailInvocations(), 'Email should have been sent');
         } else {
             System.Assert.areEqual(0, System.Limits.getEmailInvocations(), 'Deliverability is not currently enabled');

--- a/nebula-logger/core/tests/log-management/classes/LoggerHomeHeaderController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerHomeHeaderController_Tests.cls
@@ -26,7 +26,7 @@ private class LoggerHomeHeaderController_Tests {
         System.Assert.areEqual(0, returnedEnvironment.loggerEnabledPluginsCount);
         System.Assert.isNull(returnedEnvironment.loggerEnabledPlugins);
         System.Assert.areEqual(
-            String.isNotBlank(Logger.getNamespacePrefix()) == true ? Logger.getNamespacePrefix() : '(none)',
+            String.isNotBlank(Logger.getNamespacePrefix()) ? Logger.getNamespacePrefix() : '(none)',
             returnedEnvironment.loggerNamespacePrefix
         );
         System.Assert.areEqual(Logger.getVersionNumber(), returnedEnvironment.loggerVersionNumber);
@@ -61,7 +61,7 @@ private class LoggerHomeHeaderController_Tests {
         System.Assert.areEqual(0, returnedEnvironment.loggerEnabledPluginsCount);
         System.Assert.isNull(returnedEnvironment.loggerEnabledPlugins);
         System.Assert.areEqual(
-            String.isNotBlank(Logger.getNamespacePrefix()) == true ? Logger.getNamespacePrefix() : '(none)',
+            String.isNotBlank(Logger.getNamespacePrefix()) ? Logger.getNamespacePrefix() : '(none)',
             returnedEnvironment.loggerNamespacePrefix
         );
         System.Assert.areEqual(Logger.getVersionNumber(), returnedEnvironment.loggerVersionNumber);
@@ -90,7 +90,7 @@ private class LoggerHomeHeaderController_Tests {
         System.Assert.areEqual(0, returnedEnvironment.loggerEnabledPluginsCount);
         System.Assert.isNull(returnedEnvironment.loggerEnabledPlugins);
         System.Assert.areEqual(
-            String.isNotBlank(Logger.getNamespacePrefix()) == true ? Logger.getNamespacePrefix() : '(none)',
+            String.isNotBlank(Logger.getNamespacePrefix()) ? Logger.getNamespacePrefix() : '(none)',
             returnedEnvironment.loggerNamespacePrefix
         );
         System.Assert.areEqual(Logger.getVersionNumber(), returnedEnvironment.loggerVersionNumber);

--- a/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerSettingsController_Tests.cls
@@ -14,7 +14,7 @@ private class LoggerSettingsController_Tests {
 
         System.Assert.areEqual(expectedLoggingLevelSize, picklistOptions.size());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
-            if (String.isBlank(picklistOption.value) == true) {
+            if (String.isBlank(picklistOption.value)) {
                 System.Assert.areEqual('--None--', picklistOption.label);
             } else {
                 System.Assert.areEqual(picklistOption.value, picklistOption.label);
@@ -43,7 +43,7 @@ private class LoggerSettingsController_Tests {
         Integer expectedLogPurgeActionsSize = expectedLogPurgeActions.size() + 1; // '--NONE--' is automatically included
         System.Assert.areEqual(expectedLogPurgeActionsSize, picklistOptions.size());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
-            if (String.isBlank(picklistOption.value) == true) {
+            if (String.isBlank(picklistOption.value)) {
                 System.Assert.areEqual('--None--', picklistOption.label);
             } else {
                 System.Assert.areEqual(picklistOption.value, picklistOption.label);
@@ -60,7 +60,7 @@ private class LoggerSettingsController_Tests {
 
         System.Assert.areEqual(expectedLoggerSaveMethodSize, picklistOptions.size());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
-            if (String.isBlank(picklistOption.value) == true) {
+            if (String.isBlank(picklistOption.value)) {
                 System.Assert.areEqual('--None--', picklistOption.label);
             } else {
                 System.Assert.areEqual(picklistOption.value, picklistOption.label);
@@ -89,7 +89,7 @@ private class LoggerSettingsController_Tests {
         Integer expectedPlatformEventStorageLocationSize = expectedSaveMethods.size() + 1; // '--NONE--' is automatically included
         System.Assert.areEqual(expectedPlatformEventStorageLocationSize, picklistOptions.size(), picklistOptions.toString());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
-            if (String.isBlank(picklistOption.value) == true) {
+            if (String.isBlank(picklistOption.value)) {
                 System.Assert.areEqual('--None--', picklistOption.label);
             } else {
                 System.Assert.areEqual(picklistOption.value, picklistOption.label, 'picklistOption==' + picklistOption);
@@ -117,7 +117,7 @@ private class LoggerSettingsController_Tests {
         Integer expectedLoggerSaveMethodSize = expectedSaveMethods.size() + 1; // '--NONE--' is automatically included
         System.Assert.areEqual(expectedLoggerSaveMethodSize, picklistOptions.size(), picklistOptions.toString());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
-            if (String.isBlank(picklistOption.value) == true) {
+            if (String.isBlank(picklistOption.value)) {
                 System.Assert.areEqual('--None--', picklistOption.label);
             } else {
                 System.Assert.areEqual(picklistOption.value, picklistOption.label, 'picklistOption==' + picklistOption);
@@ -135,7 +135,7 @@ private class LoggerSettingsController_Tests {
 
         System.Assert.areEqual(expectedSetupOwnerTypeSize, picklistOptions.size());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
-            if (String.isBlank(picklistOption.value) == true) {
+            if (String.isBlank(picklistOption.value)) {
                 System.Assert.areEqual('--None--', picklistOption.label);
             } else {
                 System.Assert.areEqual(picklistOption.value, picklistOption.label);
@@ -159,7 +159,7 @@ private class LoggerSettingsController_Tests {
 
         System.Assert.areEqual(expectedShareAccessLevelSize, picklistOptions.size(), picklistOptions.toString());
         for (LoggerSettingsController.PicklistOption picklistOption : picklistOptions) {
-            if (String.isBlank(picklistOption.value) == true) {
+            if (String.isBlank(picklistOption.value)) {
                 System.Assert.areEqual('--None--', picklistOption.label);
             } else {
                 System.Assert.areEqual(picklistOption.value, picklistOption.label);

--- a/nebula-logger/core/tests/log-management/utilities/LoggerTestConfigurator.cls
+++ b/nebula-logger/core/tests/log-management/utilities/LoggerTestConfigurator.cls
@@ -114,7 +114,7 @@ public without sharing class LoggerTestConfigurator {
 
     /**
      * @description Creates mock instances of `LoggerSObjectHandler__mdt` for each `SObjectType` used by Nebula Logger,
-     *              with each `LoggerSObjectHandler__mdt` automatically set to `IsEnabled__c == true`
+     *              with `IsEnabled__c` set to `true` on each `LoggerSObjectHandler__mdt` record
      */
     public static void setupMockSObjectHandlerConfigurations() {
         setupMockSObjectHandlerConfigurations(true);
@@ -122,7 +122,7 @@ public without sharing class LoggerTestConfigurator {
 
     /**
      * @description Creates mock instances of `LoggerSObjectHandler__mdt` for each `SObjectType` used by Nebula Logger,
-     *              with each `LoggerSObjectHandler__mdt` enabled/disabled based on the provided boolean
+     *              with `IsEnabled__c` set  based on the provided boolean on each `LoggerSObjectHandler__mdt` record
      * @param  isEnabled The Boolean value to control if all mock `LoggerSObjectHandler__mdt` records should be enabled (`true`) or disabled (`false`)
      */
     public static void setupMockSObjectHandlerConfigurations(Boolean isEnabled) {

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -1115,7 +1115,10 @@ private class LogEntryEventBuilder_Tests {
     }
 
     @IsTest
-    static void it_should_set_http_response_fields_when_populated() {
+    static void it_should_set_http_response_fields_when_storing_header_values_is_enabled() {
+        LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'StoreHttpResponseHeaderValues', Value__c = String.valueOf(true));
+        LoggerParameter.setMock(mockParameter);
+        System.Assert.isTrue(LoggerParameter.STORE_HTTP_RESPONSE_HEADER_VALUES);
         LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
@@ -1136,6 +1139,31 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.areEqual(response.getBody(), builder.getLogEntryEvent().HttpResponseBody__c);
         System.Assert.areEqual(String.join(response.getHeaderKeys(), '\n'), builder.getLogEntryEvent().HttpResponseHeaderKeys__c);
         System.Assert.areEqual(String.join(formattedHeaders, '\n'), builder.getLogEntryEvent().HttpResponseHeaders__c);
+        System.Assert.areEqual(response.getStatus(), builder.getLogEntryEvent().HttpResponseStatus__c);
+        System.Assert.areEqual(response.getStatusCode(), builder.getLogEntryEvent().HttpResponseStatusCode__c);
+    }
+
+    @IsTest
+    static void it_should_set_http_response_fields_when_storing_header_values_is_disabled() {
+        LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'StoreHttpResponseHeaderValues', Value__c = String.valueOf(false));
+        LoggerParameter.setMock(mockParameter);
+        System.Assert.isFalse(LoggerParameter.STORE_HTTP_RESPONSE_HEADER_VALUES);
+        LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true, new Set<String>());
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
+        System.HttpResponse response = new System.HttpResponse();
+        response.setBody('Hello, world!');
+        response.setHeader('someKey', 'some string value');
+        response.setHeader('anotherKey', 'an amazing example value, wow');
+        response.setStatus('STATUS_GOOD_JOB_YOU_DID_IT');
+        response.setStatusCode(201);
+
+        builder.setHttpResponseDetails(response);
+
+        System.Assert.areEqual(response.getBody(), builder.getLogEntryEvent().HttpResponseBody__c);
+        System.Assert.areEqual(String.join(response.getHeaderKeys(), '\n'), builder.getLogEntryEvent().HttpResponseHeaderKeys__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpResponseHeaders__c);
         System.Assert.areEqual(response.getStatus(), builder.getLogEntryEvent().HttpResponseStatus__c);
         System.Assert.areEqual(response.getStatusCode(), builder.getLogEntryEvent().HttpResponseStatusCode__c);
     }

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -1109,6 +1109,7 @@ private class LogEntryEventBuilder_Tests {
 
         System.Assert.isNull(builder.getLogEntryEvent().HttpResponseBody__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpResponseHeaderKeys__c);
+        System.Assert.isNull(builder.getLogEntryEvent().HttpResponseHeaders__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpResponseStatus__c);
         System.Assert.isNull(builder.getLogEntryEvent().HttpResponseStatusCode__c);
     }
@@ -1128,8 +1129,13 @@ private class LogEntryEventBuilder_Tests {
 
         builder.setHttpResponseDetails(response);
 
+        List<String> formattedHeaders = new List<String>();
+        for (String headerKey : response.getHeaderKeys()) {
+            formattedHeaders.add(headerKey + ': ' + response.getHeader(headerKey));
+        }
         System.Assert.areEqual(response.getBody(), builder.getLogEntryEvent().HttpResponseBody__c);
         System.Assert.areEqual(String.join(response.getHeaderKeys(), '\n'), builder.getLogEntryEvent().HttpResponseHeaderKeys__c);
+        System.Assert.areEqual(String.join(formattedHeaders, '\n'), builder.getLogEntryEvent().HttpResponseHeaders__c);
         System.Assert.areEqual(response.getStatus(), builder.getLogEntryEvent().HttpResponseStatus__c);
         System.Assert.areEqual(response.getStatusCode(), builder.getLogEntryEvent().HttpResponseStatusCode__c);
     }

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -1197,7 +1197,7 @@ private class LogEntryEventBuilder_Tests {
     static void it_should_not_set_stack_trace_for_new_builder_instance_when_disabled_via_logger_parameter() {
         // Don't bother testing stack trace logic when using a namespace prefix - there are
         // some platform limitations that prevent these tests from behaving as expected
-        if (LogEntryEventBuilder.class.getName().contains('.') == true) {
+        if (LogEntryEventBuilder.class.getName().contains('.')) {
             return;
         }
 
@@ -1215,7 +1215,7 @@ private class LogEntryEventBuilder_Tests {
     static void it_should_not_set_stack_trace_for_parseStackTrace_method_when_disabled_via_logger_parameter() {
         // Don't bother testing stack trace logic when using a namespace prefix - there are
         // some platform limitations that prevent these tests from behaving as expected
-        if (LogEntryEventBuilder.class.getName().contains('.') == true) {
+        if (LogEntryEventBuilder.class.getName().contains('.')) {
             return;
         }
 
@@ -1234,7 +1234,7 @@ private class LogEntryEventBuilder_Tests {
     static void it_should_set_stack_trace_and_origin_location_for_class_constructor_trace_string() {
         // Don't bother testing stack trace logic when using a namespace prefix - there are
         // some platform limitations that prevent these tests from behaving as expected
-        if (LogEntryEventBuilder.class.getName().contains('.') == true) {
+        if (LogEntryEventBuilder.class.getName().contains('.')) {
             return;
         }
 
@@ -1258,7 +1258,7 @@ private class LogEntryEventBuilder_Tests {
     static void it_should_set_stack_trace_and_origin_location_for_method_stack_trace_string() {
         // Don't bother testing stack trace logic when using a namespace prefix - there are
         // some platform limitations that prevent these tests from behaving as expected
-        if (LogEntryEventBuilder.class.getName().contains('.') == true) {
+        if (LogEntryEventBuilder.class.getName().contains('.')) {
             return;
         }
 
@@ -1431,7 +1431,7 @@ private class LogEntryEventBuilder_Tests {
     static void it_should_use_configured_log_entry_event_fields_for_debug_string() {
         // Don't bother testing stack trace logic when using a namespace prefix - there are
         // some platform limitations that prevent these tests from behaving as expected
-        if (LogEntryEventBuilder.class.getName().contains('.') == true) {
+        if (LogEntryEventBuilder.class.getName().contains('.')) {
             return;
         }
 

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerSObjectProxy_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerSObjectProxy_Tests.cls
@@ -27,7 +27,7 @@ private class LoggerSObjectProxy_Tests {
             FROM AuthSession
             LIMIT 1
         ];
-        if (authSessionRecords.isEmpty() == true) {
+        if (authSessionRecords.isEmpty()) {
             // Since the AuthSession object cannot be mocked, the test can only run as an integration test
             // No need to fail the test if there isn't a AuthSession record available via querying
             return;
@@ -57,7 +57,7 @@ private class LoggerSObjectProxy_Tests {
             FROM LoginHistory
             LIMIT 1
         ];
-        if (loginHistoryRecords.isEmpty() == true) {
+        if (loginHistoryRecords.isEmpty()) {
             // Since the LoginHistory object cannot be mocked, the test can only run as an integration test
             // No need to fail the test if there isn't a LoginHistory record available via querying
             return;

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -470,7 +470,7 @@ private class Logger_Tests {
     static void it_should_not_ignore_origin_when_apex_class_type_not_specified() {
         // Don't bother testing stack trace logic when using a namespace prefix - there are
         // some platform limitations that prevent these tests from behaving as expected
-        if (String.isNotBlank(Logger.getNamespacePrefix()) == true) {
+        if (String.isNotBlank(Logger.getNamespacePrefix())) {
             return;
         }
 
@@ -487,7 +487,7 @@ private class Logger_Tests {
     static void it_should_ignore_origin_when_apex_class_type_specified() {
         // Don't bother testing stack trace logic when using a namespace prefix - there are
         // some platform limitations that prevent these tests from behaving as expected
-        if (String.isNotBlank(Logger.getNamespacePrefix()) == true) {
+        if (String.isNotBlank(Logger.getNamespacePrefix())) {
             return;
         }
 

--- a/nebula-logger/core/tests/logger-engine/utilities/LoggerMockDataStore.cls
+++ b/nebula-logger/core/tests/logger-engine/utilities/LoggerMockDataStore.cls
@@ -41,7 +41,7 @@ public without sharing class LoggerMockDataStore {
 
         public override List<Database.SaveResult> insertRecords(List<SObject> records) {
             List<Database.SaveResult> mockSaveResults = new List<Database.SaveResult>();
-            if (records == null || records.isEmpty() == true) {
+            if (records == null || records.isEmpty()) {
                 return mockSaveResults;
             }
 
@@ -99,7 +99,7 @@ public without sharing class LoggerMockDataStore {
         }
 
         public void deliver() {
-            if (this.publishedPlatformEvents.isEmpty() == true) {
+            if (this.publishedPlatformEvents.isEmpty()) {
                 return;
             }
 
@@ -161,7 +161,7 @@ public without sharing class LoggerMockDataStore {
         validateRequiredFieldsArePopulated(record);
         validateStringFieldsAreNotTooLong(record);
 
-        if (recordIsValid == true && populateMockId == true) {
+        if (recordIsValid && populateMockId) {
             record.Id = LoggerMockDataCreator.createId(record.getSObjectType());
         }
         return LoggerMockDataCreator.createDatabaseSaveResult(recordIsValid, record.Id);
@@ -188,7 +188,7 @@ public without sharing class LoggerMockDataStore {
         Schema.SObjectType sobjectType = record.getSObjectType();
         for (Schema.SObjectField stringField : SOBJECT_TYPE_TO_STRING_FIELDS.get(sobjectType)) {
             Boolean isFieldValueTooLong = ((String) record.get(stringField))?.length() > stringField.getDescribe().getLength();
-            if (isFieldValueTooLong == true) {
+            if (isFieldValueTooLong) {
                 SObjectException ex = new SObjectException();
                 ex.setMessage('The field value for ' + stringField + ' is too long: ' + record.get(stringField));
                 throw ex;
@@ -197,7 +197,7 @@ public without sharing class LoggerMockDataStore {
     }
 
     private static void loadFields(Schema.SObjectType sobjectType) {
-        if (SOBJECT_TYPE_TO_ALL_FIELDS.containsKey(sobjectType) == true && SOBJECT_TYPE_TO_REQUIRED_FIELDS.containsKey(sobjectType) == true) {
+        if (SOBJECT_TYPE_TO_ALL_FIELDS.containsKey(sobjectType) && SOBJECT_TYPE_TO_REQUIRED_FIELDS.containsKey(sobjectType)) {
             return;
         }
 

--- a/nebula-logger/extra-tests/classes/NebulaLogger_E2E_Tests.cls
+++ b/nebula-logger/extra-tests/classes/NebulaLogger_E2E_Tests.cls
@@ -193,7 +193,7 @@ private class NebulaLogger_E2E_Tests {
             this.request = request;
 
             this.response = new System.HttpResponse();
-            if (String.isNotBlank(this.responseBody) == true) {
+            if (String.isNotBlank(this.responseBody)) {
                 response.setBody(this.responseBody);
             }
             response.setStatusCode(this.statusCode);

--- a/nebula-logger/extra-tests/tests/LoggerCache_Tests_PlatformCache.cls
+++ b/nebula-logger/extra-tests/tests/LoggerCache_Tests_PlatformCache.cls
@@ -188,7 +188,7 @@ private class LoggerCache_Tests_PlatformCache {
         System.Assert.areEqual(mockValue, LoggerCache.getSessionCache().get(mockKey));
         // Depending on how you start Apex tests, you may or may not have an active session
         // during the test execution, so session cache may or may not be available (╯°□°)╯︵ ┻━┻
-        if (Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).isAvailable() == true) {
+        if (Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).isAvailable()) {
             System.Assert.isTrue(Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
             System.Assert.areEqual(mockValue, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
         }
@@ -209,7 +209,7 @@ private class LoggerCache_Tests_PlatformCache {
         System.Assert.areEqual(mockValue, LoggerCache.getSessionCache().get(mockKey));
         // Depending on how you start Apex tests, you may or may not have an active session
         // during the test execution, so session cache may or may not be available (╯°□°)╯︵ ┻━┻
-        if (Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).isAvailable() == true) {
+        if (Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).isAvailable()) {
             System.Assert.isTrue(Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
             System.Assert.areEqual(LoggerCache.PLATFORM_CACHE_NULL_VALUE, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
         }
@@ -234,7 +234,7 @@ private class LoggerCache_Tests_PlatformCache {
         System.Assert.areEqual(newMockValue, LoggerCache.getSessionCache().get(mockKey));
         // Depending on how you start Apex tests, you may or may not have an active session
         // during the test execution, so session cache may or may not be available (╯°□°)╯︵ ┻━┻
-        if (Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).isAvailable() == true) {
+        if (Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).isAvailable()) {
             System.Assert.isTrue(Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
             System.Assert.areEqual(newMockValue, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
         }
@@ -253,7 +253,7 @@ private class LoggerCache_Tests_PlatformCache {
         System.Assert.areEqual(mockValue, LoggerCache.getSessionCache().get(mockKey));
         // Depending on how you start Apex tests, you may or may not have an active session
         // during the test execution, so session cache may or may not be available (╯°□°)╯︵ ┻━┻
-        if (Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).isAvailable() == true) {
+        if (Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).isAvailable()) {
             System.Assert.isTrue(Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).contains(mockKey));
             System.Assert.areEqual(mockValue, Cache.Session.getPartition(LoggerCache.PLATFORM_CACHE_PARTITION_NAME).get(mockKey));
         }

--- a/nebula-logger/extra-tests/tests/Logger_Tests_Network.cls
+++ b/nebula-logger/extra-tests/tests/Logger_Tests_Network.cls
@@ -19,7 +19,7 @@ private class Logger_Tests_Network {
 
         List<Profile> matchingProfiles = [SELECT Id, UserLicense.Name FROM Profile WHERE Name = :EXPERIENCE_CLOUD_GUEST_PROFILE_NAME];
 
-        if (matchingProfiles.isEmpty() == true) {
+        if (matchingProfiles.isEmpty()) {
             return;
         }
 
@@ -28,7 +28,7 @@ private class Logger_Tests_Network {
 
         // Even if Experience Cloud is enabled, the expected test site might not exist, so exit early if the guest user cannot be found
         List<User> guestUsers = [SELECT Id FROM User WHERE Profile.Name = :EXPERIENCE_CLOUD_GUEST_PROFILE_NAME AND Profile.UserType = :GUEST_USER_TYPE];
-        if (guestUsers.isEmpty() == true) {
+        if (guestUsers.isEmpty()) {
             return;
         }
 
@@ -50,7 +50,7 @@ private class Logger_Tests_Network {
 
         // Even if Experience Cloud is enabled, the expected test site might not exist, so exit early if the guest user cannot be found
         List<User> guestUsers = [SELECT Id FROM User WHERE Profile.Name = :EXPERIENCE_CLOUD_GUEST_PROFILE_NAME AND Profile.UserType = :GUEST_USER_TYPE];
-        if (guestUsers.isEmpty() == true) {
+        if (guestUsers.isEmpty()) {
             return;
         }
 
@@ -79,7 +79,7 @@ private class Logger_Tests_Network {
             FROM User
             WHERE Profile.Name = :EXPERIENCE_CLOUD_GUEST_PROFILE_NAME AND Profile.UserType = :GUEST_USER_TYPE
         ];
-        if (guestUsers.isEmpty() == true) {
+        if (guestUsers.isEmpty()) {
             return;
         }
 

--- a/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFlowExecutionErrorEventHandler.cls
+++ b/nebula-logger/plugins/async-failure-additions/plugin/classes/LogFlowExecutionErrorEventHandler.cls
@@ -33,7 +33,7 @@ public without sharing class LogFlowExecutionErrorEventHandler {
             );
             flowLogEntry.timestamp = flowExecutionErrorEvent.EventDate;
             LogEntryEventBuilder builder = flowLogEntry.addToLoggerBuffer()?.setRecord(flowExecutionErrorEvent.FlowVersionId);
-            if (builder.shouldSave() == true) {
+            if (builder.shouldSave()) {
                 // TODO remove this in a future release, this is a temporary fix until orgs have upgraded to v4.8.4.
                 // Prior to v4.8.4, there was a bug in core package where the TimestampString__c field would be out of
                 // sync with the Timestamp__c field, resulting in inaccurate data being used.

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveController.cls
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchiveController.cls
@@ -37,7 +37,7 @@ public with sharing class LogEntryArchiveController {
         // Big Objects have very, very limited support for SOQL filtering, so additional filtering is applied after querying
         // Since additional filtering is applied below (outside of the query), so this query gets as many rows
         // as possible to maximize the possible matches from post-query filtering
-        Integer queryLimit = System.Test.isRunningTest() == true ? 1 : System.Limits.getLimitQueryRows();
+        Integer queryLimit = System.Test.isRunningTest() ? 1 : System.Limits.getLimitQueryRows();
         for (LogEntryArchive__b logEntryArchive : [
             SELECT
                 LoggedByUsername__c,
@@ -60,7 +60,7 @@ public with sharing class LogEntryArchiveController {
 
         // In a test context, creating Big Object data will actually, truly create the data - it's not isolated
         // from the org's data. That makes testing trickier, so mock records are injected here.
-        if (System.Test.isRunningTest() == true) {
+        if (System.Test.isRunningTest()) {
             matchingLogEntryArchives.clear();
             for (LogEntryArchive__b mockLogEntryArchive : MOCK_RECORDS) {
                 addMatches(matchingLogEntryArchives, mockLogEntryArchive, minimumLoggingLevelOrdinal, messageSearchTerm, rowLimit);
@@ -82,7 +82,7 @@ public with sharing class LogEntryArchiveController {
             return;
         }
 
-        if (matchesFilterCriteria(potentialMatchingArchive, minimumLoggingLevelOrdinal, messageSearchTerm) == true) {
+        if (matchesFilterCriteria(potentialMatchingArchive, minimumLoggingLevelOrdinal, messageSearchTerm)) {
             matchingLogEntryArchives.add(potentialMatchingArchive);
         }
     }
@@ -93,9 +93,9 @@ public with sharing class LogEntryArchiveController {
         messageSearchTerm = messageSearchTerm == null ? '' : messageSearchTerm;
         String messageValue = logEntryArchive.Message__c == null ? '' : logEntryArchive.Message__c;
         Boolean matchesSearchTerm =
-            String.isBlank(messageSearchTerm) == true ||
-            messageValue.containsIgnoreCase(messageSearchTerm) == true ||
-            Pattern.matches(messageSearchTerm, messageValue) == true;
+            String.isBlank(messageSearchTerm) ||
+            messageValue.containsIgnoreCase(messageSearchTerm) ||
+            Pattern.matches(messageSearchTerm, messageValue);
 
         return matchesLoggingLevelOrdinal && matchesSearchTerm;
     }

--- a/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchivePlugin.cls
+++ b/nebula-logger/plugins/big-object-archiving/plugin/classes/LogEntryArchivePlugin.cls
@@ -99,7 +99,7 @@ public without sharing class LogEntryArchivePlugin implements LoggerPlugin.Batch
             LOG_ENTRY_ARCHIVES_TO_SAVE.add(new LogEntryArchiveBuilder(logEntryEvent).getLogEntryArchive());
         }
 
-        if (LOG_ENTRY_ARCHIVES_TO_SAVE.isEmpty() == true) {
+        if (LOG_ENTRY_ARCHIVES_TO_SAVE.isEmpty()) {
             return;
         }
 
@@ -193,7 +193,7 @@ public without sharing class LogEntryArchivePlugin implements LoggerPlugin.Batch
     }
 
     private void saveLogEntryArchives(String saveMethodName) {
-        if (System.Test.isRunningTest() == true) {
+        if (System.Test.isRunningTest()) {
             lastSaveMethodUsed = saveMethodName;
         }
 

--- a/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter.cls
+++ b/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionFilter.cls
@@ -380,7 +380,7 @@ public without sharing class LogRetentionFilter {
             x = x.trim();
             x = x.replace('AND', '&&');
             x = x.replace('OR', '||');
-            while (x.contains('(') == true) {
+            while (x.contains('(')) {
                 String sub = x.substringAfterLast('(').substringBefore(')');
                 x = x.replace('(' + sub + ')', String.valueOf(evaluate(sub)));
             }

--- a/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionRulesPlugin.cls
+++ b/nebula-logger/plugins/log-retention-rules/plugin/classes/LogRetentionRulesPlugin.cls
@@ -61,7 +61,7 @@ public without sharing class LogRetentionRulesPlugin implements LoggerPlugin.Tri
         Map<Id, Log__c> logIdToLog = new Map<Id, Log__c>();
         List<LogRetentionFilter.FilterResult> filterResults = this.runFilters(logEntries);
         for (LogRetentionFilter.FilterResult filterResult : filterResults) {
-            if (filterResult.matchesFilter() == true) {
+            if (filterResult.matchesFilter()) {
                 Id logId = (Id) filterResult.getRecord().get(Schema.LogEntry__c.Log__c);
                 Log__c log = logIdToLog.get(logId);
                 if (log == null) {
@@ -95,7 +95,7 @@ public without sharing class LogRetentionRulesPlugin implements LoggerPlugin.Tri
             queriedRulesByDeveloperName.put(rule.DeveloperName, rule);
             queriedConditionsByRuleDeveloperName.put(rule.DeveloperName, rule.LogRetentionRuleConditions__r);
 
-            if (System.Test.isRunningTest() == true) {
+            if (System.Test.isRunningTest()) {
                 queriedRulesByDeveloperName.clear();
                 queriedConditionsByRuleDeveloperName.clear();
             }

--- a/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin.cls
+++ b/nebula-logger/plugins/slack/plugin/slack/classes/SlackLoggerPlugin.cls
@@ -53,7 +53,7 @@ public without sharing class SlackLoggerPlugin implements LoggerPlugin.Triggerab
      * @param  context The instance of `LoggerTriggerableContext`, provided by the logging system
      */
     public void execute(LoggerPlugin__mdt configuration, LoggerTriggerableContext context) {
-        if (context.sobjectType != Schema.Log__c.SObjectType || String.isBlank(ENDPOINT) == true) {
+        if (context.sobjectType != Schema.Log__c.SObjectType || String.isBlank(ENDPOINT)) {
             return;
         }
 
@@ -78,7 +78,7 @@ public without sharing class SlackLoggerPlugin implements LoggerPlugin.Triggerab
         // TODO bulkify tags querying
         // this.requeryTags();
 
-        if (this.logs.isEmpty() == true) {
+        if (this.logs.isEmpty()) {
             return;
         }
 
@@ -99,12 +99,12 @@ public without sharing class SlackLoggerPlugin implements LoggerPlugin.Triggerab
             // 'Short' is a reserved word in Apex, but used in Slack's API, so the conversion happens in JSON
             String notificationJson = JSON.serialize(notification).replace('"isShort"', '"short"');
             request.setBody(notificationJson);
-            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
                 Logger.finest('Sending log entries to Slack endpoint').setHttpRequestDetails(request);
             }
 
             System.HttpResponse response = new System.Http().send(request);
-            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+            if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
                 Logger.finest('Sent log entries to Slack endpoint').setHttpResponseDetails(response);
             }
 
@@ -135,7 +135,7 @@ public without sharing class SlackLoggerPlugin implements LoggerPlugin.Triggerab
     private void sendAsyncSlackNotifications() {
         List<Log__c> logsToSend = new List<Log__c>();
         for (Log__c log : this.logs) {
-            if (log.SendSlackNotification__c == true) {
+            if (log.SendSlackNotification__c) {
                 logsToSend.add(log);
             }
         }
@@ -188,7 +188,7 @@ public without sharing class SlackLoggerPlugin implements LoggerPlugin.Triggerab
         request.setEndpoint(ENDPOINT);
         request.setMethod('POST');
         request.setHeader('Content-Type', 'application/json');
-        if (LoggerParameter.ENABLE_SYSTEM_MESSAGES == true) {
+        if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
             Logger.finest('Created Slack HTTP Request').setHttpRequestDetails(request);
         }
         return request;
@@ -269,14 +269,14 @@ public without sharing class SlackLoggerPlugin implements LoggerPlugin.Triggerab
             fieldValue = record.get(fieldPath);
         }
 
-        if (IGNORE_NULL_FIELDS == true && fieldValue == null) {
+        if (IGNORE_NULL_FIELDS && fieldValue == null) {
             return null;
         }
 
         String stringValue = String.valueOf(fieldValue);
         Integer maxShortLength = 255;
         fieldDto.isShort = stringValue.contains('\n') == false || stringValue.length() <= maxShortLength;
-        String valueWrapper = fieldDto.isShort == true ? '`' : '\n```\n';
+        String valueWrapper = fieldDto.isShort ? '`' : '\n```\n';
         fieldDto.value = valueWrapper + stringValue + valueWrapper;
         return fieldDto;
     }
@@ -317,7 +317,7 @@ public without sharing class SlackLoggerPlugin implements LoggerPlugin.Triggerab
             ORDER BY UniqueId__c
         ];
 
-        if (tagNames.isEmpty() == true) {
+        if (tagNames.isEmpty()) {
             return null;
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.11.7",
+    "version": "4.11.8",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -13,9 +13,9 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.11.7.NEXT",
-            "versionName": "Bugfix for Tags Not Saving for Save Method SYNCHRONOUS_DML",
-            "versionDescription": "Added a new composite key field, LogEntry__c.UniqueId__c, to fix a bug where tagging data would not save properly when using the save method SYNCHRONOUS_DML",
+            "versionNumber": "4.11.8.NEXT",
+            "versionName": "New Field LogEntry__c.HttpResponseHeaders__c",
+            "versionDescription": "Added a new field, LogEntry__c.HttpResponseHeaders__c, to store header keys and values (the existing field LogEntry__c.HttpResponseHeaderKeys__c only stores the keys, not the values)",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -155,6 +155,7 @@
         "Nebula Logger - Core@4.11.5-custom-index-for-log-retention-date": "04t5Y000001HZdZQAW",
         "Nebula Logger - Core@4.11.6-new-method-logger.setasynccontext()": "04t5Y000001HZfGQAW",
         "Nebula Logger - Core@4.11.7-bugfix-for-tags-not-saving-for-save-method-synchronous_dml": "04t5Y000001HZfaQAG",
+        "Nebula Logger - Core@4.11.8-new-field-logentry__c.httpresponseheaders__c": "04t5Y000001Oig9QAC",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
## New Feature: Store `HttpResponse` Header Values
- Resolved #561 (reported by @TrangOul) by adding new fields `LogEntryEvent__e.HttpResponseHeaders__c` and `LogEntry__c.HttpResponseHeaders__c` that store the full key-value pair for each header set on the logged instance of `System.HttpResponse`. These fields are now automatically set when using the instance method `LogEntryEventBuilder.setHttpResponseDetails(System.HttpResponse)`.
  - Based on [the great suggestion from @TrangOul](https://github.com/jongpie/NebulaLogger/issues/561#issue-1924171609), each header key-value pair is stored in the format `Header: value` to match the ([HTTP standard](https://datatracker.ietf.org/doc/html/rfc1945#section-4.2)). A `\n` line break is used as a delimiter between each header when there are multiple headers.
  - For orgs that do not want to store the header values (either due to security concerns with storing this information, or other concerns), you can disable this functionality org-wide by updating the new `LoggerParameter__mdt` record `StoreHttpResponseHeaderValues` to `false`. By default, this feature is enabled/set to `true`
  - The existing fields `LogEntryEvent__e.HttpResponseHeaderKeys__c` and `LogEntry__c.HttpResponseHeaderKeys__c` will continue to be populated. These fields store only the header keys, not the header values, and some orgs have existing tests & logic that rely on checking the logged keys. These fields are always populated for instances of `System.HttpResponse`, regardless of the configuration of the new `LoggerParameter__mdt` record `StoreHttpResponseHeaderValues`.
- Updated permission sets `LoggerAdmin` and `LoggerLogViewer` to have `read` access to the new field `LogEntry__c.HttpResponseHeaders__c`. 
  - The permission set `LoggerEndUser` intentionally does **_not_** have access to this field (or any other fields related to `HttpResponse` or `HttpRequest`).
- Added new field `LogEntry__c.HttpResponseHeaders__c` to the FlexiPage `LogEntryRecordPage`. This field is shown in addition to the existing field `LogEntry__c.HttpResponseHeaderKeys__c`, shown in the (massive 😅) screenshot below  
  
  ![image](https://github.com/jongpie/NebulaLogger/assets/1267157/f4a51f88-8cce-4268-8666-3705f0be9a4a)

## Updated Internal Coding Conventions for Apex `if` Statements
- Updated ~300 `if` statements throughout the codebase to simplify checking Booleans from `if(condition == true)` to just `if(condition)`. A few existing Booleans were also updated to have a default value to avoid issues with `null` values.
  - This (hopefully) shouldn't impact any functionality in Nebula Logger - the goal of this change is purely to update the coding style used within the codebase to be a bit more concise, based on some feedback received over the last year or so, including a discussion last year with @rmccu in #383 and [PR comment from @TrangOul](https://github.com/jongpie/NebulaLogger/pull/564#discussion_r1347445950).