### PR TITLE
chore: remove deprecated ApiVersion__c from slack fieldset

### DIFF
--- a/nebula-logger/plugins/slack/README.md
+++ b/nebula-logger/plugins/slack/README.md
@@ -2,8 +2,8 @@
 
 > :information_source: This plugin requires `v4.7.1` or newer of Nebula Logger's unlocked package
 
-[![Install Unlocked Package Plugin in a Sandbox](../.images/btn-install-unlocked-package-plugin-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015nDJQAY)
-[![Install Unlocked Package Plugin in Production](../.images/btn-install-unlocked-package-plugin-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015nDJQAY)
+[![Install Unlocked Package Plugin in a Sandbox](../.images/btn-install-unlocked-package-plugin-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oERQAY)
+[![Install Unlocked Package Plugin in Production](../.images/btn-install-unlocked-package-plugin-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oERQAY)
 
 Adds a Slack integration for the unlocked package edition of Nebula Logger. Any logs with log entries that meet a certain (configurable) logging level will automatically be posted to your Slack channel via an asynchronous `Queueable` job.
 

--- a/nebula-logger/plugins/slack/plugin/core/main/log-management/objects/Log__c/fieldSets/SlackLogNotificationFields.fieldSet-meta.xml
+++ b/nebula-logger/plugins/slack/plugin/core/main/log-management/objects/Log__c/fieldSets/SlackLogNotificationFields.fieldSet-meta.xml
@@ -3,11 +3,6 @@
     <fullName>SlackLogNotificationFields</fullName>
     <description>The default list of fields displayed in Slack notifications sent Nebula Logger's Slack plugin.</description>
     <displayedFields>
-        <field>ApiVersion__c</field>
-        <isFieldManaged>false</isFieldManaged>
-        <isRequired>false</isRequired>
-    </displayedFields>
-    <displayedFields>
         <field>TotalLimitsCpuTimeUsed__c</field>
         <isFieldManaged>false</isFieldManaged>
         <isRequired>false</isRequired>

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "plugin:version:create:big-object": "sf package version create --json --package \"Nebula Logger - Core Plugin - Big Object Archiving\" --skip-ancestor-check --code-coverage --installation-key-bypass --wait 30",
         "plugin:version:create:log-retention-rules": "sf package version create --json --package \"Nebula Logger - Core Plugin - Log Retention Rules\" --skip-ancestor-check --code-coverage --installation-key-bypass --wait 30",
         "plugin:version:create:logger-admin-dashboard": "sf package version create --json --package \"Nebula Logger - Core Plugin - Logger Admin Dashboard\" --skip-ancestor-check --code-coverage --installation-key-bypass --wait 30",
-        "plugin:version:create:slack": "sf package version create --json --package \"Nebula Logger - Core Plugin - Slack\" --skip-ancestor-check --code-coverage -k --wait 30",
+        "plugin:version:create:slack": "sf package version create --json --package \"Nebula Logger - Core Plugin - Slack\" --skip-ancestor-check --code-coverage --installation-key-bypass --wait 30",
         "prepare": "husky install && chmod +x ./.husky/pre-commit",
         "prettier:fix": "prettier --write \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",
         "prettier:verify": "prettier --list-different \"**/*.{cls,cmp,component,css,html,js,json,md,page,trigger,xml,yaml,yml}\"",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -27,8 +27,8 @@
                     "package": "Nebula Logger - Core@4.7.2-parent-log-transaction-id-bugfix"
                 }
             ],
-            "versionName": "Added logging for Screen Flow failures",
             "versionNumber": "1.0.2.NEXT",
+            "versionName": "Added logging for Screen Flow failures",
             "versionDescription": "Allows unhandled exceptions within screen flows to be automatically logged (toggleable, default off)"
         },
         {
@@ -39,8 +39,8 @@
                     "package": "Nebula Logger - Core@4.7.1-plugin-framework-overhaul"
                 }
             ],
-            "versionName": "Beta Release",
             "versionNumber": "0.9.0.NEXT",
+            "versionName": "Beta Release",
             "versionDescription": "Initial beta version of new plugin",
             "default": false
         },
@@ -52,8 +52,8 @@
                     "package": "Nebula Logger - Core@4.7.1-plugin-framework-overhaul"
                 }
             ],
-            "versionName": "Beta Release",
             "versionNumber": "0.9.0.NEXT",
+            "versionName": "Beta Release",
             "versionDescription": "Initial beta version of new plugin",
             "default": false
         },
@@ -65,9 +65,9 @@
                     "package": "Nebula Logger - Core@4.7.1-plugin-framework-overhaul"
                 }
             ],
-            "versionName": "Customizable Notification Fields",
-            "versionNumber": "1.5.2.NEXT",
-            "versionDescription": "Added support for customizing which Log__c fields are included in Slack notifications with a new field set, Log__c.SlackNotificationFields, and a new LoggerParameter__mdt record, LoggerParameter.SlackLogNotificationFields",
+            "versionNumber": "1.5.3.NEXT",
+            "versionName": "Removed ApiVersion__c in Field Set",
+            "versionDescription": "Removed the deprecated field Log__c.ApiVersion__c from the field set Log__c.SlackNotificationFields",
             "default": false
         },
         {
@@ -193,6 +193,8 @@
         "Nebula Logger - Core Plugin - Slack@0.9.2-beta-release-round-3": "04t5Y0000015l2WQAQ",
         "Nebula Logger - Core Plugin - Slack@0.10.0": "04t5Y0000015lgQQAQ",
         "Nebula Logger - Core Plugin - Slack@1.5.0": "04t5Y0000015lvVQAQ",
-        "Nebula Logger - Core Plugin - Slack@1.5.1": "04t5Y0000023Qu8QAE"
+        "Nebula Logger - Core Plugin - Slack@1.5.1": "04t5Y0000023Qu8QAE",
+        "Nebula Logger - Core Plugin - Slack@1.5.2": "04t5Y0000015nDJQAY",
+        "Nebula Logger - Core Plugin - Slack@1.5.3": "04t5Y0000015oERQAY"
     }
 }


### PR DESCRIPTION
I found out in my slack notification that this deprecated field is sent.

I propose to remove it from fieldset.