### PR TITLE
Dynamic field visibility for LogEntry__c HTTP response header fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.11.10
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001OigJQAS)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001OigJQAS)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001OigxQAC)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001OigxQAC)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001OigJQAS`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001OigxQAC`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001OigJQAS`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001OigxQAC`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.11.8
+## Unlocked Package - v4.11.10
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001OigJQAS)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001OigJQAS)

--- a/nebula-logger/core/main/log-management/classes/LogEntryHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryHandler.cls
@@ -261,8 +261,9 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
     }
 
     private void setCheckboxFields() {
-        // A formula field can't be used for checking if a long text area field is set/null
-        // So, this code handles maintaing some checkbox fields via Apex instead
+        // Long textarea fields can't be used in filters for SOQL, list views, etc, and a formula field can't be used
+        // for checking if a long text area field is set/null...
+        // So, this code handles maintaining some checkbox fields via Apex instead
         for (LogEntry__c logEntry : this.logEntries) {
             logEntry.HasDatabaseResultJson__c = logEntry.DatabaseResultJson__c != null;
             logEntry.HasExceptionStackTrace__c = logEntry.ExceptionStackTrace__c != null;

--- a/nebula-logger/core/main/log-management/classes/LogEntryHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryHandler.cls
@@ -25,12 +25,12 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
     protected override void executeBeforeInsert(List<SObject> triggerNew) {
         this.logEntries = (List<LogEntry__c>) triggerNew;
 
-        this.setCheckboxFields();
         this.setApexClassFields();
         this.setComponentFields();
         this.setFlowDefinitionFields();
         this.setFlowVersionFields();
         this.setRecordNames();
+        this.setCheckboxFields();
     }
 
     protected override void executeBeforeUpdate(Map<Id, SObject> triggerNewMap, Map<Id, SObject> triggerOldMap) {
@@ -41,17 +41,6 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
         // and it conceptually feels weird for there to be scenarios where these fields could be inaccurate,
         // so keep them up to date just to be safe
         this.setCheckboxFields();
-    }
-
-    private void setCheckboxFields() {
-        // A formula field can't be used for checking if a long text area field is set/null
-        // So, this code handles maintaing some checkbox fields via Apex instead
-        for (LogEntry__c logEntry : this.logEntries) {
-            logEntry.HasExceptionStackTrace__c = logEntry.ExceptionStackTrace__c != null;
-            logEntry.HasInlineTags__c = logEntry.Tags__c != null;
-            logEntry.HasRecordJson__c = logEntry.RecordJson__c != null;
-            logEntry.HasStackTrace__c = logEntry.StackTrace__c != null;
-        }
     }
 
     private void setApexClassFields() {
@@ -268,6 +257,22 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
                     logEntry.RecordName__c = recordName;
                 }
             }
+        }
+    }
+
+    private void setCheckboxFields() {
+        // A formula field can't be used for checking if a long text area field is set/null
+        // So, this code handles maintaing some checkbox fields via Apex instead
+        for (LogEntry__c logEntry : this.logEntries) {
+            logEntry.HasDatabaseResultJson__c = logEntry.DatabaseResultJson__c != null;
+            logEntry.HasExceptionStackTrace__c = logEntry.ExceptionStackTrace__c != null;
+            logEntry.HasHttpRequestBody__c = logEntry.HttpRequestBody__c != null;
+            logEntry.HasHttpResponseBody__c = logEntry.HttpResponseBody__c != null;
+            logEntry.HasHttpResponseHeaderKeys__c = logEntry.HttpResponseHeaderKeys__c != null;
+            logEntry.HasHttpResponseHeaders__c = logEntry.HttpResponseHeaders__c != null;
+            logEntry.HasInlineTags__c = logEntry.Tags__c != null;
+            logEntry.HasRecordJson__c = logEntry.RecordJson__c != null;
+            logEntry.HasStackTrace__c = logEntry.StackTrace__c != null;
         }
     }
 

--- a/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
@@ -594,6 +594,13 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.HttpResponseHeaderKeys__c</fieldItem>
                 <identifier>RecordHttpResponseHeaderKeys_cField1</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.HasHttpResponseHeaders__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>false</rightValue>
+                    </criteria>
+                </visibilityRule>
             </fieldInstance>
         </itemInstances>
         <itemInstances>
@@ -604,6 +611,13 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.HttpResponseHeaders__c</fieldItem>
                 <identifier>RecordHttpResponseHeaders_cField1</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.HasHttpResponseHeaders__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>true</rightValue>
+                    </criteria>
+                </visibilityRule>
             </fieldInstance>
         </itemInstances>
         <itemInstances>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasDatabaseResultJson__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasDatabaseResultJson__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HasDatabaseResultJson__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Has Database Result JSON</label>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpRequestBody__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpRequestBody__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HasHttpRequestBody__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Has HTTP Response Body</label>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpRequestBody__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpRequestBody__c.field-meta.xml
@@ -5,7 +5,7 @@
     <complianceGroup>None</complianceGroup>
     <defaultValue>false</defaultValue>
     <externalId>false</externalId>
-    <label>Has HTTP Response Body</label>
+    <label>Has HTTP Request Body</label>
     <securityClassification>Confidential</securityClassification>
     <trackFeedHistory>false</trackFeedHistory>
     <trackTrending>false</trackTrending>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpResponseBody__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpResponseBody__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HasHttpResponseBody__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Has HTTP Response Body</label>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpResponseHeaderKeys__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpResponseHeaderKeys__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HasHttpResponseHeaderKeys__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Has HTTP Response Header Keys</label>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpResponseHeaders__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpResponseHeaders__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HasHttpResponseHeaders__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Has HTTP Response Headers</label>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -350,6 +350,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.HasDatabaseResultJson__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.HasDatabaseResult__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -361,6 +366,26 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>LogEntry__c.HasException__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpRequestBody__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpResponseBody__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpResponseHeaderKeys__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpResponseHeaders__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
@@ -391,6 +416,11 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>LogEntry__c.HttpRequestBody__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HttpRequestCompressed__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -188,6 +188,11 @@
         <field>LogEntry__c.FlowVersionRunInMode__c</field>
         <readable>true</readable>
     </fieldPermissions>
+     <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasDatabaseResultJson__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
         <field>LogEntry__c.HasDatabaseResult__c</field>
@@ -201,6 +206,31 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>LogEntry__c.HasException__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpRequestBody__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpResponseBody__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpResponseHeaderKeys__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpResponseHeaders__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasInlineTags__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -272,7 +272,7 @@
         <field>LogEntry__c.FlowVersionRunInMode__c</field>
         <readable>true</readable>
     </fieldPermissions>
-     <fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>LogEntry__c.HasDatabaseResultJson__c</field>
         <readable>true</readable>
@@ -340,6 +340,11 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>LogEntry__c.HttpRequestBody__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HttpRequestCompressed__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -272,6 +272,11 @@
         <field>LogEntry__c.FlowVersionRunInMode__c</field>
         <readable>true</readable>
     </fieldPermissions>
+     <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasDatabaseResultJson__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
         <field>LogEntry__c.HasDatabaseResult__c</field>
@@ -285,6 +290,26 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>LogEntry__c.HasException__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpRequestBody__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpResponseBody__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpResponseHeaderKeys__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpResponseHeaders__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.11.8';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.11.10';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final Set<String> IGNORED_APEX_CLASSES = initializeIgnoredApexClasses();
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
@@ -6,7 +6,7 @@
 import { LightningElement, api } from 'lwc';
 import { createLoggerService } from './loggerService';
 
-const CURRENT_VERSION_NUMBER = 'v4.11.8';
+const CURRENT_VERSION_NUMBER = 'v4.11.10';
 
 export default class Logger extends LightningElement {
     #loggerService = createLoggerService();

--- a/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
@@ -126,291 +126,368 @@ private class LogEntryHandler_Tests {
     }
 
     @IsTest
-    static void it_should_set_hasInlineTags_to_true_when_populated_on_insert() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        String inlineTags = String.join(new List<String>{ 'some tag', 'another tag' }, '\n');
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, Tags__c = inlineTags);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
+    static void it_should_set_hasDatabaseResultJson_on_before_insert() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(DatabaseResultJson__c = 'some value');
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(DatabaseResultJson__c = null);
+        System.Assert.isNotNull(matchingLogEntry.DatabaseResultJson__c);
+        System.Assert.isNull(nonMatchingLogEntry.DatabaseResultJson__c);
 
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-
-        System.Assert.areEqual(
-            2,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_INSERT,
+            new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry }
         );
-        logEntry = [SELECT Id, HasInlineTags__c, Tags__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.areEqual(true, logEntry.HasInlineTags__c);
-        System.Assert.areEqual(inlineTags, logEntry.Tags__c);
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasDatabaseResultJson__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasDatabaseResultJson__c);
     }
 
     @IsTest
-    static void it_should_set_hasInlineTags_to_false_when_not_populated_on_insert() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        String inlineTags = null;
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, Tags__c = inlineTags);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
-
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-
-        System.Assert.areEqual(
-            2,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
+    static void it_should_set_hasDatabaseResultJson_on_before_update() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(
+            DatabaseResultJson__c = 'some value',
+            Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType)
         );
-        logEntry = [SELECT Id, HasInlineTags__c, Tags__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.areEqual(false, logEntry.HasInlineTags__c);
-        System.Assert.isNull(logEntry.Tags__c);
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(DatabaseResultJson__c = null, Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+        List<LogEntry__c> updatedRecords = new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry };
+        System.Assert.isNotNull(matchingLogEntry.DatabaseResultJson__c);
+        System.Assert.isNull(nonMatchingLogEntry.DatabaseResultJson__c);
+
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_UPDATE,
+            updatedRecords,
+            new Map<Id, SObject>(updatedRecords),
+            null
+        );
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasDatabaseResultJson__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasDatabaseResultJson__c);
     }
 
     @IsTest
-    static void it_should_set_hasInlineTags_to_true_when_populated_on_updated() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, Tags__c = null);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-        logEntry = [SELECT Id, Tags__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.isNull(logEntry.Tags__c);
-        String inlineTags = String.join(new List<String>{ 'some tag', 'another tag' }, '\n');
-        logEntry.Tags__c = inlineTags;
+    static void it_should_set_hasExceptionStackTrace_on_before_insert() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(ExceptionStackTrace__c = 'some value');
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(ExceptionStackTrace__c = null);
+        System.Assert.isNotNull(matchingLogEntry.ExceptionStackTrace__c);
+        System.Assert.isNull(nonMatchingLogEntry.ExceptionStackTrace__c);
 
-        update logEntry;
-
-        System.Assert.areEqual(
-            4,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed four times - two times for BEFORE_INSERT/AFTER_INSERT' + ' and two more times for BEFORE_UPDATE/AFTER_UPDATE'
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_INSERT,
+            new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry }
         );
-        logEntry = [SELECT Id, HasInlineTags__c, Tags__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.areEqual(true, logEntry.HasInlineTags__c);
-        System.Assert.areEqual(inlineTags, logEntry.Tags__c);
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasExceptionStackTrace__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasExceptionStackTrace__c);
     }
 
     @IsTest
-    static void it_should_set_hasInlineTags_to_false_when_not_populated_on_updated() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        String inlineTags = String.join(new List<String>{ 'some tag', 'another tag' }, '\n');
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, Tags__c = inlineTags);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-        logEntry = [SELECT Id, Tags__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.areEqual(inlineTags, logEntry.Tags__c);
-        logEntry.Tags__c = null;
-
-        update logEntry;
-
-        System.Assert.areEqual(
-            4,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed four times - two times for BEFORE_INSERT/AFTER_INSERT' + ' and two more times for BEFORE_UPDATE/AFTER_UPDATE'
+    static void it_should_set_hasExceptionStackTrace_on_before_update() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(
+            ExceptionStackTrace__c = 'some value',
+            Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType)
         );
-        logEntry = [SELECT Id, HasInlineTags__c, Tags__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.areEqual(false, logEntry.HasInlineTags__c);
-        System.Assert.isNull(logEntry.Tags__c);
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(ExceptionStackTrace__c = null, Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+        List<LogEntry__c> updatedRecords = new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry };
+        System.Assert.isNotNull(matchingLogEntry.ExceptionStackTrace__c);
+        System.Assert.isNull(nonMatchingLogEntry.ExceptionStackTrace__c);
+
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_UPDATE,
+            updatedRecords,
+            new Map<Id, SObject>(updatedRecords),
+            null
+        );
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasExceptionStackTrace__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasExceptionStackTrace__c);
     }
 
     @IsTest
-    static void it_should_set_hasRecordJson_to_true_when_populated_on_insert() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        String recordJson = '{}';
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, RecordJson__c = recordJson);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
+    static void it_should_set_hasHttpRequestBody_on_before_insert() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(HttpRequestBody__c = 'some value');
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(HttpRequestBody__c = null);
+        System.Assert.isNotNull(matchingLogEntry.HttpRequestBody__c);
+        System.Assert.isNull(nonMatchingLogEntry.HttpRequestBody__c);
 
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-
-        System.Assert.areEqual(
-            2,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_INSERT,
+            new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry }
         );
-        logEntry = [SELECT Id, HasRecordJson__c, RecordJson__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.areEqual(true, logEntry.HasRecordJson__c);
-        System.Assert.areEqual(recordJson, logEntry.RecordJson__c);
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasHttpRequestBody__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasHttpRequestBody__c);
     }
 
     @IsTest
-    static void it_should_set_hasRecordJson_to_false_when_not_populated_on_insert() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        String recordJson = null;
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, RecordJson__c = recordJson);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
+    static void it_should_set_hasHttpRequestBody_on_before_update() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(HttpRequestBody__c = 'some value', Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(HttpRequestBody__c = null, Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+        List<LogEntry__c> updatedRecords = new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry };
+        System.Assert.isNotNull(matchingLogEntry.HttpRequestBody__c);
+        System.Assert.isNull(nonMatchingLogEntry.HttpRequestBody__c);
 
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-
-        System.Assert.areEqual(
-            2,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_UPDATE,
+            updatedRecords,
+            new Map<Id, SObject>(updatedRecords),
+            null
         );
-        logEntry = [SELECT Id, HasRecordJson__c, RecordJson__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.areEqual(false, logEntry.HasRecordJson__c);
-        System.Assert.isNull(logEntry.RecordJson__c);
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasHttpRequestBody__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasHttpRequestBody__c);
     }
 
     @IsTest
-    static void it_should_set_hasRecordJson_to_true_when_populated_on_updated() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, RecordJson__c = null);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-        logEntry = [SELECT Id, RecordJson__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.isNull(logEntry.RecordJson__c);
-        String recordJson = '{}';
-        logEntry.RecordJson__c = recordJson;
+    static void it_should_set_hasHttpResponseBody_on_before_insert() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(HttpResponseBody__c = 'some value');
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(HttpResponseBody__c = null);
+        System.Assert.isNotNull(matchingLogEntry.HttpResponseBody__c);
+        System.Assert.isNull(nonMatchingLogEntry.HttpResponseBody__c);
 
-        update logEntry;
-
-        System.Assert.areEqual(
-            4,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed four times - two times for BEFORE_INSERT/AFTER_INSERT' + ' and two more times for BEFORE_UPDATE/AFTER_UPDATE'
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_INSERT,
+            new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry }
         );
-        logEntry = [SELECT Id, HasRecordJson__c, RecordJson__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.areEqual(true, logEntry.HasRecordJson__c);
-        System.Assert.areEqual(recordJson, logEntry.RecordJson__c);
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasHttpResponseBody__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasHttpResponseBody__c);
     }
 
     @IsTest
-    static void it_should_set_hasRecordJson_to_false_when_not_populated_on_updated() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        String recordJson = '{}';
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, RecordJson__c = recordJson);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-        logEntry = [SELECT Id, RecordJson__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.isNotNull(logEntry.RecordJson__c);
-        logEntry.RecordJson__c = null;
+    static void it_should_set_hasHttpResponseBody_on_before_update() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(HttpResponseBody__c = 'some value', Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(HttpResponseBody__c = null, Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+        List<LogEntry__c> updatedRecords = new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry };
+        System.Assert.isNotNull(matchingLogEntry.HttpResponseBody__c);
+        System.Assert.isNull(nonMatchingLogEntry.HttpResponseBody__c);
 
-        update logEntry;
-
-        System.Assert.areEqual(
-            4,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed four times - two times for BEFORE_INSERT/AFTER_INSERT' + ' and two more times for BEFORE_UPDATE/AFTER_UPDATE'
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_UPDATE,
+            updatedRecords,
+            new Map<Id, SObject>(updatedRecords),
+            null
         );
-        logEntry = [SELECT Id, HasRecordJson__c, RecordJson__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.areEqual(false, logEntry.HasRecordJson__c);
-        System.Assert.isNull(logEntry.RecordJson__c);
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasHttpResponseBody__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasHttpResponseBody__c);
     }
 
     @IsTest
-    static void it_should_set_hasExceptionStackTrace_to_false_when_null() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, ExceptionStackTrace__c = null);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
+    static void it_should_set_hasHttpResponseHeaderKeys_on_before_insert() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(HttpResponseHeaderKeys__c = 'some value');
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(HttpResponseHeaderKeys__c = null);
+        System.Assert.isNotNull(matchingLogEntry.HttpResponseHeaderKeys__c);
+        System.Assert.isNull(nonMatchingLogEntry.HttpResponseHeaderKeys__c);
 
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-
-        System.Assert.areEqual(
-            2,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_INSERT,
+            new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry }
         );
-        logEntry = [SELECT Id, HasExceptionStackTrace__c, ExceptionStackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.isTrue(!logEntry.HasExceptionStackTrace__c);
-        System.Assert.isNull(logEntry.ExceptionStackTrace__c);
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasHttpResponseHeaderKeys__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasHttpResponseHeaderKeys__c);
     }
 
     @IsTest
-    static void it_should_set_hasExceptionStackTrace_to_true_when_populated() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        String stackTrace = 'something';
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, ExceptionStackTrace__c = stackTrace);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
-
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-
-        System.Assert.areEqual(
-            2,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
+    static void it_should_set_hasHttpResponseHeaderKeys_on_before_update() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(
+            HttpResponseHeaderKeys__c = 'some value',
+            Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType)
         );
-        logEntry = [SELECT Id, HasExceptionStackTrace__c, ExceptionStackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.isTrue(logEntry.HasExceptionStackTrace__c);
-        System.Assert.areEqual(stackTrace, logEntry.ExceptionStackTrace__c);
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(
+            HttpResponseHeaderKeys__c = null,
+            Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType)
+        );
+        List<LogEntry__c> updatedRecords = new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry };
+        System.Assert.isNotNull(matchingLogEntry.HttpResponseHeaderKeys__c);
+        System.Assert.isNull(nonMatchingLogEntry.HttpResponseHeaderKeys__c);
+
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_UPDATE,
+            updatedRecords,
+            new Map<Id, SObject>(updatedRecords),
+            null
+        );
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasHttpResponseHeaderKeys__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasHttpResponseHeaderKeys__c);
     }
 
     @IsTest
-    static void it_should_set_hasExceptionStackTrace_to_true_when_updated() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, ExceptionStackTrace__c = null);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-        logEntry = [SELECT Id, ExceptionStackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.isNull(logEntry.ExceptionStackTrace__c);
+    static void it_should_set_hasHttpResponseHeaders_on_before_insert() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(HttpResponseHeaders__c = 'some value');
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(HttpResponseHeaders__c = null);
+        System.Assert.isNotNull(matchingLogEntry.HttpResponseHeaders__c);
+        System.Assert.isNull(nonMatchingLogEntry.HttpResponseHeaders__c);
 
-        String stackTrace = 'something';
-        logEntry.ExceptionStackTrace__c = stackTrace;
-        update logEntry;
-
-        System.Assert.areEqual(
-            4,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed four times - two times for BEFORE_INSERT/AFTER_INSERT' + ' and two more times for BEFORE_UPDATE/AFTER_UPDATE'
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_INSERT,
+            new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry }
         );
-        logEntry = [SELECT Id, HasExceptionStackTrace__c, ExceptionStackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.isTrue(logEntry.HasExceptionStackTrace__c);
-        System.Assert.areEqual(stackTrace, logEntry.ExceptionStackTrace__c);
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasHttpResponseHeaders__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasHttpResponseHeaders__c);
     }
 
     @IsTest
-    static void it_should_set_hasStackTrace_to_false_when_null() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, StackTrace__c = null);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
-
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-
-        System.Assert.areEqual(
-            2,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
+    static void it_should_set_hasHttpResponseHeaders_on_before_update() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(
+            HttpResponseHeaders__c = 'some value',
+            Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType)
         );
-        logEntry = [SELECT Id, HasStackTrace__c, StackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.isTrue(!logEntry.HasStackTrace__c);
-        System.Assert.isNull(logEntry.StackTrace__c);
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(HttpResponseHeaders__c = null, Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+        List<LogEntry__c> updatedRecords = new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry };
+        System.Assert.isNotNull(matchingLogEntry.HttpResponseHeaders__c);
+        System.Assert.isNull(nonMatchingLogEntry.HttpResponseHeaders__c);
+
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_UPDATE,
+            updatedRecords,
+            new Map<Id, SObject>(updatedRecords),
+            null
+        );
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasHttpResponseHeaders__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasHttpResponseHeaders__c);
+    }
+    @IsTest
+    static void it_should_set_hasInlineTags_on_before_insert() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(Tags__c = 'some value');
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(Tags__c = null);
+        System.Assert.isNotNull(matchingLogEntry.Tags__c);
+        System.Assert.isNull(nonMatchingLogEntry.Tags__c);
+
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_INSERT,
+            new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry }
+        );
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasInlineTags__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasInlineTags__c);
     }
 
     @IsTest
-    static void it_should_set_hasStackTrace_to_true_when_populated() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        String stackTrace = 'something';
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, StackTrace__c = stackTrace);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
+    static void it_should_set_hasInlineTags_on_before_update() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(Tags__c = 'some value', Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(Tags__c = null, Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+        List<LogEntry__c> updatedRecords = new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry };
+        System.Assert.isNotNull(matchingLogEntry.Tags__c);
+        System.Assert.isNull(nonMatchingLogEntry.Tags__c);
 
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-
-        System.Assert.areEqual(
-            2,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed two times - once for BEFORE_INSERT and once for AFTER_INSERT'
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_UPDATE,
+            updatedRecords,
+            new Map<Id, SObject>(updatedRecords),
+            null
         );
-        logEntry = [SELECT Id, HasStackTrace__c, StackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.isTrue(logEntry.HasStackTrace__c);
-        System.Assert.areEqual(stackTrace, logEntry.StackTrace__c);
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasInlineTags__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasInlineTags__c);
     }
 
     @IsTest
-    static void it_should_set_hasStackTrace_to_true_when_updated() {
-        Log__c log = [SELECT Id FROM Log__c LIMIT 1];
-        LogEntry__c logEntry = new LogEntry__c(Log__c = log.Id, StackTrace__c = null);
-        LoggerMockDataCreator.createDataBuilder(logEntry).populateRequiredFields().getRecord();
-        LoggerDataStore.getDatabase().insertRecord(logEntry);
-        logEntry = [SELECT Id, StackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.isNull(logEntry.StackTrace__c);
+    static void it_should_set_hasRecordJson_on_before_insert() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(RecordJson__c = 'some value');
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(RecordJson__c = null);
+        System.Assert.isNotNull(matchingLogEntry.RecordJson__c);
+        System.Assert.isNull(nonMatchingLogEntry.RecordJson__c);
 
-        String stackTrace = 'something';
-        logEntry.StackTrace__c = stackTrace;
-        update logEntry;
-
-        System.Assert.areEqual(
-            4,
-            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntry__c.SObjectType).size(),
-            'Handler class should have executed four times - two times for BEFORE_INSERT/AFTER_INSERT' + ' and two more times for BEFORE_UPDATE/AFTER_UPDATE'
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_INSERT,
+            new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry }
         );
-        logEntry = [SELECT Id, HasStackTrace__c, StackTrace__c FROM LogEntry__c WHERE Id = :logEntry.Id];
-        System.Assert.isTrue(logEntry.HasStackTrace__c);
-        System.Assert.areEqual(stackTrace, logEntry.StackTrace__c);
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasRecordJson__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasRecordJson__c);
+    }
+
+    @IsTest
+    static void it_should_set_hasRecordJson_on_before_update() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(RecordJson__c = 'some value', Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(RecordJson__c = null, Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+        List<LogEntry__c> updatedRecords = new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry };
+        System.Assert.isNotNull(matchingLogEntry.RecordJson__c);
+        System.Assert.isNull(nonMatchingLogEntry.RecordJson__c);
+
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_UPDATE,
+            updatedRecords,
+            new Map<Id, SObject>(updatedRecords),
+            null
+        );
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasRecordJson__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasRecordJson__c);
+    }
+
+    @IsTest
+    static void it_should_set_hasStackTrace_on_before_insert() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(StackTrace__c = 'some value');
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(StackTrace__c = null);
+        System.Assert.isNotNull(matchingLogEntry.StackTrace__c);
+        System.Assert.isNull(nonMatchingLogEntry.StackTrace__c);
+
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_INSERT,
+            new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry }
+        );
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasStackTrace__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasStackTrace__c);
+    }
+
+    @IsTest
+    static void it_should_set_hasStackTrace_on_before_update() {
+        LogEntry__c matchingLogEntry = new LogEntry__c(StackTrace__c = 'some value', Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+        LogEntry__c nonMatchingLogEntry = new LogEntry__c(StackTrace__c = null, Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+        List<LogEntry__c> updatedRecords = new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry };
+        System.Assert.isNotNull(matchingLogEntry.StackTrace__c);
+        System.Assert.isNull(nonMatchingLogEntry.StackTrace__c);
+
+        LoggerTriggerableContext context = new LoggerTriggerableContext(
+            Schema.LogEntry__c.SObjectType,
+            TriggerOperation.BEFORE_UPDATE,
+            updatedRecords,
+            new Map<Id, SObject>(updatedRecords),
+            null
+        );
+        new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+        System.Assert.isTrue(matchingLogEntry.HasStackTrace__c);
+        System.Assert.isFalse(nonMatchingLogEntry.HasStackTrace__c);
     }
 
     @IsTest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.11.8",
+    "version": "4.11.10",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -157,6 +157,7 @@
         "Nebula Logger - Core@4.11.7-bugfix-for-tags-not-saving-for-save-method-synchronous_dml": "04t5Y000001HZfaQAG",
         "Nebula Logger - Core@4.11.8-new-field-logentry__c.httpresponseheaders__c": "04t5Y000001Oig9QAC",
         "Nebula Logger - Core@4.11.9-new-fields-log__c.loggedbyusernametext__c-and-logentry__c.loggedbyusernametext__c": "04t5Y000001OigJQAS",
+        "Nebula Logger - Core@4.11.10-conditional-visibility-for-http-response-headers": "04t5Y000001OigxQAC",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -14,7 +14,7 @@
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
             "versionNumber": "4.11.10.NEXT",
-            "versionName": "Conditional Visibility for Fields LogEntry__c.HttpResponseHeaders__c and LogEntry__c.HttpResponseHeaderKeys__c",
+            "versionName": "Conditional Visibility for HTTP Response Headers",
             "versionDescription": "Added several new checkbox fields on LogEntry__c that correspond to each long textarea field, and updated LogEntryRecordPage.flexipage to have conditional visibility for the fields HttpResponseHeaderKeys__c and HttpResponseHeaders__c based on new checkbox fields",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -13,9 +13,9 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.11.8.NEXT",
-            "versionName": "New Field LogEntry__c.HttpResponseHeaders__c",
-            "versionDescription": "Added a new field, LogEntry__c.HttpResponseHeaders__c, to store header keys and values (the existing field LogEntry__c.HttpResponseHeaderKeys__c only stores the keys, not the values)",
+            "versionNumber": "4.11.10.NEXT",
+            "versionName": "Conditional Visibility for Fields LogEntry__c.HttpResponseHeaders__c and LogEntry__c.HttpResponseHeaderKeys__c",
+            "versionDescription": "Added several new checkbox fields on LogEntry__c that correspond to each long textarea field, and updated LogEntryRecordPage.flexipage to have conditional visibility for the fields HttpResponseHeaderKeys__c and HttpResponseHeaders__c based on new checkbox fields",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"


### PR DESCRIPTION
## New `LogEntry__c` checkbox fields

- Added new checkbox fields on `LogEntry__c` for each long textarea fields that didn't previously have an equivalent checkbox field. Note: these new fields will be inaccurate for existing `LogEntry__c` records (but correct on new records).
  - `HasDatabaseResultJson__c` - set based on `logEntry.DatabaseResultJson__c != null`
  - `HasHttpRequestBody__c` - set based on `logEntry.HttpRequestBody__c != null`
  - `HasHttpResponseBody__c` - set based on `logEntry.HttpResponseBody__c != null`
  - `HasHttpResponseHeaderKeys__c` - set based on `logEntry.HttpResponseHeaderKeys__c != null`
  - `HasHttpResponseHeaders__c` - set based on `logEntry.HttpResponseHeaders__c != null`
- Code cleanup: rewrote several existing tests in `LogEntryHandler_Tests` to be true unit tests that do not rely on DML

## Dynamic field visibility for `LogEntry__c` HTTP response header field

- Resolved #566 by updating `LogEntryRecordPage.flexipage-meta.xml` to have conditional visibility for the fields `HttpResponseHeaderKeys__c` and `HttpResponseHeaders__c`, based on the new checkbox field `HasHttpResponseHeaders__c`