### PR TITLE
Added New Comments__c Field on LoggerParameter__mdt

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.13.4
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkEwQAK)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkEwQAK)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkFBQA0)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkFBQA0)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001MkEwQAK`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001MkFBQA0`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001MkEwQAK`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001MkFBQA0`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.13.3
+## Unlocked Package - v4.13.4
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkEwQAK)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkEwQAK)

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.CallStatusApi.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.CallStatusApi.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Call Status API</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.DefaultLogEntryRelatedListFieldSet.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.DefaultLogEntryRelatedListFieldSet.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Default Log Entry Related List Field Set</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableLogEntryEventStream.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableLogEntryEventStream.md-meta.xml
@@ -7,10 +7,14 @@
     <label>Enable Log Entry Event Stream</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"
-        >When set to &apos;true&apos; (default), the LWC logEntryEventStream is enabled &amp; subscribes to LogEntryEvent__e records, using the Emp API. Using the Emp API counts towards your org's event delivery allocations, so the LWC can be disabled if the allocation needs to be conserved. See this page for more details may be generated that contain additional details about the logging system - https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_event_limits.htm</value>
+        >When set to &apos;true&apos; (default), the LWC logEntryEventStream is enabled &amp; subscribes to LogEntryEvent__e records, using the Emp API. Using the Emp API counts towards your org&apos;s event delivery allocations, so the LWC can be disabled if the allocation needs to be conserved. See this page for more details may be generated that contain additional details about the logging system - https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/platform_event_limits.htm</value>
     </values>
     <values>
         <field>Value__c</field>

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableLoggerSystemMessages.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableLoggerSystemMessages.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Enable Logger System Messages</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value xsi:type="xsd:string">When enabled, log entries may be generated that contain additional details about the logging system.</value>
     </values>

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableStackTraceParsing.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableStackTraceParsing.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Enable Stack Trace Parsing</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableTagging.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.EnableTagging.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Enable Tagging</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.LogEntryEventStreamDisplayFields.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.LogEntryEventStreamDisplayFields.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Log Entry Event Stream Display Fields</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value xsi:type="xsd:string">Contains the fields to be displayed in the Tabular view of the Log Entry Event Stream Tab under the Logger Console.</value>
     </values>

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.NormalizeScenarioData.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.NormalizeScenarioData.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Normalize Scenario Data</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.NormalizeTagData.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.NormalizeTagData.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Normalize Tag Data</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.PlatformCachePartitionName.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.PlatformCachePartitionName.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Platform Cache Partition Name</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value xsi:type="xsd:string">Indicates the name of the Platform Cache partition to use for caching (when platform cache is enabled).
 

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryApexClassData.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryApexClassData.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Query Apex Class Data</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryApexTriggerData.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryApexTriggerData.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Query Apex Trigger Data</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryAuthSessionData.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryAuthSessionData.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Query Auth Session Data</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryAuthSessionDataSynchronously.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryAuthSessionDataSynchronously.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Query Auth Session Data Synchronously</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryFlowDefinitionViewData.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryFlowDefinitionViewData.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Query Flow Definition View Data</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryNetworkData.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryNetworkData.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Query Network Data</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value xsi:type="xsd:string">Note: this parameter only applies to orgs that are using Experience Cloud (Communities).
 

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryNetworkDataSynchronously.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryNetworkDataSynchronously.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Query Network Data Synchronously</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value xsi:type="xsd:string">Note: this parameter only applies to orgs that are using Experience Cloud (Communities).
 

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryOrganizationData.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryOrganizationData.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Query Organization Data</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryOrganizationDataSynchronously.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryOrganizationDataSynchronously.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Query Organization Data Synchronously</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryRelatedRecordData.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryRelatedRecordData.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Query Related Record Data</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryUserData.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryUserData.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Query User Data</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryUserDataSynchronously.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.QueryUserDataSynchronously.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Query User Data Synchronously</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.SendErrorEmailNotifications.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.SendErrorEmailNotifications.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Send Error Email Notifications</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreHttpResponseHeaderValues.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreHttpResponseHeaderValues.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Store HTTP Response Header Values</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreOrganizationLimits.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreOrganizationLimits.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Store Organization Limits</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreRestRequestHeaderValues.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreRestRequestHeaderValues.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Store REST Request Header Values</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreRestResponseHeaderValues.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreRestResponseHeaderValues.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Store REST Response Header Values</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreTransactionLimits.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreTransactionLimits.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Store Transaction Limits</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.SystemDebugMessageFormat.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.SystemDebugMessageFormat.md-meta.xml
@@ -7,6 +7,10 @@
     <label>System.debug() Message Format</label>
     <protected>true</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value xsi:type="xsd:string">Controls the format of the Apex Log System Debug messages with fields from LogEntryEvent__e</value>
     </values>

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.UseFirstSpecifiedScenario.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.UseFirstSpecifiedScenario.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Use First Specified Scenario</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.UsePlatformCache.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.UsePlatformCache.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Use Platform Cache</label>
     <protected>false</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value
             xsi:type="xsd:string"

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.UsePlatformCache.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.UsePlatformCache.md-meta.xml
@@ -15,6 +15,7 @@
         <value
             xsi:type="xsd:string"
         >When set to &apos;true&apos; (default), Nebula Logger will used Platform Cache to cache organization and session data in the cache partition LoggerCache.
+
 When set to &apos;false&apos;, any cached data is only cached within a single transaction.</value>
     </values>
     <values>

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.UseTopicsForTags.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.UseTopicsForTags.md-meta.xml
@@ -7,6 +7,10 @@
     <label>Use Topics for Tags</label>
     <protected>true</protected>
     <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true" />
+    </values>
+    <values>
         <field>Description__c</field>
         <value xsi:type="xsd:string">When set to &apos;true&apos;, any custom Logger tags will use the standard objects Topic and TopicAssignment
 

--- a/nebula-logger/core/main/configuration/layouts/LoggerParameter__mdt-Logger Parameter Layout.layout-meta.xml
+++ b/nebula-logger/core/main/configuration/layouts/LoggerParameter__mdt-Logger Parameter Layout.layout-meta.xml
@@ -27,11 +27,24 @@
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>Description__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <style>OneColumn</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
+        <detailHeading>true</detailHeading>
+        <editHeading>true</editHeading>
+        <label>Parameter Customizations</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>Value__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>Description__c</field>
+                <field>Comments__c</field>
             </layoutItems>
         </layoutColumns>
         <style>OneColumn</style>
@@ -79,7 +92,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h1F000005MrCN</masterLabel>
+        <masterLabel>00h7d000002qsE4</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/nebula-logger/core/main/configuration/objects/LoggerParameter__mdt/fields/Comments__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerParameter__mdt/fields/Comments__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Comments__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText
+    >A place to store any notes about how this LoggerParameter__mdt has been customized in the current org. This is purely for documentation purposes.</inlineHelpText>
+    <label>Comments</label>
+    <length>4000</length>
+    <type>LongTextArea</type>
+    <visibleLines>6</visibleLines>
+</CustomField>

--- a/nebula-logger/core/main/configuration/objects/LoggerParameter__mdt/fields/Comments__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerParameter__mdt/fields/Comments__c.field-meta.xml
@@ -4,7 +4,7 @@
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
-    >A place to store any notes about how this LoggerParameter__mdt has been customized in the current org. This is purely for documentation purposes.</inlineHelpText>
+    >A place to store any comments or notes about customizations that have been made to this LoggerParameter__mdt in the current org. This is purely for documentation purposes.</inlineHelpText>
     <label>Comments</label>
     <length>4000</length>
     <type>LongTextArea</type>

--- a/nebula-logger/core/main/configuration/objects/LoggerParameter__mdt/listViews/All.listView-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerParameter__mdt/listViews/All.listView-meta.xml
@@ -5,6 +5,7 @@
     <columns>DeveloperName</columns>
     <columns>Value__c</columns>
     <columns>Description__c</columns>
+    <columns>Comments__c</columns>
     <columns>IsProtected</columns>
     <filterScope>Everything</filterScope>
     <label>All</label>

--- a/nebula-logger/core/main/log-management/lwc/logBatchPurge/logBatchPurge.html
+++ b/nebula-logger/core/main/log-management/lwc/logBatchPurge/logBatchPurge.html
@@ -1,3 +1,8 @@
+<!--**********************************************************************************************
+ * This file is part of the Nebula Logger project, released under the MIT License.               *
+ * See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.   *
+ **********************************************************************************************-->
+
 <template>
     <lightning-card title={title} icon-name="standard:record_delete">
         <div class="slds-p-around_small">

--- a/nebula-logger/core/main/log-management/lwc/logOrganizationLimits/logOrganizationLimits.html
+++ b/nebula-logger/core/main/log-management/lwc/logOrganizationLimits/logOrganizationLimits.html
@@ -1,3 +1,8 @@
+<!--**********************************************************************************************
+ * This file is part of the Nebula Logger project, released under the MIT License.               *
+ * See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.   *
+ **********************************************************************************************-->
+
 <template>
     <c-logger-page-section>
         <span slot="title">Organization Limits</span>

--- a/nebula-logger/core/main/log-management/lwc/logOrganizationLimits/logOrganizationLimits.js
+++ b/nebula-logger/core/main/log-management/lwc/logOrganizationLimits/logOrganizationLimits.js
@@ -1,3 +1,8 @@
+/*************************************************************************************************
+ * This file is part of the Nebula Logger project, released under the MIT License.               *
+ * See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.   *
+ ************************************************************************************************/
+
 import { LightningElement, api, wire } from 'lwc';
 import { getRecord, getFieldValue } from 'lightning/uiRecordApi';
 import ORGANIZATION_LIMITS_FIELD from '@salesforce/schema/Log__c.OrganizationLimits__c';

--- a/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.html
+++ b/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.html
@@ -1,3 +1,8 @@
+<!--**********************************************************************************************
+ * This file is part of the Nebula Logger project, released under the MIT License.               *
+ * See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.   *
+ **********************************************************************************************-->
+
 <template>
     <div class="slds-page-header">
         <div class="slds-page-header__row">

--- a/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.js
+++ b/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/loggerHomeHeader.js
@@ -1,3 +1,8 @@
+/*************************************************************************************************
+ * This file is part of the Nebula Logger project, released under the MIT License.               *
+ * See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.   *
+ ************************************************************************************************/
+
 import { LightningElement, wire } from 'lwc';
 import { NavigationMixin } from 'lightning/navigation';
 import getEnvironmentDetails from '@salesforce/apex/LoggerHomeHeaderController.getEnvironmentDetails';

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.13.3';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.13.4';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
     private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 import FORM_FACTOR from '@salesforce/client/formFactor';
 
-const CURRENT_VERSION_NUMBER = 'v4.13.3';
+const CURRENT_VERSION_NUMBER = 'v4.13.4';
 
 // JavaScript equivalent to the Apex class ComponentLogger.ComponentLogEntry
 const ComponentLogEntry = class {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.13.3",
+    "version": "4.13.4",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -14,9 +14,9 @@
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
             "scopeProfiles": true,
-            "versionNumber": "4.13.3.NEXT",
-            "versionName": "Optionally Enforce Scenario Usage",
-            "versionDescription": "Added the ability to require scenario-based logging, using a new LoggerParameter__mdt record 'RequireScenarioUsage'",
+            "versionNumber": "4.13.4.NEXT",
+            "versionName": "Logger Parameter Comments",
+            "versionDescription": "Added new field LoggerParameter__mdt.Comments__c to provide a place to add comments & notes about customizations made to LoggerParameter__mdt records",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -171,6 +171,7 @@
         "Nebula Logger - Core@4.13.1-apex-observability": "04t5Y000001MkE3QAK",
         "Nebula Logger - Core@4.13.2-capture-organization-limits-usage": "04t5Y000001MkEmQAK",
         "Nebula Logger - Core@4.13.3-optionally-enforce-scenario-usage": "04t5Y000001MkEwQAK",
+        "Nebula Logger - Core@4.13.4-logger-parameter-comments": "04t5Y000001MkFBQA0",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
- Added new field `LoggerParameter__mdt.Comments__c` as a place for admins & developers to store notes about why a `LoggerParameter__mdt` record has been customized. 
  - This is only intended for documentation purposes to help admins viewing the record in the org, as well as a way to document customizations in git/VCS
  
  ![image](https://github.com/jongpie/NebulaLogger/assets/1267157/911fae3d-bd11-4d7d-9f20-f07a09b9eb57)

- Updated `LoggerParameter__mdt` records to include the XML node for the new `Comments__c` field
- Scope creep: added missing project license info in several LWC files
- Scope creep: added `.npmrc` file to explicitly set the npm registry