### PR TITLE
Bugfix: child Log__c records are not always linked to their parent Log__c record

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.12.4
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001Mk5AQAS)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001Mk5AQAS)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001Mk5KQAS)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001Mk5KQAS)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001Mk5AQAS`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001Mk5KQAS`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001Mk5AQAS`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001Mk5KQAS`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.12.3
+## Unlocked Package - v4.12.4
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001Mk5AQAS)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001Mk5AQAS)

--- a/docs/apex/Log-Management/LogManagementDataSelector.md
+++ b/docs/apex/Log-Management/LogManagementDataSelector.md
@@ -317,6 +317,26 @@ List&lt;Log\_\_c&gt;
 
 The list of matching `Log__c` records
 
+#### `getLogsWithoutParentLogByParentTransactionId(List<String> parentTransactionIds)` → `List<Log__c>`
+
+Returns a `List&lt;Log__c&gt;` of records with the specified parent transaction IDs and a `null` value in `ParentLog__c`
+
+##### Parameters
+
+| Param                  | Description                                                                  |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| `parentTransactionIds` | The list of `String` parent transaction IDs of the `Log__c` records to query |
+
+##### Return
+
+**Type**
+
+List&lt;Log\_\_c&gt;
+
+**Description**
+
+The list of matching `Log__c` records
+
 #### `getProfilesById(List<Id> profileIds)` → `List<Profile>`
 
 Returns a `List&lt;Profile&gt;` of records with the specified profile IDs

--- a/nebula-logger/core/main/log-management/classes/LogHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogHandler.cls
@@ -133,14 +133,8 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
             parentLogTransactionIdToRecordId.put(parentLog.TransactionId__c, parentLog.Id);
         }
 
-        // List<Log__c> logsWithParentLog = new List<Log__c>();
-        // List<Log__c> logsWithParentTransactionId = new List<Log__c>();
-
         for (Log__c log : this.logs) {
             if (String.isNotBlank(log.ParentLogTransactionId__c)) {
-                // if (parentLogTransactionIdToRecordId.containsKey(log.ParentLogTransactionId__c) == false) {
-                //     parentLogTransactionIdToRecordId.get(log.ParentLogTransactionId__c);
-                // }
                 log.ParentLog__c = parentLogTransactionIdToRecordId.get(log.ParentLogTransactionId__c);
             }
         }

--- a/nebula-logger/core/main/log-management/classes/LogHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogHandler.cls
@@ -51,6 +51,7 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
     protected override void executeAfterInsert(Map<Id, SObject> triggerNewMap) {
         this.logs = (List<Log__c>) triggerNewMap.values();
 
+        this.updateUnlinkedChildLogs();
         this.shareLogsWithLoggingUsers();
     }
 
@@ -132,8 +133,14 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
             parentLogTransactionIdToRecordId.put(parentLog.TransactionId__c, parentLog.Id);
         }
 
+        // List<Log__c> logsWithParentLog = new List<Log__c>();
+        // List<Log__c> logsWithParentTransactionId = new List<Log__c>();
+
         for (Log__c log : this.logs) {
             if (String.isNotBlank(log.ParentLogTransactionId__c)) {
+                // if (parentLogTransactionIdToRecordId.containsKey(log.ParentLogTransactionId__c) == false) {
+                //     parentLogTransactionIdToRecordId.get(log.ParentLogTransactionId__c);
+                // }
                 log.ParentLog__c = parentLogTransactionIdToRecordId.get(log.ParentLogTransactionId__c);
             }
         }
@@ -194,6 +201,22 @@ public without sharing class LogHandler extends LoggerSObjectHandler {
                 log.Priority__c = secondPriority;
             }
         }
+    }
+
+    private void updateUnlinkedChildLogs() {
+        Map<String, Log__c> transactionIdToPossibleParentLog = new Map<String, Log__c>();
+        for (Log__c log : this.logs) {
+            if (log.TransactionId__c != log.ParentLogTransactionId__c) {
+                transactionIdToPossibleParentLog.put(log.TransactionId__c, log);
+            }
+        }
+        List<String> possibleParentLogTransactionIds = new List<String>(transactionIdToPossibleParentLog.keySet());
+
+        List<Log__c> unlinkedChildLogs = LogManagementDataSelector.getInstance().getLogsWithoutParentLogByParentTransactionId(possibleParentLogTransactionIds);
+        for (Log__c unlinkedChildLog : unlinkedChildLogs) {
+            unlinkedChildLog.ParentLog__c = transactionIdToPossibleParentLog.get(unlinkedChildLog.ParentLogTransactionId__c)?.Id;
+        }
+        LoggerDataStore.getDatabase().updateRecords(unlinkedChildLogs);
     }
 
     private void shareLogsWithLoggingUsers() {

--- a/nebula-logger/core/main/log-management/classes/LogManagementDataSelector.cls
+++ b/nebula-logger/core/main/log-management/classes/LogManagementDataSelector.cls
@@ -224,6 +224,19 @@ public without sharing virtual class LogManagementDataSelector {
     }
 
     /**
+     * @description Returns a `List<Log__c>` of records with the specified parent transaction IDs and a `null` value in `ParentLog__c`
+     * @param  transactionIds The list of `String` parent transaction IDs of the `Log__c` records to query
+     * @return                The list of matching `Log__c` records
+     */
+    public virtual List<Log__c> getLogsWithoutParentLogByParentTransactionId(List<String> parentTransactionIds) {
+        return [
+            SELECT Id, ParentLogTransactionId__c, ParentLog__c, ParentLog__r.TransactionId__c, TransactionId__c
+            FROM Log__c
+            WHERE ParentLogTransactionId__c IN :parentTransactionIds AND ParentLog__c = NULL
+        ];
+    }
+
+    /**
      * @description Returns a `List<Log__c>` of records with the specified transaction IDs
      * @param  transactionIds The list of `String` transaction IDs of the `Log__c` records to query
      * @return                The list of matching `Log__c` records

--- a/nebula-logger/core/main/log-management/classes/LogManagementDataSelector.cls
+++ b/nebula-logger/core/main/log-management/classes/LogManagementDataSelector.cls
@@ -225,8 +225,8 @@ public without sharing virtual class LogManagementDataSelector {
 
     /**
      * @description Returns a `List<Log__c>` of records with the specified parent transaction IDs and a `null` value in `ParentLog__c`
-     * @param  transactionIds The list of `String` parent transaction IDs of the `Log__c` records to query
-     * @return                The list of matching `Log__c` records
+     * @param  parentTransactionIds The list of `String` parent transaction IDs of the `Log__c` records to query
+     * @return                      The list of matching `Log__c` records
      */
     public virtual List<Log__c> getLogsWithoutParentLogByParentTransactionId(List<String> parentTransactionIds) {
         return [

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.12.3';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.12.4';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final Set<String> IGNORED_APEX_CLASSES = initializeIgnoredApexClasses();
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
@@ -6,7 +6,7 @@
 import { LightningElement, api } from 'lwc';
 import { createLoggerService } from './loggerService';
 
-const CURRENT_VERSION_NUMBER = 'v4.12.3';
+const CURRENT_VERSION_NUMBER = 'v4.12.4';
 
 export default class Logger extends LightningElement {
     #loggerService = createLoggerService();

--- a/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogHandler_Tests.cls
@@ -287,13 +287,40 @@ private class LogHandler_Tests {
     }
 
     @IsTest
-    static void it_should_set_parent_log_when_it_exists() {
+    static void it_should_set_parent_log_when_it_exists_in_the_database() {
         String parentLogTransactionId = 'ABC-1234';
         Log__c parentLog = new Log__c(TransactionId__c = parentLogTransactionId);
         insert parentLog;
         Log__c log = new Log__c(ParentLogTransactionId__c = parentLogTransactionId, TransactionId__c = 'XYZ-5678');
 
         insert log;
+
+        log = [SELECT Id, ParentLogTransactionId__c, ParentLog__c FROM Log__c WHERE Id = :log.Id];
+        System.Assert.areEqual(parentLogTransactionId, log.ParentLogTransactionId__c, JSON.serializePretty(log));
+        System.Assert.areEqual(parentLog.Id, log.ParentLog__c, JSON.serializePretty(log));
+    }
+
+    @IsTest
+    static void it_should_set_parent_log_when_it_is_created_after_child_log() {
+        String parentLogTransactionId = 'ABC-1234';
+        Log__c log = new Log__c(ParentLogTransactionId__c = parentLogTransactionId, TransactionId__c = 'XYZ-5678');
+        insert log;
+        Log__c parentLog = new Log__c(TransactionId__c = parentLogTransactionId);
+
+        insert parentLog;
+
+        log = [SELECT Id, ParentLogTransactionId__c, ParentLog__c FROM Log__c WHERE Id = :log.Id];
+        System.Assert.areEqual(parentLogTransactionId, log.ParentLogTransactionId__c, JSON.serializePretty(log));
+        System.Assert.areEqual(parentLog.Id, log.ParentLog__c, JSON.serializePretty(log));
+    }
+
+    @IsTest
+    static void it_should_set_parent_log_when_it_exists_in_the_same_trigger_context() {
+        String parentLogTransactionId = 'ABC-1234';
+        Log__c parentLog = new Log__c(TransactionId__c = parentLogTransactionId);
+        Log__c log = new Log__c(ParentLogTransactionId__c = parentLogTransactionId, TransactionId__c = 'XYZ-5678');
+
+        insert new List<Log__c>{ log, parentLog };
 
         log = [SELECT Id, ParentLogTransactionId__c, ParentLog__c FROM Log__c WHERE Id = :log.Id];
         System.Assert.areEqual(parentLogTransactionId, log.ParentLogTransactionId__c, JSON.serializePretty(log));

--- a/nebula-logger/core/tests/log-management/classes/LogManagementDataSelector_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogManagementDataSelector_Tests.cls
@@ -229,6 +229,44 @@ private class LogManagementDataSelector_Tests {
     }
 
     @IsTest
+    static void it_returns_logs_for_specified_parent_log_transaction_ids_and_no_parent_log() {
+        LoggerSObjectHandler.shouldExecute(false);
+        Log__c parentLog = (Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord();
+        parentLog.TransactionId__c = 'some unique value for this log';
+        insert parentLog;
+        List<Log__c> logsToCreate = new List<Log__c>();
+        List<Log__c> expectedLogs = new List<Log__c>();
+        List<String> parentLogTransactionIds = new List<String>();
+        for (Integer i = 0; i < 5; i++) {
+            Log__c log = (Log__c) LoggerMockDataCreator.createDataBuilder(Schema.Log__c.SObjectType).populateRequiredFields().getRecord();
+            log.TransactionId__c = 'some_fake_transaction_id_' + i;
+            // Make 1 log with an actual an actual parent log
+            if (i == 0) {
+                log.ParentLog__c = parentLog.Id;
+                log.ParentLogTransactionId__c = parentLog.TransactionId__c;
+            }
+            // Make a few logs with a parent transaction ID but no parent log
+            if (i == 1 || i == 2 || i == 3) {
+                log.ParentLog__c = null;
+                log.ParentLogTransactionId__c = 'some other value';
+                expectedLogs.add(log);
+            }
+            if (String.isNotBlank(log.ParentLogTransactionId__c)) {
+                parentLogTransactionIds.add(log.ParentLogTransactionId__c);
+            }
+            logsToCreate.add(log);
+        }
+        System.Assert.areEqual(parentLogTransactionIds.size(), expectedLogs.size() + 1, 'Test has started under the wrong conditions');
+        insert logsToCreate;
+
+        List<Log__c> returnedResults = LogManagementDataSelector.getInstance().getLogsWithoutParentLogByParentTransactionId(parentLogTransactionIds);
+
+        System.Assert.isFalse(returnedResults.isEmpty());
+        System.Assert.areEqual(expectedLogs.size(), returnedResults.size());
+        System.Assert.areEqual(new Map<Id, Log__c>(expectedLogs).keySet(), new Map<Id, Log__c>(returnedResults).keySet());
+    }
+
+    @IsTest
     static void it_returns_logs_for_specified_log_transaction_ids() {
         LoggerSObjectHandler.shouldExecute(false);
         List<Log__c> logs = new List<Log__c>();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.12.3",
+    "version": "4.12.4",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -164,6 +164,7 @@
         "Nebula Logger - Core@4.12.1-improved-error-emails": "04t5Y000001Mk4bQAC",
         "Nebula Logger - Core@4.12.2-automatically-select-default-field-set-in-relatedlogentries-lwc": "04t5Y000001Mk55QAC",
         "Nebula Logger - Core@4.12.3-bugfix-for-userinfo.getsessionid()-exception": "04t5Y000001Mk5AQAS",
+        "Nebula Logger - Core@4.12.4-bugfix-child-log__c-records-not-properly-linked-to-parent-log__c-records": "04t5Y000001Mk5KQAS",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -13,9 +13,9 @@
             "package": "Nebula Logger - Core",
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
-            "versionNumber": "4.12.3.NEXT",
-            "versionName": "Bugfix for UserInfo.getSessionId() Exception",
-            "versionDescription": "Added a try-catch block to usage of UserInfo.getSessionId() to handle a platform-thrown exception that occurs in some transactions (such as connected apps with JWT).",
+            "versionNumber": "4.12.4.NEXT",
+            "versionName": "Bugfix Child Log__c Records Not Properly Linked to Parent Log__c Records",
+            "versionDescription": "Fixed some scenarios where a Log__c record would have a value in ParentLogTransactionId__c but a null value in ParentLog__c",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"


### PR DESCRIPTION
Fixes #585 by updating `LogHandler` to query & update any orphaned child `Log__c` records to link them to their parent `Log__c` records. 

Note that this does not fix any existing problematic data in your org - it only prevents new problematic records from being created. To fix existing data in an org, you can run this anonymous Apex script:

```apex
List<Log__c> unlinkedChildLogs = [
  SELECT Id, ParentLogTransactionId__c
  FROM Log__c
  WHERE ParentLogTransactionId__c != NULL AND ParentLog__c = NULL
];
List<String> parentLogTransactionIds = new List<String>();
for (Log__c unlinkedChildLog : unlinkedChildLogs) {
    parentLogTransactionIds.add(unlinkedChildLog.ParentLogTransactionId__c);
}

Map<String, Log__c> parentLogTransactionIdToLog = new Map<String, Log__c>();
for (Log__c parentLog : [SELECT Id, TransactionId__c FROM Log__c WHERE TransactionId__c IN :parentLogTransactionIds]) {
    parentLogTransactionIdToLog.put(parentLog.TransactionId__c, parentLog);
}

for (Log__c unlinkedChildLog : unlinkedChildLogs) {
    unlinkedChildLog.ParentLog__c = parentLogTransactionIdToLog.get(unlinkedChildLog.ParentLogTransactionId__c)?.Id;
}
update unlinkedChildLogs;
```