### PR TITLE
Optionally enforce scenario-based logging usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.13.2
+## Unlocked Package - v4.13.3
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkEmQAK)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkEmQAK)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.13.3
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkEmQAK)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkEmQAK)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkEwQAK)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkEwQAK)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001MkEmQAK`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001MkEwQAK`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001MkEmQAK`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001MkEwQAK`
 
 ---
 

--- a/config/linters/lint-staged.config.js
+++ b/config/linters/lint-staged.config.js
@@ -7,10 +7,11 @@ module.exports = {
         return [`eslint --config ./config/linters/.eslintrc.json ${filenames.join(' ')} --fix`];
         // FIXME this command should only run tests for the changed LWCs (instead of running tests for all LWCs)
         // return [`eslint --config ./config/linters/.eslintrc.json ${filenames.join(' ')} --fix`, `npm run test:lwc`];
+    },
+    '*.{cls,trigger}': filenames => {
+        return filenames.map(
+            filename => `sf scanner run --pmdconfig ./config/linters/pmd-ruleset.xml --engine pmd --severity-threshold 3 --target '${filename}'`
+        );
+        // return [`npm run scan:apex`, `npm run docs:fix && git add ./docs/ && git commit --amend --no-edit`];
     }
-    // FIXME this command should only scan the changed Apex files (instead of scanning all Apex files)
-    // '*.{cls,trigger}': () => {
-    //     return [`npm run scan:apex`];
-    //     // return [`npm run scan:apex`, `npm run docs:fix && git add ./docs/ && git commit --amend --no-edit`];
-    // }
 };

--- a/docs/apex/Configuration/LoggerParameter.md
+++ b/docs/apex/Configuration/LoggerParameter.md
@@ -94,6 +94,10 @@ Controls if Nebula Logger queries `Schema.User` data. When set to `false`, any `
 
 Indicates if Nebula Logger queries `Schema.User` data is queried synchronously &amp; populated on `LogEntryEvent__e` records. When set to `false`, any `Schema.User` fields on `LogEntryEvent__e` that rely on querying will not be populated - the data will instead be queried asynchronously and populated on any resulting `Log__c` records. Controlled by the custom metadata record `LoggerParameter.QueryUserDataSynchronously`, or `true` as the default
 
+#### `REQUIRE_SCENARIO_USAGE` → `Boolean`
+
+Indicates if Nebula Logger will enforce scenario-based logging to be used. When set to `false`, specifying a scenario is completely optional. When set to `true`, a scenario is required to be set before any logging can occur. If a logging method is called &amp;amp; the current scenario is null/blank, then Nebula Logger will throw a runtime exception. Controlled by the custom metadata record `LoggerParameter.RequireScenarioUsage`, or `false` as the default
+
 #### `SEND_ERROR_EMAIL_NOTIFICATIONS` → `Boolean`
 
 Indicates if Nebula Logger will send an error email notification if any internal exceptions occur. Controlled by the custom metadata record `LoggerParameter.SendErrorEmailNotifications`, or `true` as the default

--- a/docs/apex/Logger-Engine/Logger.md
+++ b/docs/apex/Logger-Engine/Logger.md
@@ -5730,6 +5730,10 @@ The new entry&apos;s instance of `LogEntryEventBuilder`, useful for chaining met
 
 ### Inner Classes
 
+#### Logger.LoggerException class
+
+---
+
 #### Logger.QueueableSaver class
 
 Inner class for publishing log entries via the Queueable interface.

--- a/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
@@ -335,6 +335,19 @@ public class LoggerParameter {
         private set;
     }
 
+    public static final Boolean REQUIRE_SCENARIO_USAGE {
+        get {
+            if (REQUIRE_SCENARIO_USAGE == null) {
+                // Most features in Nebula Logger are enabled (true) by default,
+                // but this one is intentionally set to false by default - not
+                // all orgs want or need to use scenario-based logging
+                REQUIRE_SCENARIO_USAGE = getBoolean('RequireScenarioUsage', false);
+            }
+            return REQUIRE_SCENARIO_USAGE;
+        }
+        private set;
+    }
+
     /**
      * @description Indicates if Nebula Logger will send an error email notification if any internal exceptions occur.
      *              Controlled by the custom metadata record `LoggerParameter.SendErrorEmailNotifications`, or `true` as the default

--- a/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
@@ -335,6 +335,13 @@ public class LoggerParameter {
         private set;
     }
 
+    /**
+     * @description Indicates if Nebula Logger will enforce scenario-based logging to be used.
+     *              When set to `false`, specifying a scenario is completely optional.
+     *              When set to `true`, a scenario is required to be set before any logging can occur.
+     *              If a logging method is called &amp; the current scenario is null/blank, then Nebula Logger will throw a runtime exception.
+     *              Controlled by the custom metadata record `LoggerParameter.RequireScenarioUsage`, or `false` as the default
+     */
     public static final Boolean REQUIRE_SCENARIO_USAGE {
         get {
             if (REQUIRE_SCENARIO_USAGE == null) {

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.RequireScenarioUsage.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.RequireScenarioUsage.md-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomMetadata
+    xmlns="http://soap.sforce.com/2006/04/metadata"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+>
+    <label>Require Scenario Usage</label>
+    <protected>false</protected>
+    <values>
+        <field>Description__c</field>
+        <value xsi:type="xsd:string">When set to &apos;false&apos; (default), specifying a scenario is completely optional.
+
+When set to &apos;true&apos;, a scenario is required to be set before any logging can occur. If a logging method is called &amp; the current scenario is null/blank, then Nebula Logger will throw a runtime exception.</value>
+    </values>
+    <values>
+        <field>Value__c</field>
+        <value xsi:type="xsd:string">false</value>
+    </values>
+</CustomMetadata>

--- a/nebula-logger/core/main/log-management/flexipages/LoggerScenarioRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LoggerScenarioRecordPage.flexipage-meta.xml
@@ -34,6 +34,21 @@
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
+                    <name>actionNames</name>
+                    <valueList>
+                        <valueListItems>
+                            <value>Log__c.Manage</value>
+                        </valueListItems>
+                    </valueList>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>adminFilters</name>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>maxRecordsToDisplay</name>
+                    <value>30</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>parentFieldApiName</name>
                     <value>LoggerScenario__c.Id</value>
                 </componentInstanceProperties>
@@ -42,19 +57,62 @@
                     <value>Logs__r</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
-                    <name>relatedListComponentOverride</name>
+                    <name>relatedListDisplayType</name>
                     <value>ADVGRID</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
-                    <name>rowsToDisplay</name>
-                    <value>30</value>
+                    <name>relatedListFieldAliases</name>
+                    <valueList>
+                        <valueListItems>
+                            <value>NAME</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>StartTime__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>LoggedByUsernameLink__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>TransactionId__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>TotalLogEntries__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>TotalERRORLogEntries__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>TotalWARNLogEntries__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>OWNER.ALIAS</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>Priority__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>Status__c</value>
+                        </valueListItems>
+                    </valueList>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListLabel</name>
+                    <value>Logs</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>showActionBar</name>
                     <value>true</value>
                 </componentInstanceProperties>
-                <componentName>force:relatedListSingleContainer</componentName>
-                <identifier>force_relatedListSingleContainer</identifier>
+                <componentInstanceProperties>
+                    <name>sortFieldAlias</name>
+                    <value>StartTime__c</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>sortFieldOrder</name>
+                    <value>Descending</value>
+                </componentInstanceProperties>
+                <componentName>lst:dynamicRelatedList</componentName>
+                <identifier>lst_dynamicRelatedList</identifier>
             </componentInstance>
         </itemInstances>
         <name>relatedTabContent</name>
@@ -64,6 +122,18 @@
         <itemInstances>
             <componentInstance>
                 <componentInstanceProperties>
+                    <name>actionNames</name>
+                    <valueList>
+                        <valueListItems>
+                            <value>MassChangeOwner</value>
+                        </valueListItems>
+                    </valueList>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>maxRecordsToDisplay</name>
+                    <value>30</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>parentFieldApiName</name>
                     <value>LoggerScenario__c.Id</value>
                 </componentInstanceProperties>
@@ -72,19 +142,56 @@
                     <value>LogEntries__r</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
-                    <name>relatedListComponentOverride</name>
+                    <name>relatedListDisplayType</name>
                     <value>ADVGRID</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
-                    <name>rowsToDisplay</name>
-                    <value>30</value>
+                    <name>relatedListFieldAliases</name>
+                    <valueList>
+                        <valueListItems>
+                            <value>NAME</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>Timestamp__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>LoggedByUsernameLink__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>Origin__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>Message__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>LoggingLevelWithImage__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>Log__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>RecordLink__c</value>
+                        </valueListItems>
+                    </valueList>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListLabel</name>
+                    <value>Log Entries</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>showActionBar</name>
-                    <value>true</value>
+                    <value>false</value>
                 </componentInstanceProperties>
-                <componentName>force:relatedListSingleContainer</componentName>
-                <identifier>force_relatedListSingleContainer3</identifier>
+                <componentInstanceProperties>
+                    <name>sortFieldAlias</name>
+                    <value>Timestamp__c</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>sortFieldOrder</name>
+                    <value>Descending</value>
+                </componentInstanceProperties>
+                <componentName>lst:dynamicRelatedList</componentName>
+                <identifier>lst_dynamicRelatedList2</identifier>
             </componentInstance>
         </itemInstances>
         <name>Facet-bf77ace2-6cee-4ca4-88b4-990633a74278</name>
@@ -125,7 +232,7 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>active</name>
-                    <value>true</value>
+                    <value>false</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>body</name>
@@ -141,6 +248,10 @@
         </itemInstances>
         <itemInstances>
             <componentInstance>
+                <componentInstanceProperties>
+                    <name>active</name>
+                    <value>false</value>
+                </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>body</name>
                     <value>Facet-bf77ace2-6cee-4ca4-88b4-990633a74278</value>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -1560,6 +1560,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.TransactionScenario__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.UserLicenseDefinitionKey__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.13.2';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.13.3';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
     private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -18,6 +18,7 @@ global with sharing class Logger {
     private static final String CURRENT_VERSION_NUMBER = 'v4.13.2';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
+    private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';
     private static final String ORGANIZATION_DOMAIN_URL = System.URL.getOrgDomainUrl()?.toExternalForm();
     private static final String REQUEST_ID = System.Request.getCurrent().getRequestId();
     private static final Map<String, SaveMethod> SAVE_METHOD_NAME_TO_SAVE_METHOD = new Map<String, SaveMethod>();
@@ -3351,6 +3352,10 @@ global with sharing class Logger {
     private static LogEntryEventBuilder newEntry(System.LoggingLevel loggingLevel, Boolean shouldSave) {
         LogEntryEventBuilder logEntryEventBuilder = new LogEntryEventBuilder(getUserSettings(), loggingLevel, shouldSave);
         if (logEntryEventBuilder.shouldSave()) {
+            if (LoggerParameter.REQUIRE_SCENARIO_USAGE && String.isBlank(currentEntryScenario)) {
+                throw new LoggerException(MISSING_SCENARIO_ERROR_MESSAGE);
+            }
+
             LogEntryEvent__e logEntryEvent = logEntryEventBuilder.getLogEntryEvent();
             logEntryEvent.ApiVersion__c = getOrganizationApiVersion();
             logEntryEvent.EntryScenario__c = currentEntryScenario;
@@ -3491,6 +3496,10 @@ global with sharing class Logger {
             Logger.setAsyncContext(queueableContext);
             LoggerDataStore.getEventBus().publishRecords(this.logEntryEvents, PLATFORM_EVENT_DML_OPTIONS);
         }
+    }
+
+    // Inner class used for any exceptions specific to Nebula Logger functionality
+    public class LoggerException extends Exception {
     }
 
     // Inner class used for deserializing data from the status API

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -3499,6 +3499,7 @@ global with sharing class Logger {
     }
 
     // Inner class used for any exceptions specific to Nebula Logger functionality
+    @SuppressWarnings('PMD.ApexDoc')
     public class LoggerException extends Exception {
     }
 

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 import FORM_FACTOR from '@salesforce/client/formFactor';
 
-const CURRENT_VERSION_NUMBER = 'v4.13.2';
+const CURRENT_VERSION_NUMBER = 'v4.13.3';
 
 // JavaScript equivalent to the Apex class ComponentLogger.ComponentLogEntry
 const ComponentLogEntry = class {

--- a/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
@@ -273,6 +273,33 @@ private class LoggerParameter_Tests {
     }
 
     @IsTest
+    static void it_should_use_true_as_default_constant_value_for_require_scenario_usage_when_null() {
+        LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'RequireScenarioUsage', Value__c = null));
+
+        Boolean returnedValue = LoggerParameter.REQUIRE_SCENARIO_USAGE;
+
+        System.Assert.isFalse(returnedValue);
+    }
+
+    @IsTest
+    static void it_should_return_constant_value_for_require_scenario_usage_when_true() {
+        LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'RequireScenarioUsage', Value__c = JSON.serialize(true)));
+
+        Boolean returnedValue = LoggerParameter.REQUIRE_SCENARIO_USAGE;
+
+        System.Assert.isTrue(returnedValue);
+    }
+
+    @IsTest
+    static void it_should_return_constant_value_for_require_scenario_usage_when_false() {
+        LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'RequireScenarioUsage', Value__c = JSON.serialize(false)));
+
+        Boolean returnedValue = LoggerParameter.REQUIRE_SCENARIO_USAGE;
+
+        System.Assert.isFalse(returnedValue);
+    }
+
+    @IsTest
     static void it_should_return_constant_value_for_send_error_email_notifications() {
         Boolean mockValue = false;
         LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'SendErrorEmailNotifications', Value__c = JSON.serialize(mockValue));

--- a/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
@@ -273,7 +273,7 @@ private class LoggerParameter_Tests {
     }
 
     @IsTest
-    static void it_should_use_true_as_default_constant_value_for_require_scenario_usage_when_null() {
+    static void it_should_use_false_as_default_constant_value_for_require_scenario_usage_when_null() {
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'RequireScenarioUsage', Value__c = null));
 
         Boolean returnedValue = LoggerParameter.REQUIRE_SCENARIO_USAGE;

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -326,6 +326,25 @@ private class Logger_Tests {
     }
 
     @IsTest
+    static void it_should_require_scenario_when_parameter_enabled() {
+        LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'RequireScenarioUsage', Value__c = String.valueOf(true));
+        LoggerParameter.setMock(mockParameter);
+        System.Assert.isTrue(LoggerParameter.REQUIRE_SCENARIO_USAGE);
+        String nullScenario = null;
+
+        Logger.setScenario(nullScenario);
+        Exception thrownException;
+        try {
+            Logger.info('Some message');
+        } catch (Exception ex) {
+            thrownException = ex;
+        }
+
+        System.Assert.isNotNull(thrownException, 'An exception should have been thrown due to a null scenario');
+        System.Assert.isInstanceOfType(thrownException, Logger.LoggerException.class);
+    }
+
+    @IsTest
     static void it_should_use_the_first_specified_scenario_as_transaction_scenario_when_parameter_is_true() {
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
         LoggerParameter.setMock(new LoggerParameter__mdt(DeveloperName = 'UseFirstSpecifiedScenario', Value__c = String.valueOf(true)));

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     },
     "scripts": {
         "apex:tail:log": "sf apex tail log --color",
-        "apex:tail:log:file": "sf apex tail log | tee sf_tail.log",
+        "apex:tail:log:file": "sh scripts/build/tail-log-to-file.sh",
         "devhub:details": "pwsh ./scripts/build/get-devhub-org-details.ps1",
         "devhub:limits": "pwsh ./scripts/build/get-devhub-org-limits.ps1",
         "devhub:open": "pwsh ./scripts/build/open-devhub-org.ps1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.13.2",
+    "version": "4.13.3",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/scripts/build/tail-log-to-file.sh
+++ b/scripts/build/tail-log-to-file.sh
@@ -1,0 +1,6 @@
+now=$(date +"%Y-%m-%dT%H_%M_%S%z")
+logDirectory="logs"
+
+echo "Starting sf apex tail log at ${now}"
+[[ -d ${logDirectory} ]] || mkdir ${logDirectory}
+sf apex tail log --color | tee ./${logDirectory}/sf_tail_${now}.log

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -170,6 +170,7 @@
         "Nebula Logger - Core@4.13.0-spring-'24-release": "04t5Y000001Mk8dQAC",
         "Nebula Logger - Core@4.13.1-apex-observability": "04t5Y000001MkE3QAK",
         "Nebula Logger - Core@4.13.2-capture-organization-limits-usage": "04t5Y000001MkEmQAK",
+        "Nebula Logger - Core@4.13.3-optionally-enforce-scenario-usage": "04t5Y000001MkEwQAK",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -14,9 +14,9 @@
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
             "scopeProfiles": true,
-            "versionNumber": "4.13.2.NEXT",
-            "versionName": "Capture Organization Limits Usage",
-            "versionDescription": "Added the ability to capture & view organization limits on Log__c with new LWC logOrganizationLimits, as well as the ability to toggle capturing of transaction limits with a new LoggerParameter__mdt record",
+            "versionNumber": "4.13.3.NEXT",
+            "versionName": "Optionally Enforce Scenario Usage",
+            "versionDescription": "Added the ability to require scenario-based logging, using a new LoggerParameter__mdt record 'RequireScenarioUsage'",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"


### PR DESCRIPTION
- Resolved #645 by adding the ability to optionally enforce using scenario-based logging. This is controlled by a new `LoggerParameter__mdt` record, `RequireScenarioUsage`, and is disabled (`false`) by default.
  - When set to `false`, specifying a scenario is completely optional. 
  - When set to `true`, a scenario is required to be set before any logging can occur. If a logging method is called &amp;amp; the current scenario is null/blank, then Nebula Logger will throw a runtime exception.
- Upgraded `LoggerScenarioRecordPage` flexipage to use dynamic related lists for `Log__c` and `LogEntry__c`
- Added missing field permission for `Log__c.TransactionScenario__c` to `LoggerAdmin` permission set