### PR TITLE
Bugfix: session data is not populated when logging in LWC

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.13.10
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkHqQAK)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkHqQAK)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000027L04QAE)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000027L04QAE)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y000001MkHqQAK`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000027L04QAE`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y000001MkHqQAK`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000027L04QAE`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.13.9
+## Unlocked Package - v4.13.10
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkHqQAK)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y000001MkHqQAK)

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
@@ -182,6 +182,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
                 OrganizationType__c = logEntryEvent.OrganizationType__c,
                 OwnerId = this.determineLogOwnerId(logEntryEvent),
                 ParentLogTransactionId__c = logEntryEvent.ParentLogTransactionId__c,
+                ParentSessionId__c = logEntryEvent.ParentSessionId__c,
                 ProfileId__c = logEntryEvent.ProfileId__c,
                 ProfileName__c = logEntryEvent.ProfileName__c,
                 RequestId__c = logEntryEvent.RequestId__c,

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
@@ -614,6 +614,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
             log.LoginPlatform__c = matchingAuthSessionProxy.LoginHistory.Platform;
             log.LoginType__c = matchingAuthSessionProxy.LoginType;
             log.LogoutUrl__c = matchingAuthSessionProxy.LogoutUrl;
+            log.ParentSessionId__c = matchingAuthSessionProxy.ParentId;
             log.SessionId__c = matchingAuthSessionProxy.Id;
             log.SessionSecurityLevel__c = matchingAuthSessionProxy.SessionSecurityLevel;
             log.SessionType__c = matchingAuthSessionProxy.SessionType;

--- a/nebula-logger/core/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LogRecordPage.flexipage-meta.xml
@@ -622,6 +622,22 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
+                <fieldItem>Record.ParentSessionId__c</fieldItem>
+                <identifier>RecordParentSessionId_cField</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.ParentSessionId__c}</leftValue>
+                        <operator>NE</operator>
+                    </criteria>
+                </visibilityRule>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.SessionId__c</fieldItem>
                 <identifier>RecordSessionId__cField</identifier>
             </fieldInstance>

--- a/nebula-logger/core/main/log-management/objects/Log__c/fields/ParentSessionId__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/Log__c/fields/ParentSessionId__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ParentSessionId__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
+    <externalId>false</externalId>
+    <label>Parent Session ID</label>
+    <length>120</length>
+    <required>false</required>
+    <securityClassification>Confidential</securityClassification>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -1417,6 +1417,11 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Log__c.ParentSessionId__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Log__c.Priority__c</field>
         <readable>true</readable>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -929,6 +929,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.ParentSessionId__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.ProfileId__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -1338,6 +1338,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Log__c.ParentSessionId__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Log__c.Priority__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -869,6 +869,7 @@ global with sharing class LogEntryEventBuilder {
         logEntryEvent.LoginPlatform__c = CACHED_AUTH_SESSION_PROXY.LoginHistory.Platform;
         logEntryEvent.LoginType__c = CACHED_AUTH_SESSION_PROXY.LoginType;
         logEntryEvent.LogoutUrl__c = CACHED_AUTH_SESSION_PROXY.LogoutUrl;
+        logEntryEvent.ParentSessionId__c = CACHED_AUTH_SESSION_PROXY.ParentId;
         logEntryEvent.SessionId__c = CACHED_AUTH_SESSION_PROXY.Id;
         logEntryEvent.SessionSecurityLevel__c = CACHED_AUTH_SESSION_PROXY.SessionSecurityLevel;
         logEntryEvent.SessionType__c = CACHED_AUTH_SESSION_PROXY.SessionType;

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.13.9';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.13.10';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
     private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/classes/LoggerEngineDataSelector.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerEngineDataSelector.cls
@@ -50,12 +50,14 @@ public without sharing virtual class LoggerEngineDataSelector {
                 LoginHistory.Platform,
                 LoginHistory.UserId,
                 LogoutUrl,
+                ParentId,
                 SessionSecurityLevel,
                 SessionType,
                 SourceIp,
                 UsersId
             FROM AuthSession
-            WHERE UsersId IN :userIds AND IsCurrent = TRUE AND ParentId = NULL
+            WHERE UsersId IN :userIds AND IsCurrent = TRUE
+            ORDER BY ParentId NULLS FIRST
         ]) {
             LoggerSObjectProxy.AuthSession authSessionProxy = new LoggerSObjectProxy.AuthSession(authSession);
             userIdToAuthSessionProxy.put(authSessionProxy.UsersId, authSessionProxy);

--- a/nebula-logger/core/main/logger-engine/classes/LoggerSObjectProxy.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerSObjectProxy.cls
@@ -22,6 +22,7 @@ public without sharing class LoggerSObjectProxy {
         public Id LoginHistoryId;
         public LoginHistory LoginHistory;
         public String LogoutUrl;
+        public Id ParentId;
         public String SessionSecurityLevel;
         public String SessionType;
         public String SourceIp;
@@ -35,6 +36,7 @@ public without sharing class LoggerSObjectProxy {
                 this.LoginHistoryId = authSessionRecord.LoginHistoryId;
                 this.LoginType = authSessionRecord.LoginType;
                 this.LogoutUrl = authSessionRecord.LogoutUrl;
+                this.ParentId = authSessionRecord.ParentId;
                 this.SessionSecurityLevel = authSessionRecord.SessionSecurityLevel;
                 this.SessionType = authSessionRecord.SessionType;
                 this.SourceIp = authSessionRecord.SourceIp;

--- a/nebula-logger/core/main/logger-engine/classes/LoggerSObjectProxy.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerSObjectProxy.cls
@@ -9,6 +9,7 @@
  *              Each inner class maps to a corresponding `SObjectType` that is difficult to work with Apex for some reason or another,
  *              such as not being mockable or creatable, or not existing in all orgs.
  */
+@SuppressWarnings('PMD.ExcessivePublicCount')
 public without sharing class LoggerSObjectProxy {
     /**
      * @description All `Schema.AuthSession` SObjects are read-only in Apex, which makes them more difficult to work with, and impossible

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 import FORM_FACTOR from '@salesforce/client/formFactor';
 
-const CURRENT_VERSION_NUMBER = 'v4.13.9';
+const CURRENT_VERSION_NUMBER = 'v4.13.10';
 
 // JavaScript equivalent to the Apex class ComponentLogger.ComponentLogEntry
 const ComponentLogEntry = class {

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/ParentSessionId__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/ParentSessionId__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ParentSessionId__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Parent Session ID</label>
+    <length>120</length>
+    <required>false</required>
+    <securityClassification>Confidential</securityClassification>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -587,26 +587,43 @@ private class LogEntryEventHandler_Tests {
         logEntryEvent.SessionType__c = null;
         logEntryEvent.SourceIp__c = null;
         LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'QueryAuthSessionDataSynchronously', Value__c = String.valueOf(false)));
+        System.Assert.isFalse(LoggerParameter.QUERY_AUTH_SESSION_DATA_SYNCHRONOUSLY);
+        MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
+        LoggerEngineDataSelector.setMock(mockSelector);
+        LoggerSObjectProxy.LoginHistory mockLoginHistoryProxy = new LoggerSObjectProxy.LoginHistory(null);
+        mockLoginHistoryProxy.Application = 'Application';
+        mockLoginHistoryProxy.Browser = 'Browser';
+        mockLoginHistoryProxy.Platform = 'Platform';
+        mockLoginHistoryProxy.UserId = System.UserInfo.getUserId();
+        LoggerSObjectProxy.AuthSession mockAuthSessionProxy = new LoggerSObjectProxy.AuthSession(null);
+        mockAuthSessionProxy.Id = LoggerMockDataCreator.createId(Schema.AuthSession.SObjectType);
+        mockAuthSessionProxy.LoginHistory = mockLoginHistoryProxy;
+        mockAuthSessionProxy.LoginHistoryId = LoggerMockDataCreator.createId(Schema.LoginHistory.SObjectType);
+        mockAuthSessionProxy.LoginType = 'LoginType';
+        mockAuthSessionProxy.LogoutUrl = 'LogoutUrl';
+        mockAuthSessionProxy.ParentId = LoggerMockDataCreator.createId(Schema.AuthSession.SObjectType);
+        mockAuthSessionProxy.SessionSecurityLevel = 'SessionSecurityLevel';
+        mockAuthSessionProxy.SessionType = 'SessionType';
+        mockAuthSessionProxy.SourceIp = 'SourceIp';
+        mockAuthSessionProxy.UsersId = System.UserInfo.getUserId();
+        mockSelector.setCachedAuthSessionProxy(mockAuthSessionProxy);
+        System.Assert.areEqual(0, mockSelector.getCachedAuthSessionQueryCount());
 
         LoggerMockDataStore.getEventBus().publishRecord(logEntryEvent);
         LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
 
-        List<Id> userIds = new List<Id>{ logEntryEvent.LoggedById__c };
-        LoggerSObjectProxy.AuthSession expectedAuthSessionProxy = LoggerEngineDataSelector.getInstance()
-            .getAuthSessionProxies(userIds)
-            .get(logEntryEvent.LoggedById__c);
         Log__c log = getLog();
-        System.Assert.areEqual(expectedAuthSessionProxy?.LoginHistory.Application, log.LoginApplication__c);
-        System.Assert.areEqual(expectedAuthSessionProxy?.LoginHistory.Browser, log.LoginBrowser__c);
-        System.Assert.areEqual(expectedAuthSessionProxy?.LoginHistoryId, log.LoginHistoryId__c);
-        System.Assert.areEqual(expectedAuthSessionProxy?.LoginHistory.Platform, log.LoginPlatform__c);
-        System.Assert.areEqual(expectedAuthSessionProxy?.LoginType, log.LoginType__c);
-        System.Assert.areEqual(expectedAuthSessionProxy?.LogoutUrl, log.LogoutUrl__c);
-        System.Assert.areEqual(expectedAuthSessionProxy?.Id, log.SessionId__c);
-        System.Assert.areEqual(expectedAuthSessionProxy?.ParentId, log.ParentSessionId__c);
-        System.Assert.areEqual(expectedAuthSessionProxy?.SessionSecurityLevel, log.SessionSecurityLevel__c);
-        System.Assert.areEqual(expectedAuthSessionProxy?.SessionType, log.SessionType__c);
-        System.Assert.areEqual(expectedAuthSessionProxy?.SourceIp, log.SourceIp__c);
+        System.Assert.areEqual(mockAuthSessionProxy.Id, log.SessionId__c);
+        System.Assert.areEqual(mockAuthSessionProxy.LoginHistory.Application, log.LoginApplication__c);
+        System.Assert.areEqual(mockAuthSessionProxy.LoginHistory.Browser, log.LoginBrowser__c);
+        System.Assert.areEqual(mockAuthSessionProxy.LoginHistory.Platform, log.LoginPlatform__c);
+        System.Assert.areEqual(mockAuthSessionProxy.LoginHistoryId, log.LoginHistoryId__c);
+        System.Assert.areEqual(mockAuthSessionProxy.LoginType, log.LoginType__c);
+        System.Assert.areEqual(mockAuthSessionProxy.LogoutUrl, log.LogoutUrl__c);
+        System.Assert.areEqual(mockAuthSessionProxy.ParentId, log.ParentSessionId__c);
+        System.Assert.areEqual(mockAuthSessionProxy.SessionSecurityLevel, log.SessionSecurityLevel__c);
+        System.Assert.areEqual(mockAuthSessionProxy.SessionType, log.SessionType__c);
+        System.Assert.areEqual(mockAuthSessionProxy.SourceIp, log.SourceIp__c);
     }
 
     @IsTest
@@ -1792,5 +1809,26 @@ private class LogEntryEventHandler_Tests {
             'logEntry.TriggerOperationType__c was not properly set'
         );
         System.Assert.areEqual(logEntryEvent.TriggerSObjectType__c, logEntry.TriggerSObjectType__c, 'logEntry.TriggerSObjectType__c was not properly set');
+    }
+
+    private class MockLoggerEngineDataSelector extends LoggerEngineDataSelector {
+        private Integer authSessionProxiesQueryCount = 0;
+        private LoggerSObjectProxy.AuthSession mockAuthSessionProxy;
+
+        public Integer getCachedAuthSessionQueryCount() {
+            return authSessionProxiesQueryCount;
+        }
+
+        public override Map<Id, LoggerSObjectProxy.AuthSession> getAuthSessionProxies(List<Id> userIds) {
+            this.authSessionProxiesQueryCount++;
+            if (this.mockAuthSessionProxy != null) {
+                return new Map<Id, LoggerSObjectProxy.AuthSession>{ mockAuthSessionProxy.UsersId => mockAuthSessionProxy };
+            }
+            return super.getAuthSessionProxies(userIds);
+        }
+
+        public void setCachedAuthSessionProxy(LoggerSObjectProxy.AuthSession mockAuthSessionProxy) {
+            this.mockAuthSessionProxy = mockAuthSessionProxy;
+        }
     }
 }

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -581,6 +581,7 @@ private class LogEntryEventHandler_Tests {
         logEntryEvent.LoginPlatform__c = null;
         logEntryEvent.LoginType__c = null;
         logEntryEvent.LogoutUrl__c = null;
+        logEntryEvent.ParentSessionId__c = null;
         logEntryEvent.SessionId__c = null;
         logEntryEvent.SessionSecurityLevel__c = null;
         logEntryEvent.SessionType__c = null;
@@ -602,6 +603,7 @@ private class LogEntryEventHandler_Tests {
         System.Assert.areEqual(expectedAuthSessionProxy?.LoginType, log.LoginType__c);
         System.Assert.areEqual(expectedAuthSessionProxy?.LogoutUrl, log.LogoutUrl__c);
         System.Assert.areEqual(expectedAuthSessionProxy?.Id, log.SessionId__c);
+        System.Assert.areEqual(expectedAuthSessionProxy?.ParentId, log.ParentSessionId__c);
         System.Assert.areEqual(expectedAuthSessionProxy?.SessionSecurityLevel, log.SessionSecurityLevel__c);
         System.Assert.areEqual(expectedAuthSessionProxy?.SessionType, log.SessionType__c);
         System.Assert.areEqual(expectedAuthSessionProxy?.SourceIp, log.SourceIp__c);
@@ -1253,6 +1255,7 @@ private class LogEntryEventHandler_Tests {
                 OrganizationType__c,
                 OwnerId,
                 ParentLogTransactionId__c,
+                ParentSessionId__c,
                 ProfileId__c,
                 ProfileName__c,
                 RequestId__c,
@@ -1425,10 +1428,10 @@ private class LogEntryEventHandler_Tests {
         System.Assert.areEqual(logOwnerId, log.OwnerId, 'log.OwnerId was not properly set');
         System.Assert.areEqual(logEntryEvent.OrganizationApiVersion__c, log.OrganizationApiVersion__c, 'log.OrganizationApiVersion__c was not properly set');
         System.Assert.areEqual(logEntryEvent.ParentLogTransactionId__c, log.ParentLogTransactionId__c, 'log.ParentLogTransactionId__c was not properly set');
+        System.Assert.areEqual(logEntryEvent.ParentSessionId__c, log.ParentSessionId__c, 'log.ParentSessionId__c was not properly set');
         System.Assert.areEqual(logEntryEvent.ProfileId__c, log.ProfileId__c, 'log.ProfileId__c was not properly set');
         System.Assert.areEqual(logEntryEvent.ProfileName__c, log.ProfileName__c, 'log.ProfileName__c was not properly set');
         System.Assert.areEqual(logEntryEvent.RequestId__c, log.RequestId__c, 'log.RequestId__c was not properly set');
-        System.Assert.areEqual(logEntryEvent.SessionId__c, log.SessionId__c, 'log.SessionId__c was not properly set');
         System.Assert.areEqual(logEntryEvent.SessionId__c, log.SessionId__c, 'log.SessionId__c was not properly set');
         System.Assert.areEqual(logEntryEvent.SessionSecurityLevel__c, log.SessionSecurityLevel__c, 'log.SessionSecurityLevel__c was not properly set');
         System.Assert.areEqual(logEntryEvent.SessionType__c, log.SessionType__c, 'log.SessionType__c was not properly set');

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -202,6 +202,7 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isNull(logEntryEvent.LoginPlatform__c);
         System.Assert.isNull(logEntryEvent.LoginType__c);
         System.Assert.isNull(logEntryEvent.LogoutUrl__c);
+        System.Assert.isNull(logEntryEvent.ParentSessionId__c);
         System.Assert.isNull(logEntryEvent.SessionId__c);
         System.Assert.isNull(logEntryEvent.SessionSecurityLevel__c);
         System.Assert.isNull(logEntryEvent.SessionType__c);
@@ -214,6 +215,23 @@ private class LogEntryEventBuilder_Tests {
         System.Assert.isTrue(LoggerParameter.QUERY_AUTH_SESSION_DATA_SYNCHRONOUSLY);
         MockLoggerEngineDataSelector mockSelector = new MockLoggerEngineDataSelector();
         LoggerEngineDataSelector.setMock(mockSelector);
+        LoggerSObjectProxy.LoginHistory mockLoginHistoryProxy = new LoggerSObjectProxy.LoginHistory(null);
+        mockLoginHistoryProxy.Application = 'Application';
+        mockLoginHistoryProxy.Browser = 'Browser';
+        mockLoginHistoryProxy.Platform = 'Platform';
+        mockLoginHistoryProxy.UserId = System.UserInfo.getUserId();
+        LoggerSObjectProxy.AuthSession mockAuthSessionProxy = new LoggerSObjectProxy.AuthSession(null);
+        mockAuthSessionProxy.Id = LoggerMockDataCreator.createId(Schema.AuthSession.SObjectType);
+        mockAuthSessionProxy.LoginHistory = mockLoginHistoryProxy;
+        mockAuthSessionProxy.LoginHistoryId = LoggerMockDataCreator.createId(Schema.LoginHistory.SObjectType);
+        mockAuthSessionProxy.LoginType = 'LoginType';
+        mockAuthSessionProxy.LogoutUrl = 'LogoutUrl';
+        mockAuthSessionProxy.ParentId = LoggerMockDataCreator.createId(Schema.AuthSession.SObjectType);
+        mockAuthSessionProxy.SessionSecurityLevel = 'SessionSecurityLevel';
+        mockAuthSessionProxy.SessionType = 'SessionType';
+        mockAuthSessionProxy.SourceIp = 'SourceIp';
+        mockAuthSessionProxy.UsersId = System.UserInfo.getUserId();
+        mockSelector.setCachedAuthSessionProxy(mockAuthSessionProxy);
         System.Assert.areEqual(0, mockSelector.getCachedAuthSessionQueryCount());
 
         LogEntryEvent__e logEntryEvent = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true)
@@ -221,17 +239,17 @@ private class LogEntryEventBuilder_Tests {
             .getLogEntryEvent();
 
         System.Assert.areEqual(1, mockSelector.getCachedAuthSessionQueryCount());
-        LoggerSObjectProxy.AuthSession cachedAuthSession = LoggerEngineDataSelector.getInstance().getCachedAuthSessionProxy();
-        System.Assert.areEqual(cachedAuthSession?.LoginHistory.Application, logEntryEvent.LoginApplication__c);
-        System.Assert.areEqual(cachedAuthSession?.LoginHistory.Browser, logEntryEvent.LoginBrowser__c);
-        System.Assert.areEqual(cachedAuthSession?.LoginHistoryId, logEntryEvent.LoginHistoryId__c);
-        System.Assert.areEqual(cachedAuthSession?.LoginHistory.Platform, logEntryEvent.LoginPlatform__c);
-        System.Assert.areEqual(cachedAuthSession?.LoginType, logEntryEvent.LoginType__c);
-        System.Assert.areEqual(cachedAuthSession?.LogoutUrl, logEntryEvent.LogoutUrl__c);
-        System.Assert.areEqual(cachedAuthSession?.Id, logEntryEvent.SessionId__c);
-        System.Assert.areEqual(cachedAuthSession?.SessionSecurityLevel, logEntryEvent.SessionSecurityLevel__c);
-        System.Assert.areEqual(cachedAuthSession?.SessionType, logEntryEvent.SessionType__c);
-        System.Assert.areEqual(cachedAuthSession?.SourceIp, logEntryEvent.SourceIp__c);
+        System.Assert.areEqual(mockAuthSessionProxy.LoginHistory.Application, logEntryEvent.LoginApplication__c);
+        System.Assert.areEqual(mockAuthSessionProxy.LoginHistory.Browser, logEntryEvent.LoginBrowser__c);
+        System.Assert.areEqual(mockAuthSessionProxy.LoginHistory.Platform, logEntryEvent.LoginPlatform__c);
+        System.Assert.areEqual(mockAuthSessionProxy.LoginHistoryId, logEntryEvent.LoginHistoryId__c);
+        System.Assert.areEqual(mockAuthSessionProxy.LoginType, logEntryEvent.LoginType__c);
+        System.Assert.areEqual(mockAuthSessionProxy.LogoutUrl, logEntryEvent.LogoutUrl__c);
+        System.Assert.areEqual(mockAuthSessionProxy.ParentId, logEntryEvent.ParentSessionId__c);
+        System.Assert.areEqual(mockAuthSessionProxy.Id, logEntryEvent.SessionId__c);
+        System.Assert.areEqual(mockAuthSessionProxy.SessionSecurityLevel, logEntryEvent.SessionSecurityLevel__c);
+        System.Assert.areEqual(mockAuthSessionProxy.SessionType, logEntryEvent.SessionType__c);
+        System.Assert.areEqual(mockAuthSessionProxy.SourceIp, logEntryEvent.SourceIp__c);
     }
 
     @IsTest

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -1858,6 +1858,10 @@ private class LogEntryEventBuilder_Tests {
         private Integer cachedUserQueryCount = 0;
         private LoggerSObjectProxy.AuthSession mockAuthSessionProxy;
 
+        public Integer getCachedAuthSessionQueryCount() {
+            return cachedAuthSessionQueryCount;
+        }
+
         public override LoggerSObjectProxy.AuthSession getCachedAuthSessionProxy() {
             this.cachedAuthSessionQueryCount++;
             if (this.mockAuthSessionProxy != null) {
@@ -1868,10 +1872,6 @@ private class LogEntryEventBuilder_Tests {
 
         public void setCachedAuthSessionProxy(LoggerSObjectProxy.AuthSession mockAuthSessionProxy) {
             this.mockAuthSessionProxy = mockAuthSessionProxy;
-        }
-
-        public Integer getCachedAuthSessionQueryCount() {
-            return cachedAuthSessionQueryCount;
         }
 
         public override Schema.Organization getCachedOrganization() {

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerEngineDataSelector_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerEngineDataSelector_Tests.cls
@@ -27,11 +27,12 @@ private class LoggerEngineDataSelector_Tests {
                 LoginHistory.Browser,
                 LoginHistory.Platform,
                 LogoutUrl,
+                ParentId,
                 SessionSecurityLevel,
                 SessionType,
                 SourceIp
             FROM AuthSession
-            WHERE UsersId = :System.UserInfo.getUserId() AND IsCurrent = TRUE AND ParentId = NULL
+            WHERE UsersId = :System.UserInfo.getUserId() AND IsCurrent = TRUE
         ];
         LoggerSObjectProxy.AuthSession expectedAuthSessionProxy = sessions.isEmpty() ? null : new LoggerSObjectProxy.AuthSession(sessions.get(0));
         System.Assert.areEqual(1, System.Limits.getQueries());

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerSObjectProxy_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerSObjectProxy_Tests.cls
@@ -20,6 +20,7 @@ private class LoggerSObjectProxy_Tests {
                 LoginHistoryId,
                 LoginType,
                 LogoutUrl,
+                ParentId,
                 SessionSecurityLevel,
                 SessionType,
                 SourceIp,
@@ -37,13 +38,14 @@ private class LoggerSObjectProxy_Tests {
         LoggerSObjectProxy.AuthSession authSessionProxy = new LoggerSObjectProxy.AuthSession(authSessionRecord);
 
         System.Assert.areEqual(authSessionRecord.Id, authSessionProxy.Id);
-        System.Assert.areEqual(authSessionRecord.LoginType, authSessionProxy.LoginType);
-        System.Assert.areEqual(authSessionRecord.LoginHistoryId, authSessionProxy.LoginHistoryId);
         System.Assert.areEqual(authSessionRecord.LoginHistory.Application, authSessionProxy.LoginHistory.Application);
         System.Assert.areEqual(authSessionRecord.LoginHistory.Browser, authSessionProxy.LoginHistory.Browser);
         System.Assert.areEqual(authSessionRecord.LoginHistory.Platform, authSessionProxy.LoginHistory.Platform);
         System.Assert.areEqual(authSessionRecord.LoginHistory.UserId, authSessionProxy.LoginHistory.UserId);
+        System.Assert.areEqual(authSessionRecord.LoginHistoryId, authSessionProxy.LoginHistoryId);
+        System.Assert.areEqual(authSessionRecord.LoginType, authSessionProxy.LoginType);
         System.Assert.areEqual(authSessionRecord.LogoutUrl, authSessionProxy.LogoutUrl);
+        System.Assert.areEqual(authSessionRecord.ParentId, authSessionProxy.ParentId);
         System.Assert.areEqual(authSessionRecord.SessionSecurityLevel, authSessionProxy.SessionSecurityLevel);
         System.Assert.areEqual(authSessionRecord.SessionType, authSessionProxy.SessionType);
         System.Assert.areEqual(authSessionRecord.SourceIp, authSessionProxy.SourceIp);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.13.9",
+    "version": "4.13.10",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -177,6 +177,7 @@
         "Nebula Logger - Core@4.13.7-fixed-function-setscenario()-in-logger-lwc": "04t5Y000001MkHRQA0",
         "Nebula Logger - Core@4.13.8-logentrymetadataviewer-lwc-bugfixes": "04t5Y000001MkHbQAK",
         "Nebula Logger - Core@4.13.9-updated-logging-level-emojis": "04t5Y000001MkHqQAK",
+        "Nebula Logger - Core@4.13.10-authsession-bugfix-for-lwc-logging": "04t5Y0000027L04QAE",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -14,9 +14,9 @@
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
             "scopeProfiles": true,
-            "versionNumber": "4.13.9.NEXT",
-            "versionName": "Updated Logging Level Emojis",
-            "versionDescription": "Updated the formula field LogEntry__c.LoggingLevelWithImage__c to use different emojis for every logging level to make it easier to visually distinguish between them",
+            "versionNumber": "4.13.10.NEXT",
+            "versionName": "AuthSession Bugfix for LWC Logging",
+            "versionDescription": "Updated AuthSession query to not filter 'ParentId = null', added new ParentSessionId__c fields on LogEntryEvent__e and Log__c to capture parent session ID",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"


### PR DESCRIPTION
- Fixed #678 by removing the filter `ParentId = null` when querying `AuthSession` data in `LoggerEngineDataSelector`
- Added a small enhancement to store the `ParentId` of the `AuthSession` record in new fields `LogEntryEvent__e.ParentSessionId__c` and `Log__c.ParentSessionId__c`
- Updated FlexiPage `LogRecordPage` to display the new field `Log__c.ParentSessionId__c` when it's populated
- Updated permission sets `LoggerAdmin`, `LoggerLogViewer`, and `LoggerEndUser` to provide read access to the new field `Log__c.ParentSessionId__c`