### PR TITLE
Fixed logEntryMetadataViewer 'View Full Source' button not showing for non-admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.13.7
+## Unlocked Package - v4.13.8
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkHRQA0)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkHRQA0)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.13.8
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkHRQA0)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkHRQA0)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkHbQAK)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkHbQAK)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001MkHRQA0`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001MkHbQAK`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001MkHRQA0`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001MkHbQAK`
 
 ---
 

--- a/nebula-logger/core/main/log-management/lwc/logEntryMetadataViewer/logEntryMetadataViewer.html
+++ b/nebula-logger/core/main/log-management/lwc/logEntryMetadataViewer/logEntryMetadataViewer.html
@@ -6,7 +6,7 @@
 <template>
     <template if:false={hasLoaded}>
         <div class="slds-is-relative" style="min-height: 6em">
-            <lightning-spinner variant="inverse"></lightning-spinner>
+            <lightning-spinner></lightning-spinner>
         </div>
     </template>
     <template if:true={hasLoaded}>

--- a/nebula-logger/core/main/log-management/lwc/logEntryMetadataViewer/logEntryMetadataViewer.js
+++ b/nebula-logger/core/main/log-management/lwc/logEntryMetadataViewer/logEntryMetadataViewer.js
@@ -33,6 +33,7 @@ export default class LogEntryMetadataViewer extends LightningElement {
     @api sourceMetadata;
 
     objectApiName = LOG_ENTRY_OBJECT;
+    hasLoaded = false;
     sourceSnippet;
 
     showFullSourceMetadataModal = false;
@@ -42,10 +43,6 @@ export default class LogEntryMetadataViewer extends LightningElement {
 
     _logEntry;
     _logEntryMetadata;
-
-    get hasLoaded() {
-        return !!this._logEntry && !!this._logEntryMetadata;
-    }
 
     get sectionTitle() {
         if (this.sourceMetadata === 'Exception') {
@@ -76,18 +73,6 @@ export default class LogEntryMetadataViewer extends LightningElement {
             : 'This Apex code has not been modified since this log entry was generated.';
     }
 
-    @wire(getMetadata, {
-        recordId: '$recordId',
-        sourceMetadata: '$sourceMetadata'
-    })
-    wiredGetLogEntryMetadata({ error, data }) {
-        if (data) {
-            this._logEntryMetadata = data;
-        } else if (error) {
-            this._logEntryMetadata = undefined;
-        }
-    }
-
     @wire(getRecord, {
         recordId: '$recordId',
         fields: LOG_ENTRY_FIELDS
@@ -110,6 +95,12 @@ export default class LogEntryMetadataViewer extends LightningElement {
             const sourceApiVersion = getFieldValue(this._logEntry, sourceApiVersionField);
             const sourceName = `${sourceApiName}.${sourceExtension} - ${sourceApiVersion}`;
             this.sourceSnippet = { ...JSON.parse(sourceSnippetJson), ...{ Title: sourceName } };
+
+            this.hasLoaded = true;
+            this._logEntryMetadata = await getMetadata({
+                recordId: this.recordId,
+                sourceMetadata: this.sourceMetadata
+            });
         }
     }
 

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -45,6 +45,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>LogEntryMetadataViewerController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>LogMassDeleteExtension</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -21,6 +21,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>LogEntryMetadataViewerController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>LogMassDeleteExtension</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -13,6 +13,10 @@
         <enabled>true</enabled>
     </classAccesses>
     <classAccesses>
+        <apexClass>LogEntryMetadataViewerController</apexClass>
+        <enabled>true</enabled>
+    </classAccesses>
+    <classAccesses>
         <apexClass>LogMassDeleteExtension</apexClass>
         <enabled>true</enabled>
     </classAccesses>

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.13.7';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.13.8';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
     private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 import FORM_FACTOR from '@salesforce/client/formFactor';
 
-const CURRENT_VERSION_NUMBER = 'v4.13.7';
+const CURRENT_VERSION_NUMBER = 'v4.13.8';
 
 // JavaScript equivalent to the Apex class ComponentLogger.ComponentLogEntry
 const ComponentLogEntry = class {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.13.7",
+    "version": "4.13.8",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -14,9 +14,9 @@
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
             "scopeProfiles": true,
-            "versionNumber": "4.13.7.NEXT",
-            "versionName": "Fixed function setScenario() in logger LWC",
-            "versionDescription": "Fixed an issue in the logger LWC's function setScenario() where the value was sometimes (often?) incorrectly set to null",
+            "versionNumber": "4.13.8.NEXT",
+            "versionName": "logEntryMetadataViewer LWC Bugfixes",
+            "versionDescription": "Fixed some additional issues in the logEntryMetadataViewer LWC that prevented the 'view full source' btn from showing up for non-admins",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -175,6 +175,7 @@
         "Nebula Logger - Core@4.13.5-performance-improvements": "04t5Y000001MkGnQAK",
         "Nebula Logger - Core@4.13.6-view-log-entry-metadata-custom-permission": "04t5Y000001MkGxQAK",
         "Nebula Logger - Core@4.13.7-fixed-function-setscenario()-in-logger-lwc": "04t5Y000001MkHRQA0",
+        "Nebula Logger - Core@4.13.8-logentrymetadataviewer-lwc-bugfixes": "04t5Y000001MkHbQAK",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
Worked with @jamessimone to troubleshoot & fix some additional issues in the `logEntryMetadataViewer` LWC that prevented the 'View Full Source' button from showing up for non-admins. This involved 3 related changes

1. Added explicit access in perm sets for the Apex class `LogEntryMetdataViewerController` to fix some perm issues, 
2. Fixed some whitespace in the LWC caused by a present-but-not-visible spinner, 
3. Updated the LWC to imperatively call controller methods - using the `@wire` annotation caused weird, silent failures when calling the Apex methods