### PR TITLE
View Log Entry Metadata custom permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.13.5
+## Unlocked Package - v4.13.6
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkGnQAK)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkGnQAK)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.13.6
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkGnQAK)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkGnQAK)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkGxQAK)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkGxQAK)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001MkGnQAK`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001MkGxQAK`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001MkGnQAK`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001MkGxQAK`
 
 ---
 

--- a/nebula-logger/core/main/log-management/classes/LogEntryMetadataViewerController.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryMetadataViewerController.cls
@@ -15,12 +15,10 @@ public without sharing class LogEntryMetadataViewerController {
      * @param       sourceMetadata Either the value `Origin` or `Exception`
      * @return      An instance of `LogEntryMetadataViewerController.LogEntryMetadata`
      */
-    // @AuraEnabled
     @AuraEnabled(cacheable=true)
     public static LogEntryMetadata getMetadata(Id recordId, String sourceMetadata) {
         LogEntryMetadata metadata = new LogEntryMetadata();
         if (canViewLogEntryMetadata() == false) {
-            // TODO decide if it makes more sense to return null
             return metadata;
         }
 
@@ -31,30 +29,27 @@ public without sharing class LogEntryMetadataViewerController {
         switch on sourceMetadata {
             when 'Exception' {
                 sourceApiName = logEntry.ExceptionSourceApiName__c;
-                sourceMetadataType = String.isBlank(logEntry.ExceptionSourceMetadataType__c)
-                    ? null
-                    : LoggerStackTrace.SourceMetadataType.valueOf(logEntry.ExceptionSourceMetadataType__c);
+                sourceMetadataType = getSourceMetadataType(logEntry.ExceptionSourceMetadataType__c);
             }
             when 'Origin' {
                 sourceApiName = logEntry.OriginSourceApiName__c;
-                sourceMetadataType = String.isBlank(logEntry.OriginSourceMetadataType__c)
-                    ? null
-                    : LoggerStackTrace.SourceMetadataType.valueOf(logEntry.OriginSourceMetadataType__c);
+                sourceMetadataType = getSourceMetadataType(logEntry.OriginSourceMetadataType__c);
             }
         }
 
-        if (sourceMetadataType == null || String.isBlank(sourceApiName)) {
-            return metadata;
+        if (String.isNotBlank(sourceApiName) && sourceMetadataType != null) {
+            querySourceMetadata(logEntry, metadata, sourceMetadataType, sourceApiName);
         }
-
-        querySourceMetadata(logEntry, metadata, sourceMetadataType, sourceApiName);
 
         return metadata;
     }
 
-    @TestVisible
     private static Boolean canViewLogEntryMetadata() {
         return Schema.ApexClass.SObjectType.getDescribe().isAccessible() || System.FeatureManagement.checkPermission('CanViewLogEntryMetadata');
+    }
+
+    private static LoggerStackTrace.SourceMetadataType getSourceMetadataType(String sourceMetadata) {
+        return String.isBlank(sourceMetadata) ? null : LoggerStackTrace.SourceMetadataType.valueOf(sourceMetadata);
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')
@@ -81,14 +76,12 @@ public without sharing class LogEntryMetadataViewerController {
             }
         }
 
-        if (codeBodyField == null || metadataRecords == null || metadataRecords.isEmpty()) {
-            return;
+        if (codeBodyField != null && metadataRecords != null && metadataRecords.isEmpty() == false) {
+            SObject metadataRecord = metadataRecords.get(0);
+
+            logEntryMetadata.HasCodeBeenModified = ((Datetime) metadataRecord.get(lastModifiedDateField)) > logEntry.Timestamp__c;
+            logEntryMetadata.Code = (String) metadataRecord.get(codeBodyField);
         }
-
-        SObject metadataRecord = metadataRecords.get(0);
-
-        logEntryMetadata.HasCodeBeenModified = ((Datetime) metadataRecord.get(lastModifiedDateField)) > logEntry.Timestamp__c;
-        logEntryMetadata.Code = (String) metadataRecord.get(codeBodyField);
     }
 
     // TODO consider combining with LogEntryHandler.SourceMetadataSnippet (which could become a top-level class)

--- a/nebula-logger/core/main/log-management/classes/LogEntryMetadataViewerController.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryMetadataViewerController.cls
@@ -19,7 +19,7 @@ public without sharing class LogEntryMetadataViewerController {
     @AuraEnabled(cacheable=true)
     public static LogEntryMetadata getMetadata(Id recordId, String sourceMetadata) {
         LogEntryMetadata metadata = new LogEntryMetadata();
-        if (Schema.ApexClass.SObjectType.getDescribe().isAccessible() == false || Schema.ApexTrigger.SObjectType.getDescribe().isAccessible() == false) {
+        if (canViewLogEntryMetadata() == false) {
             // TODO decide if it makes more sense to return null
             return metadata;
         }
@@ -50,6 +50,11 @@ public without sharing class LogEntryMetadataViewerController {
         querySourceMetadata(logEntry, metadata, sourceMetadataType, sourceApiName);
 
         return metadata;
+    }
+
+    @TestVisible
+    private static Boolean canViewLogEntryMetadata() {
+        return Schema.ApexClass.SObjectType.getDescribe().isAccessible() || System.FeatureManagement.checkPermission('CanViewLogEntryMetadata');
     }
 
     @SuppressWarnings('PMD.ExcessiveParameterList')

--- a/nebula-logger/core/main/log-management/customPermissions/CanViewLogEntryMetadata.customPermission-meta.xml
+++ b/nebula-logger/core/main/log-management/customPermissions/CanViewLogEntryMetadata.customPermission-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomPermission xmlns="http://soap.sforce.com/2006/04/metadata">
+    <isLicensed>false</isLicensed>
+    <label>Nebula Logger: Can View Log Entry Metadata</label>
+</CustomPermission>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -108,6 +108,10 @@
         <enabled>true</enabled>
         <name>CanModifyLoggerSettings</name>
     </customPermissions>
+    <customPermissions>
+        <enabled>true</enabled>
+        <name>CanViewLogEntryMetadata</name>
+    </customPermissions>
     <customSettingAccesses>
         <enabled>true</enabled>
         <name>LoggerSettings__c</name>

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.13.5';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.13.6';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
     private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 import FORM_FACTOR from '@salesforce/client/formFactor';
 
-const CURRENT_VERSION_NUMBER = 'v4.13.5';
+const CURRENT_VERSION_NUMBER = 'v4.13.6';
 
 // JavaScript equivalent to the Apex class ComponentLogger.ComponentLogEntry
 const ComponentLogEntry = class {

--- a/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
@@ -1230,19 +1230,6 @@ private class LogEntryHandler_Tests {
         return namespacePrefix;
     }
 
-    private class MockLogManagementDataSelector extends LogManagementDataSelector {
-        private Integer apexClassesQueryCount = 0;
-
-        public override List<ApexClass> getApexClasses(Set<String> apexClassNames) {
-            this.apexClassesQueryCount++;
-            return super.getApexClasses(apexClassNames);
-        }
-
-        public Integer getApexClassesQueryCount() {
-            return apexClassesQueryCount;
-        }
-    }
-
     // Helper class for testing stack trace parsing & ApexClass querying for an inner class
     private class SomeInnerClass {
         public LoggerStackTrace getLoggerStackTrace() {

--- a/nebula-logger/core/tests/log-management/classes/LogEntryMetadataViewerController_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryMetadataViewerController_Tests.cls
@@ -10,8 +10,8 @@ private class LogEntryMetadataViewerController_Tests {
     }
 
     @IsTest
-    static void it_returns_metadata_for_log_entry_when_source_metadata_is_exception() {
-        ApexClass mockExceptionApexClass = createMockApexClass('Some_Fake_Apex_Class');
+    static void it_returns_apex_class_metadata_for_log_entry_when_source_metadata_is_exception() {
+        Schema.ApexClass mockExceptionApexClass = createMockApexClass('Some_Fake_Apex_Class');
         System.Assert.isNotNull(mockExceptionApexClass.Name);
         MOCK_SELECTOR.setMockApexClass(mockExceptionApexClass);
         LogEntry__c mockLogEntry = createMockLogEntry(null, mockExceptionApexClass);
@@ -29,8 +29,27 @@ private class LogEntryMetadataViewerController_Tests {
     }
 
     @IsTest
+    static void it_returns_apex_trigger_metadata_for_log_entry_when_source_metadata_is_exception() {
+        Schema.ApexTrigger mockExceptionApexTrigger = createMockApexTrigger('Some_Fake_Apex_Trigger');
+        System.Assert.isNotNull(mockExceptionApexTrigger.Name);
+        MOCK_SELECTOR.setMockApexTrigger(mockExceptionApexTrigger);
+        LogEntry__c mockLogEntry = createMockLogEntry(null, mockExceptionApexTrigger);
+        System.Assert.areEqual(mockExceptionApexTrigger.Name, mockLogEntry.ExceptionSourceApiName__c);
+        System.Assert.isNull(mockLogEntry.OriginSourceApiName__c);
+        MOCK_SELECTOR.setMockLogEntry(mockLogEntry);
+
+        LogEntryMetadataViewerController.LogEntryMetadata logEntryMetadata = LogEntryMetadataViewerController.getMetadata(
+            mockLogEntry.Id,
+            SOURCE_METADATA_EXCEPTION
+        );
+
+        System.Assert.areEqual(mockExceptionApexTrigger.Body, logEntryMetadata.Code);
+        System.Assert.isFalse(logEntryMetadata.HasCodeBeenModified);
+    }
+
+    @IsTest
     static void it_indicates_when_exception_source_metadata_has_been_modified_after_log_entry_timestamp() {
-        ApexClass mockExceptionApexClass = createMockApexClass('Some_Fake_Apex_Class');
+        Schema.ApexClass mockExceptionApexClass = createMockApexClass('Some_Fake_Apex_Class');
         System.Assert.isNotNull(mockExceptionApexClass.Name);
         MOCK_SELECTOR.setMockApexClass(mockExceptionApexClass);
         LogEntry__c mockLogEntry = createMockLogEntry(null, mockExceptionApexClass);
@@ -49,8 +68,8 @@ private class LogEntryMetadataViewerController_Tests {
     }
 
     @IsTest
-    static void it_returns_metadata_for_log_entry_when_source_metadata_is_origin() {
-        ApexClass mockOriginSourceApexClass = createMockApexClass('Some_Fake_Apex_Class');
+    static void it_returns_apex_class_metadata_for_log_entry_when_source_metadata_is_origin() {
+        Schema.ApexClass mockOriginSourceApexClass = createMockApexClass('Some_Fake_Apex_Class');
         System.Assert.isNotNull(mockOriginSourceApexClass.Name);
         MOCK_SELECTOR.setMockApexClass(mockOriginSourceApexClass);
         LogEntry__c mockLogEntry = createMockLogEntry(mockOriginSourceApexClass, null);
@@ -69,7 +88,7 @@ private class LogEntryMetadataViewerController_Tests {
 
     @IsTest
     static void it_indicates_when_origin_source_metadata_has_been_modified_after_log_entry_timestamp() {
-        ApexClass mockOriginSourceApexClass = createMockApexClass('Some_Fake_Apex_Class');
+        Schema.ApexClass mockOriginSourceApexClass = createMockApexClass('Some_Fake_Apex_Class');
         System.Assert.isNotNull(mockOriginSourceApexClass.Name);
         MOCK_SELECTOR.setMockApexClass(mockOriginSourceApexClass);
         LogEntry__c mockLogEntry = createMockLogEntry(mockOriginSourceApexClass, null);
@@ -97,6 +116,16 @@ private class LogEntryMetadataViewerController_Tests {
         return mockLogEntry;
     }
 
+    private static LogEntry__c createMockLogEntry(Schema.ApexTrigger originApexTrigger, Schema.ApexTrigger exceptionApexTrigger) {
+        LogEntry__c mockLogEntry = (LogEntry__c) LoggerMockDataCreator.createDataBuilder(Schema.LogEntry__c.SObjectType).populateRequiredFields().getRecord();
+        mockLogEntry.ExceptionSourceApiName__c = exceptionApexTrigger?.Name;
+        mockLogEntry.ExceptionSourceMetadataType__c = exceptionApexTrigger == null ? null : LoggerStackTrace.SourceMetadataType.ApexTrigger.name();
+        mockLogEntry.OriginSourceApiName__c = originApexTrigger?.Name;
+        mockLogEntry.OriginSourceMetadataType__c = originApexTrigger == null ? null : LoggerStackTrace.SourceMetadataType.ApexTrigger.name();
+        mockLogEntry.Timestamp__c = System.now();
+        return mockLogEntry;
+    }
+
     private static Schema.ApexClass createMockApexClass(String mockApexClassName) {
         Schema.ApexClass mockApexClass = new Schema.ApexClass(
             Body = 'Wow, look at this code for a mock version of apex class ' + mockApexClassName,
@@ -105,13 +134,26 @@ private class LogEntryMetadataViewerController_Tests {
         return (Schema.ApexClass) LoggerMockDataCreator.setReadOnlyField(mockApexClass, Schema.ApexClass.LastModifiedDate, System.now().addDays(-7));
     }
 
+    private static Schema.ApexTrigger createMockApexTrigger(String mockApexTriggerName) {
+        Schema.ApexTrigger mockApexTrigger = new Schema.ApexTrigger(
+            Body = 'Wow, look at this code for a mock version of apex trigger ' + mockApexTriggerName,
+            Name = mockApexTriggerName
+        );
+        return (Schema.ApexTrigger) LoggerMockDataCreator.setReadOnlyField(mockApexTrigger, Schema.ApexTrigger.LastModifiedDate, System.now().addDays(-7));
+    }
+
     // LogEntryMetadataViewerController uses a few queries via LogManagementDataSelector - this class mocks the query results
     private class MockLogManagementDataSelector extends LogManagementDataSelector {
         private Schema.ApexClass mockApexClass;
+        private Schema.ApexTrigger mockApexTrigger;
         private LogEntry__c mockLogEntry;
 
         public override List<Schema.ApexClass> getApexClasses(Set<String> apexClassNames) {
             return new List<Schema.ApexClass>{ this.mockApexClass };
+        }
+
+        public override List<Schema.ApexTrigger> getApexTriggers(Set<String> apexTriggerNames) {
+            return new List<Schema.ApexTrigger>{ this.mockApexTrigger };
         }
 
         public override LogEntry__c getLogEntryById(Id logEntryId) {
@@ -120,6 +162,10 @@ private class LogEntryMetadataViewerController_Tests {
 
         public void setMockApexClass(Schema.ApexClass apexClass) {
             this.mockApexClass = apexClass;
+        }
+
+        public void setMockApexTrigger(Schema.ApexTrigger apexTrigger) {
+            this.mockApexTrigger = apexTrigger;
         }
 
         public void setMockLogEntry(LogEntry__c logEntry) {

--- a/nebula-logger/extra-tests/tests/LogEntryMetadataViwrCtlr_Tests_Security.cls
+++ b/nebula-logger/extra-tests/tests/LogEntryMetadataViwrCtlr_Tests_Security.cls
@@ -1,0 +1,254 @@
+//------------------------------------------------------------------------------------------------//
+// This file is part of the Nebula Logger project, released under the MIT License.                //
+// See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    //
+//------------------------------------------------------------------------------------------------//
+
+// The class being tested - LogEntryMetadataViewerController - has a very long name
+// This test class name is slightly different from the typical naming convention used
+// in Nebula Logger, because the name would be too long 😭
+@SuppressWarnings('PMD.ApexDoc, PMD.MethodNamingConventions')
+@IsTest(IsParallel=false)
+private class LogEntryMetadataViwrCtlr_Tests_Security {
+    private static final String CAN_VIEW_LOG_ENTRY_METADATA_PERMISSION_NAME = 'CanViewLogEntryMetadata';
+    private static final MockLogManagementDataSelector MOCK_SELECTOR = new MockLogManagementDataSelector();
+    private static final Schema.Profile MINIMUM_ACCESS_PROFILE = [SELECT Id FROM Profile WHERE Name = 'Minimum Access - Salesforce'];
+
+    static {
+        LogManagementDataSelector.setMock(MOCK_SELECTOR);
+    }
+
+    @IsTest
+    static void it_should_return_queried_exception_metadata_when_custom_permission_is_assigned() {
+        Schema.User minimumAccessUser = LoggerMockDataCreator.createUser(MINIMUM_ACCESS_PROFILE.Id);
+        insert minimumAccessUser;
+        PermissionSet permissionSet = new PermissionSet(Name = 'CustomPermissionEnabled', Label = 'Custom Permisison Enabled');
+        insert permissionSet;
+        SetupEntityAccess setupEntityAccess = new SetupEntityAccess(
+            ParentId = permissionSet.Id,
+            SetupEntityId = [SELECT Id FROM CustomPermission WHERE DeveloperName = :CAN_VIEW_LOG_ENTRY_METADATA_PERMISSION_NAME]
+            .Id
+        );
+        PermissionSetAssignment permissionSetAssignment = new PermissionSetAssignment(AssigneeId = minimumAccessUser.Id, PermissionSetId = permissionSet.Id);
+        insert new List<SObject>{ setupEntityAccess, permissionSetAssignment };
+        String sourceMetadata = 'Exception';
+        Schema.ApexClass mockApexClass = new Schema.ApexClass(Body = 'hello, world', Name = 'SomeApexClassName');
+        MOCK_SELECTOR.setMockApexClass(mockApexClass);
+        LogEntry__c mockLogEntry = new LogEntry__c(
+            ExceptionSourceApiName__c = mockApexClass.Name,
+            ExceptionSourceMetadataType__c = 'ApexClass',
+            Id = LoggerMockDataCreator.createId(LogEntry__c.SObjectType)
+        );
+        MOCK_SELECTOR.setMockLogEntry(mockLogEntry);
+        LogEntryMetadataViewerController.LogEntryMetadata returnedMetadata;
+
+        System.runAs(minimumAccessUser) {
+            System.Assert.isFalse(Schema.ApexClass.SObjectType.getDescribe().isAccessible());
+            System.Assert.isTrue(System.FeatureManagement.checkPermission(CAN_VIEW_LOG_ENTRY_METADATA_PERMISSION_NAME));
+            returnedMetadata = LogEntryMetadataViewerController.getMetadata(mockLogEntry.Id, sourceMetadata);
+        }
+
+        System.Assert.areEqual(mockApexClass.Body, returnedMetadata.Code);
+    }
+
+    @IsTest
+    static void it_should_return_queried_origin_metadata_when_custom_permission_is_assigned() {
+        Schema.User minimumAccessUser = LoggerMockDataCreator.createUser(MINIMUM_ACCESS_PROFILE.Id);
+        insert minimumAccessUser;
+        PermissionSet permissionSet = new PermissionSet(Name = 'CustomPermissionEnabled', Label = 'Custom Permisison Enabled');
+        insert permissionSet;
+        SetupEntityAccess setupEntityAccess = new SetupEntityAccess(
+            ParentId = permissionSet.Id,
+            SetupEntityId = [SELECT Id FROM CustomPermission WHERE DeveloperName = :CAN_VIEW_LOG_ENTRY_METADATA_PERMISSION_NAME]
+            .Id
+        );
+        PermissionSetAssignment permissionSetAssignment = new PermissionSetAssignment(AssigneeId = minimumAccessUser.Id, PermissionSetId = permissionSet.Id);
+        insert new List<SObject>{ setupEntityAccess, permissionSetAssignment };
+        String sourceMetadata = 'Origin';
+        Schema.ApexClass mockApexClass = new Schema.ApexClass(Body = 'hello, world', Name = 'SomeApexClassName');
+        MOCK_SELECTOR.setMockApexClass(mockApexClass);
+        LogEntry__c mockLogEntry = new LogEntry__c(
+            Id = LoggerMockDataCreator.createId(LogEntry__c.SObjectType),
+            OriginSourceApiName__c = mockApexClass.Name,
+            OriginSourceMetadataType__c = 'ApexClass'
+        );
+        MOCK_SELECTOR.setMockLogEntry(mockLogEntry);
+        LogEntryMetadataViewerController.LogEntryMetadata returnedMetadata;
+
+        System.runAs(minimumAccessUser) {
+            System.Assert.isFalse(Schema.ApexClass.SObjectType.getDescribe().isAccessible());
+            System.Assert.isTrue(System.FeatureManagement.checkPermission(CAN_VIEW_LOG_ENTRY_METADATA_PERMISSION_NAME));
+            returnedMetadata = LogEntryMetadataViewerController.getMetadata(mockLogEntry.Id, sourceMetadata);
+        }
+
+        System.Assert.areEqual(mockApexClass.Body, returnedMetadata.Code);
+    }
+
+    @IsTest
+    static void it_should_not_return_queried_exception_metadata_when_custom_permission_is_not_assigned() {
+        Schema.User minimumAccessUser = LoggerMockDataCreator.createUser(MINIMUM_ACCESS_PROFILE.Id);
+        insert minimumAccessUser;
+        String sourceMetadata = 'Exception';
+        Schema.ApexClass mockApexClass = new Schema.ApexClass(Body = 'hello, world', Name = 'SomeApexClassName');
+        MOCK_SELECTOR.setMockApexClass(mockApexClass);
+        LogEntry__c mockLogEntry = new LogEntry__c(
+            ExceptionSourceApiName__c = mockApexClass.Name,
+            ExceptionSourceMetadataType__c = 'ApexClass',
+            Id = LoggerMockDataCreator.createId(LogEntry__c.SObjectType)
+        );
+        MOCK_SELECTOR.setMockLogEntry(mockLogEntry);
+        LogEntryMetadataViewerController.LogEntryMetadata returnedMetadata;
+
+        System.runAs(minimumAccessUser) {
+            System.Assert.isFalse(Schema.ApexClass.SObjectType.getDescribe().isAccessible());
+            System.Assert.isFalse(System.FeatureManagement.checkPermission(CAN_VIEW_LOG_ENTRY_METADATA_PERMISSION_NAME));
+            returnedMetadata = LogEntryMetadataViewerController.getMetadata(mockLogEntry.Id, sourceMetadata);
+        }
+
+        System.Assert.isNull(returnedMetadata.Code);
+    }
+
+    @IsTest
+    static void it_should_not_return_queried_origin_metadata_when_custom_permission_is_not_assigned() {
+        Schema.User minimumAccessUser = LoggerMockDataCreator.createUser(MINIMUM_ACCESS_PROFILE.Id);
+        insert minimumAccessUser;
+        String sourceMetadata = 'Origin';
+        Schema.ApexClass mockApexClass = new Schema.ApexClass(Body = 'hello, world', Name = 'SomeApexClassName');
+        MOCK_SELECTOR.setMockApexClass(mockApexClass);
+        LogEntry__c mockLogEntry = new LogEntry__c(
+            Id = LoggerMockDataCreator.createId(LogEntry__c.SObjectType),
+            OriginSourceApiName__c = mockApexClass.Name,
+            OriginSourceMetadataType__c = 'ApexClass'
+        );
+        MOCK_SELECTOR.setMockLogEntry(mockLogEntry);
+        LogEntryMetadataViewerController.LogEntryMetadata returnedMetadata;
+
+        System.runAs(minimumAccessUser) {
+            System.Assert.isFalse(Schema.ApexClass.SObjectType.getDescribe().isAccessible());
+            System.Assert.isFalse(System.FeatureManagement.checkPermission(CAN_VIEW_LOG_ENTRY_METADATA_PERMISSION_NAME));
+            returnedMetadata = LogEntryMetadataViewerController.getMetadata(mockLogEntry.Id, sourceMetadata);
+        }
+
+        System.Assert.isNull(returnedMetadata.Code);
+    }
+
+    @IsTest
+    static void it_should_return_queried_metadata_when_loggerAdmin_permission_set_is_assigned() {
+        Schema.User minimumAccessUser = LoggerMockDataCreator.createUser(MINIMUM_ACCESS_PROFILE.Id);
+        insert minimumAccessUser;
+        LoggerTestConfigurator.assignAdminPermissionSet(minimumAccessUser.Id);
+        String sourceMetadata = 'Exception';
+        Schema.ApexClass mockApexClass = new Schema.ApexClass(Body = 'hello, world', Name = 'SomeApexClassName');
+        MOCK_SELECTOR.setMockApexClass(mockApexClass);
+        LogEntry__c mockLogEntry = new LogEntry__c(
+            ExceptionSourceApiName__c = mockApexClass.Name,
+            ExceptionSourceMetadataType__c = 'ApexClass',
+            Id = LoggerMockDataCreator.createId(LogEntry__c.SObjectType)
+        );
+        MOCK_SELECTOR.setMockLogEntry(mockLogEntry);
+        LogEntryMetadataViewerController.LogEntryMetadata returnedMetadata;
+
+        System.runAs(minimumAccessUser) {
+            System.Assert.isFalse(Schema.ApexClass.SObjectType.getDescribe().isAccessible());
+            System.Assert.isTrue(System.FeatureManagement.checkPermission(CAN_VIEW_LOG_ENTRY_METADATA_PERMISSION_NAME));
+            returnedMetadata = LogEntryMetadataViewerController.getMetadata(mockLogEntry.Id, sourceMetadata);
+        }
+
+        System.Assert.areEqual(mockApexClass.Body, returnedMetadata.Code);
+    }
+
+    @IsTest
+    static void it_should_not_return_queried_origin_metadata_when_loggerLogViewer_permission_set_is_assigned() {
+        Schema.User minimumAccessUser = LoggerMockDataCreator.createUser(MINIMUM_ACCESS_PROFILE.Id);
+        insert minimumAccessUser;
+        LoggerTestConfigurator.assignLogViewerPermissionSet(minimumAccessUser.Id);
+        String sourceMetadata = 'Origin';
+        Schema.ApexClass mockApexClass = new Schema.ApexClass(Body = 'hello, world', Name = 'SomeApexClassName');
+        MOCK_SELECTOR.setMockApexClass(mockApexClass);
+        LogEntry__c mockLogEntry = new LogEntry__c(
+            Id = LoggerMockDataCreator.createId(LogEntry__c.SObjectType),
+            OriginSourceApiName__c = mockApexClass.Name,
+            OriginSourceMetadataType__c = 'ApexClass'
+        );
+        MOCK_SELECTOR.setMockLogEntry(mockLogEntry);
+        LogEntryMetadataViewerController.LogEntryMetadata returnedMetadata;
+
+        System.runAs(minimumAccessUser) {
+            System.Assert.isFalse(Schema.ApexClass.SObjectType.getDescribe().isAccessible());
+            System.Assert.isFalse(System.FeatureManagement.checkPermission(CAN_VIEW_LOG_ENTRY_METADATA_PERMISSION_NAME));
+            returnedMetadata = LogEntryMetadataViewerController.getMetadata(mockLogEntry.Id, sourceMetadata);
+        }
+
+        System.Assert.isNull(returnedMetadata.Code);
+    }
+
+    @IsTest
+    static void it_should_not_return_queried_origin_metadata_when_loggerEndUser_permission_set_is_assigned() {
+        Schema.User minimumAccessUser = LoggerMockDataCreator.createUser(MINIMUM_ACCESS_PROFILE.Id);
+        insert minimumAccessUser;
+        LoggerTestConfigurator.assignEndUserPermissionSet(minimumAccessUser.Id);
+        String sourceMetadata = 'Origin';
+        Schema.ApexClass mockApexClass = new Schema.ApexClass(Body = 'hello, world', Name = 'SomeApexClassName');
+        MOCK_SELECTOR.setMockApexClass(mockApexClass);
+        LogEntry__c mockLogEntry = new LogEntry__c(
+            Id = LoggerMockDataCreator.createId(LogEntry__c.SObjectType),
+            OriginSourceApiName__c = mockApexClass.Name,
+            OriginSourceMetadataType__c = 'ApexClass'
+        );
+        MOCK_SELECTOR.setMockLogEntry(mockLogEntry);
+        LogEntryMetadataViewerController.LogEntryMetadata returnedMetadata;
+
+        System.runAs(minimumAccessUser) {
+            System.Assert.isFalse(Schema.ApexClass.SObjectType.getDescribe().isAccessible());
+            System.Assert.isFalse(System.FeatureManagement.checkPermission(CAN_VIEW_LOG_ENTRY_METADATA_PERMISSION_NAME));
+            returnedMetadata = LogEntryMetadataViewerController.getMetadata(mockLogEntry.Id, sourceMetadata);
+        }
+
+        System.Assert.isNull(returnedMetadata.Code);
+    }
+
+    @IsTest
+    static void it_should_not_return_queried_origin_metadata_when_loggerLogCreator_permission_set_is_assigned() {
+        Schema.User minimumAccessUser = LoggerMockDataCreator.createUser(MINIMUM_ACCESS_PROFILE.Id);
+        insert minimumAccessUser;
+        LoggerTestConfigurator.assignLogCreatorPermissionSet(minimumAccessUser.Id);
+        String sourceMetadata = 'Origin';
+        Schema.ApexClass mockApexClass = new Schema.ApexClass(Body = 'hello, world', Name = 'SomeApexClassName');
+        MOCK_SELECTOR.setMockApexClass(mockApexClass);
+        LogEntry__c mockLogEntry = new LogEntry__c(
+            Id = LoggerMockDataCreator.createId(LogEntry__c.SObjectType),
+            OriginSourceApiName__c = mockApexClass.Name,
+            OriginSourceMetadataType__c = 'ApexClass'
+        );
+        MOCK_SELECTOR.setMockLogEntry(mockLogEntry);
+        LogEntryMetadataViewerController.LogEntryMetadata returnedMetadata;
+
+        System.runAs(minimumAccessUser) {
+            System.Assert.isFalse(Schema.ApexClass.SObjectType.getDescribe().isAccessible());
+            System.Assert.isFalse(System.FeatureManagement.checkPermission(CAN_VIEW_LOG_ENTRY_METADATA_PERMISSION_NAME));
+            returnedMetadata = LogEntryMetadataViewerController.getMetadata(mockLogEntry.Id, sourceMetadata);
+        }
+
+        System.Assert.isNull(returnedMetadata.Code);
+    }
+
+    private class MockLogManagementDataSelector extends LogManagementDataSelector {
+        private Schema.ApexClass mockApexClass;
+        private LogEntry__c mockLogEntry;
+
+        public override List<Schema.ApexClass> getApexClasses(Set<String> apexClassNames) {
+            return new List<Schema.ApexClass>{ this.mockApexClass };
+        }
+
+        public override LogEntry__c getLogEntryById(Id logEntryId) {
+            return this.mockLogEntry;
+        }
+
+        public void setMockApexClass(Schema.ApexClass apexClass) {
+            this.mockApexClass = apexClass;
+        }
+
+        public void setMockLogEntry(LogEntry__c logEntry) {
+            this.mockLogEntry = logEntry;
+        }
+    }
+}

--- a/nebula-logger/extra-tests/tests/LogEntryMetadataViwrCtlr_Tests_Security.cls-meta.xml
+++ b/nebula-logger/extra-tests/tests/LogEntryMetadataViwrCtlr_Tests_Security.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.13.5",
+    "version": "4.13.6",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -14,9 +14,9 @@
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
             "scopeProfiles": true,
-            "versionNumber": "4.13.5.NEXT",
-            "versionName": "Performance improvements",
-            "versionDescription": "Added LoggerBenchmarking_Tests and optimized Logger performance when creating large numbers of log entries",
+            "versionNumber": "4.13.6.NEXT",
+            "versionName": "View Log Entry Metadata Custom Permission",
+            "versionDescription": "Added new custom permission CanViewLogEntryMetadata so that users without query access to ApexClass and ApexTrigger can still see the source code in the LWC logEntryMetadataViewer",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -173,6 +173,7 @@
         "Nebula Logger - Core@4.13.3-optionally-enforce-scenario-usage": "04t5Y000001MkEwQAK",
         "Nebula Logger - Core@4.13.4-logger-parameter-comments": "04t5Y000001MkFBQA0",
         "Nebula Logger - Core@4.13.5-performance-improvements": "04t5Y000001MkGnQAK",
+        "Nebula Logger - Core@4.13.6-view-log-entry-metadata-custom-permission": "04t5Y000001MkGxQAK",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
- Added new custom permission `CanViewLogEntryMetadata` so that users without query access to `ApexClass` and `ApexTrigger` can still see the source code in the LWC `logEntryMetadataViewer`
- Updated the permission set `LoggerAdmin` to assign the new custom permission `CanViewLogEntryMetadata`
- Added some more test methods in `LogEntryMetadataViewerController_Tests`, and cleaned up some code in `LogEntryMetadataViewerController`