### PR TITLE
Deprecated & replaced BrowserUrl__c fields with new BrowserAddress__c fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.13.14
+## Unlocked Package - v4.13.15
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oE2QAI)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oE2QAI)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.13.15
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oE2QAI)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oE2QAI)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oF5QAI)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oF5QAI)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oE2QAI`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oF5QAI`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015oE2QAI`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015oF5QAI`
 
 ---
 

--- a/docs/apex/Logger-Engine/ComponentLogger.md
+++ b/docs/apex/Logger-Engine/ComponentLogger.md
@@ -85,6 +85,10 @@ A DTO object used to create log entries for lightning components
 
 ##### Properties
 
+###### `browserAddress` → `String`
+
+The URL displayed in the user&apos;s browser
+
 ###### `browserFormFactor` → `String`
 
 The form factor of the user&apos;s browser
@@ -99,7 +103,7 @@ The resolution of the user&apos;s device
 
 ###### `browserUrl` → `String`
 
-The URL displayed in the user&apos;s browser
+DEPRECATED: Use `browserAddress` instead
 
 ###### `browserUserAgent` → `String`
 

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
@@ -255,9 +255,11 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
             }
 
             LogEntry__c logEntry = new LogEntry__c(
+                BrowserAddress__c = logEntryEvent.BrowserAddress__c,
                 BrowserFormFactor__c = logEntryEvent.BrowserFormFactor__c,
                 BrowserLanguage__c = logEntryEvent.BrowserLanguage__c,
                 BrowserScreenResolution__c = logEntryEvent.BrowserScreenResolution__c,
+                // TODO BrowserUrl__c is deprecated (replaced by BrowserAddress__c), but keep setting BrowserUrl__c for now so people have time to migrate to referencing BrowserAddress__c
                 BrowserUrl__c = logEntryEvent.BrowserUrl__c,
                 BrowserUserAgent__c = logEntryEvent.BrowserUserAgent__c,
                 BrowserWindowResolution__c = logEntryEvent.BrowserWindowResolution__c,

--- a/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
@@ -2150,6 +2150,16 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
+                <fieldItem>Record.BrowserAddress__c</fieldItem>
+                <identifier>RecordBrowserAddress_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.BrowserLanguage__c</fieldItem>
                 <identifier>RecordBrowserLanguage_cField</identifier>
             </fieldInstance>

--- a/nebula-logger/core/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
+++ b/nebula-logger/core/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
@@ -129,29 +129,33 @@
         <label>Browser Information</label>
         <layoutColumns>
             <layoutItems>
-                <behavior>Edit</behavior>
+                <behavior>Readonly</behavior>
                 <field>BrowserUserAgent__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
+                <behavior>Readonly</behavior>
                 <field>BrowserUrl__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
+                <behavior>Readonly</behavior>
+                <field>BrowserAddress__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
                 <field>BrowserLanguage__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
-                <behavior>Edit</behavior>
+                <behavior>Readonly</behavior>
                 <field>BrowserFormFactor__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
+                <behavior>Readonly</behavior>
                 <field>BrowserScreenResolution__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
+                <behavior>Readonly</behavior>
                 <field>BrowserWindowResolution__c</field>
             </layoutItems>
         </layoutColumns>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/BrowserAddress__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/BrowserAddress__c.field-meta.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>BrowserWindowResolution__c</fullName>
+    <fullName>BrowserAddress__c</fullName>
     <businessStatus>Active</businessStatus>
     <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
-    <label>Browser Window Resolution</label>
-    <length>255</length>
-    <required>false</required>
+    <label>Browser Address</label>
+    <length>2000</length>
     <securityClassification>Confidential</securityClassification>
-    <trackFeedHistory>false</trackFeedHistory>
+    <trackFeedHistory>true</trackFeedHistory>
     <trackTrending>false</trackTrending>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
 </CustomField>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/BrowserFormFactor__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/BrowserFormFactor__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>BrowserFormFactor__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>None</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Browser Form Factor</label>
     <required>false</required>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/BrowserLanguage__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/BrowserLanguage__c.field-meta.xml
@@ -2,9 +2,12 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>BrowserLanguage__c</fullName>
     <externalId>false</externalId>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <label>Browser Language</label>
     <length>255</length>
     <required>false</required>
+    <securityClassification>Confidential</securityClassification>
     <trackFeedHistory>false</trackFeedHistory>
     <trackTrending>false</trackTrending>
     <type>Text</type>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/BrowserScreenResolution__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/BrowserScreenResolution__c.field-meta.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>BrowserScreenResolution__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Browser Screen Resolution</label>
     <length>255</length>
     <required>false</required>
+    <securityClassification>Confidential</securityClassification>
     <trackFeedHistory>false</trackFeedHistory>
     <trackTrending>false</trackTrending>
     <type>Text</type>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/BrowserUrl__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/BrowserUrl__c.field-meta.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>BrowserUrl__c</fullName>
+    <businessStatus>DeprecateCandidate</businessStatus>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
-    <label>Browser URL</label>
+    <inlineHelpText>Deprecated: instead use the field BrowserAddress__c</inlineHelpText>
+    <label>DEPRECATED: Browser URL</label>
     <required>false</required>
+    <securityClassification>Confidential</securityClassification>
     <trackFeedHistory>false</trackFeedHistory>
     <trackTrending>false</trackTrending>
     <type>Url</type>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/BrowserUserAgent__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/BrowserUserAgent__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>BrowserUserAgent__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>None</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <label>Browser User Agent</label>
     <length>255</length>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -183,6 +183,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.BrowserAddress__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.BrowserFormFactor__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -103,6 +103,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.BrowserAddress__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.BrowserFormFactor__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/logger-engine/classes/ComponentLogger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/ComponentLogger.cls
@@ -80,12 +80,23 @@ public inherited sharing class ComponentLogger {
     }
 
     private static void setBrowserDetails(LogEntryEvent__e logEntryEvent, ComponentLogEntry componentLogEntry) {
-        logEntryEvent.BrowserFormFactor__c = componentLogEntry.browserFormFactor;
-        logEntryEvent.BrowserLanguage__c = componentLogEntry.browserLanguage;
-        logEntryEvent.BrowserScreenResolution__c = componentLogEntry.browserScreenResolution;
-        logEntryEvent.BrowserUrl__c = componentLogEntry.browserUrl;
-        logEntryEvent.BrowserUserAgent__c = componentLogEntry.browserUserAgent;
-        logEntryEvent.BrowserWindowResolution__c = componentLogEntry.browserWindowResolution;
+        logEntryEvent.BrowserAddress__c = LoggerDataStore.truncateFieldValue(Schema.LogEntryEvent__e.BrowserAddress__c, componentLogEntry.browserAddress);
+        logEntryEvent.BrowserFormFactor__c = LoggerDataStore.truncateFieldValue(
+            Schema.LogEntryEvent__e.BrowserFormFactor__c,
+            componentLogEntry.browserFormFactor
+        );
+        logEntryEvent.BrowserLanguage__c = LoggerDataStore.truncateFieldValue(Schema.LogEntryEvent__e.BrowserLanguage__c, componentLogEntry.browserLanguage);
+        logEntryEvent.BrowserScreenResolution__c = LoggerDataStore.truncateFieldValue(
+            Schema.LogEntryEvent__e.BrowserScreenResolution__c,
+            componentLogEntry.browserScreenResolution
+        );
+        // TODO BrowserUrl__c is deprecated (replaced by BrowserAddress__c), but keep setting BrowserUrl__c for now so people have time to migrate to referencing BrowserAddress__c
+        logEntryEvent.BrowserUrl__c = LoggerDataStore.truncateFieldValue(Schema.LogEntryEvent__e.BrowserUrl__c, componentLogEntry.browserAddress);
+        logEntryEvent.BrowserUserAgent__c = LoggerDataStore.truncateFieldValue(Schema.LogEntryEvent__e.BrowserUserAgent__c, componentLogEntry.browserUserAgent);
+        logEntryEvent.BrowserWindowResolution__c = LoggerDataStore.truncateFieldValue(
+            Schema.LogEntryEvent__e.BrowserWindowResolution__c,
+            componentLogEntry.browserWindowResolution
+        );
     }
 
     private static void setComponentErrorDetails(LogEntryEvent__e logEntryEvent, ComponentError componentError) {
@@ -224,6 +235,12 @@ public inherited sharing class ComponentLogger {
      */
     public class ComponentLogEntry {
         /**
+         * @description The URL displayed in the user's browser
+         */
+        @AuraEnabled
+        public String browserAddress { get; set; }
+
+        /**
          * @description The form factor of the user's browser
          */
         @AuraEnabled
@@ -242,7 +259,7 @@ public inherited sharing class ComponentLogger {
         public String browserScreenResolution { get; set; }
 
         /**
-         * @description The URL displayed in the user's browser
+         * @description DEPRECATED: Use `browserAddress` instead
          */
         @AuraEnabled
         public String browserUrl { get; set; }

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.13.14';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.13.15';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
     private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/__tests__/logger.test.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/__tests__/logger.test.js
@@ -908,6 +908,7 @@ describe('logger lwc legacy markup tests', () => {
             .getComponentLogEntry();
 
         expect(logger.getBufferSize()).toEqual(0);
+        expect(logEntry.browserAddress).toEqual(window.location.href);
         expect(logEntry.browserFormFactor).toEqual(FORM_FACTOR);
         expect(logEntry.browserLanguage).toEqual(window.navigator.language);
         expect(logEntry.browserScreenResolution).toEqual(window.screen.availWidth + ' x ' + window.screen.availHeight);

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
@@ -8,9 +8,11 @@ const CURRENT_VERSION_NUMBER = 'v4.13.14';
 
 // JavaScript equivalent to the Apex class ComponentLogger.ComponentLogEntry
 const ComponentLogEntry = class {
+    browserAddress = null;
     browserFormFactor = null;
     browserLanguage = null;
     browserScreenResolution = null;
+    // TODO Deprecated, remove in a future release
     browserUrl = null;
     browserUserAgent = null;
     browserWindowResolution = null;
@@ -144,10 +146,12 @@ const LogEntryBuilder = class {
     }
 
     _setBrowserDetails() {
+        this.#componentLogEntry.browserAddress = window.location.href;
         this.#componentLogEntry.browserFormFactor = FORM_FACTOR;
         this.#componentLogEntry.browserLanguage = window.navigator.language;
         this.#componentLogEntry.browserScreenResolution = window.screen.availWidth + ' x ' + window.screen.availHeight;
-        this.#componentLogEntry.browserUrl = window.location.href;
+        // TODO Deprecated, remove in a future release
+        this.#componentLogEntry.browserUrl = this.#componentLogEntry.browserAddress;
         this.#componentLogEntry.browserUserAgent = window.navigator.userAgent;
         this.#componentLogEntry.browserWindowResolution = window.innerWidth + ' x ' + window.innerHeight;
     }

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 import FORM_FACTOR from '@salesforce/client/formFactor';
 
-const CURRENT_VERSION_NUMBER = 'v4.13.14';
+const CURRENT_VERSION_NUMBER = 'v4.13.15';
 
 // JavaScript equivalent to the Apex class ComponentLogger.ComponentLogEntry
 const ComponentLogEntry = class {

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/BrowserAddress__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/BrowserAddress__c.field-meta.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>BrowserFormFactor__c</fullName>
+    <fullName>BrowserAddress__c</fullName>
     <businessStatus>Active</businessStatus>
     <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>Browser Form Factor</label>
-    <length>255</length>
-    <required>false</required>
+    <label>Browser Address</label>
+    <length>2000</length>
     <securityClassification>Confidential</securityClassification>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
 </CustomField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/BrowserLanguage__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/BrowserLanguage__c.field-meta.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>BrowserLanguage__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
@@ -8,6 +10,7 @@
     <label>Browser Language</label>
     <length>255</length>
     <required>false</required>
+    <securityClassification>Confidential</securityClassification>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/BrowserScreenResolution__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/BrowserScreenResolution__c.field-meta.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>BrowserScreenResolution__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
@@ -8,6 +10,7 @@
     <label>Browser Screen Resolution</label>
     <length>255</length>
     <required>false</required>
+    <securityClassification>Confidential</securityClassification>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/BrowserUrl__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/BrowserUrl__c.field-meta.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>BrowserUrl__c</fullName>
+    <businessStatus>DeprecateCandidate</businessStatus>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>Browser URL</label>
+    <label>DEPRECATED: Browser URL</label>
     <length>255</length>
     <required>false</required>
+    <securityClassification>Confidential</securityClassification>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/BrowserUserAgent__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/BrowserUserAgent__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>BrowserUserAgent__c</fullName>
     <businessStatus>Active</businessStatus>
-    <complianceGroup>None</complianceGroup>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/BrowserWindowResolution__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/BrowserWindowResolution__c.field-meta.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>BrowserWindowResolution__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
@@ -8,6 +10,7 @@
     <label>Browser Window Resolution</label>
     <length>255</length>
     <required>false</required>
+    <securityClassification>Confidential</securityClassification>
     <type>Text</type>
     <unique>false</unique>
 </CustomField>

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -1303,6 +1303,7 @@ private class LogEntryEventHandler_Tests {
                 UserType__c,
                 (
                     SELECT
+                        BrowserAddress__c,
                         BrowserFormFactor__c,
                         BrowserLanguage__c,
                         BrowserScreenResolution__c,
@@ -1513,6 +1514,7 @@ private class LogEntryEventHandler_Tests {
     }
 
     private static void validateLogEntryFields(LogEntryEvent__e logEntryEvent, LogEntry__c logEntry) {
+        System.Assert.areEqual(logEntryEvent.BrowserAddress__c, logEntry.BrowserAddress__c, 'logEntry.BrowserAddress__c was not properly set');
         System.Assert.areEqual(logEntryEvent.BrowserFormFactor__c, logEntry.BrowserFormFactor__c, 'logEntry.BrowserFormFactor__c was not properly set');
         System.Assert.areEqual(logEntryEvent.BrowserLanguage__c, logEntry.BrowserLanguage__c, 'logEntry.BrowserLanguage__c was not properly set');
         System.Assert.areEqual(

--- a/nebula-logger/core/tests/logger-engine/classes/ComponentLogger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/ComponentLogger_Tests.cls
@@ -67,10 +67,11 @@ private class ComponentLogger_Tests {
             'Non-null value populated for OriginSourceMetadata__c: ' + System.JSON.serializePretty(publishedLogEntryEvent)
         );
         System.Assert.isNull(publishedLogEntryEvent.StackTrace__c);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserAddress__c);
         System.Assert.areEqual(componentLogEntry.browserFormFactor, publishedLogEntryEvent.BrowserFormFactor__c);
         System.Assert.areEqual(componentLogEntry.browserLanguage, publishedLogEntryEvent.BrowserLanguage__c);
         System.Assert.areEqual(componentLogEntry.browserScreenResolution, publishedLogEntryEvent.BrowserScreenResolution__c);
-        System.Assert.areEqual(componentLogEntry.browserUrl, publishedLogEntryEvent.BrowserUrl__c);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserUrl__c);
         System.Assert.areEqual(componentLogEntry.browserUserAgent, publishedLogEntryEvent.BrowserUserAgent__c);
         System.Assert.areEqual(componentLogEntry.browserWindowResolution, publishedLogEntryEvent.BrowserWindowResolution__c);
         System.Assert.areEqual(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
@@ -112,10 +113,11 @@ private class ComponentLogger_Tests {
         System.Assert.areEqual(expectedComponentType, publishedLogEntryEvent.ComponentType__c);
         System.Assert.areEqual(expectedComponentApiName + '.' + expectedComponentFunctionName, publishedLogEntryEvent.OriginLocation__c);
         System.Assert.areEqual(expectedSourceType, publishedLogEntryEvent.OriginSourceMetadataType__c);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserAddress__c);
         System.Assert.areEqual(componentLogEntry.browserFormFactor, publishedLogEntryEvent.BrowserFormFactor__c);
         System.Assert.areEqual(componentLogEntry.browserLanguage, publishedLogEntryEvent.BrowserLanguage__c);
         System.Assert.areEqual(componentLogEntry.browserScreenResolution, publishedLogEntryEvent.BrowserScreenResolution__c);
-        System.Assert.areEqual(componentLogEntry.browserUrl, publishedLogEntryEvent.BrowserUrl__c);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserUrl__c);
         System.Assert.areEqual(componentLogEntry.browserUserAgent, publishedLogEntryEvent.BrowserUserAgent__c);
         System.Assert.areEqual(componentLogEntry.browserWindowResolution, publishedLogEntryEvent.BrowserWindowResolution__c);
         System.Assert.areEqual(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
@@ -182,10 +184,11 @@ private class ComponentLogger_Tests {
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserAddress__c);
         System.Assert.areEqual(componentLogEntry.browserFormFactor, publishedLogEntryEvent.BrowserFormFactor__c);
         System.Assert.areEqual(componentLogEntry.browserLanguage, publishedLogEntryEvent.BrowserLanguage__c);
         System.Assert.areEqual(componentLogEntry.browserScreenResolution, publishedLogEntryEvent.BrowserScreenResolution__c);
-        System.Assert.areEqual(componentLogEntry.browserUrl, publishedLogEntryEvent.BrowserUrl__c);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserUrl__c);
         System.Assert.areEqual(componentLogEntry.browserUserAgent, publishedLogEntryEvent.BrowserUserAgent__c);
         System.Assert.areEqual(componentLogEntry.browserWindowResolution, publishedLogEntryEvent.BrowserWindowResolution__c);
         System.Assert.areEqual(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
@@ -227,10 +230,11 @@ private class ComponentLogger_Tests {
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserAddress__c);
         System.Assert.areEqual(componentLogEntry.browserFormFactor, publishedLogEntryEvent.BrowserFormFactor__c);
         System.Assert.areEqual(componentLogEntry.browserLanguage, publishedLogEntryEvent.BrowserLanguage__c);
         System.Assert.areEqual(componentLogEntry.browserScreenResolution, publishedLogEntryEvent.BrowserScreenResolution__c);
-        System.Assert.areEqual(componentLogEntry.browserUrl, publishedLogEntryEvent.BrowserUrl__c);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserUrl__c);
         System.Assert.areEqual(componentLogEntry.browserUserAgent, publishedLogEntryEvent.BrowserUserAgent__c);
         System.Assert.areEqual(componentLogEntry.browserWindowResolution, publishedLogEntryEvent.BrowserWindowResolution__c);
         System.Assert.areEqual(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
@@ -304,6 +308,57 @@ private class ComponentLogger_Tests {
     }
 
     @IsTest
+    static void it_should_truncate_long_browser_fields_when_publishing_to_the_event_bus() {
+        LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+        ComponentLogger.ComponentLogEntry componentLogEntry = createMockComponentLogEntry();
+        componentLogEntry.browserAddress = 'A'.repeat(Schema.LogEntryEvent__e.BrowserAddress__c.getDescribe().getLength() + 1);
+        componentLogEntry.browserFormFactor = 'B'.repeat(Schema.LogEntryEvent__e.BrowserFormFactor__c.getDescribe().getLength() + 1);
+        componentLogEntry.browserLanguage = 'C'.repeat(Schema.LogEntryEvent__e.BrowserLanguage__c.getDescribe().getLength() + 1);
+        componentLogEntry.browserScreenResolution = 'D'.repeat(Schema.LogEntryEvent__e.BrowserScreenResolution__c.getDescribe().getLength() + 1);
+        componentLogEntry.browserUrl = 'E'.repeat(Schema.LogEntryEvent__e.BrowserUrl__c.getDescribe().getLength() + 1);
+        componentLogEntry.browserUserAgent = 'F'.repeat(Schema.LogEntryEvent__e.BrowserUserAgent__c.getDescribe().getLength() + 1);
+        componentLogEntry.browserWindowResolution = 'G'.repeat(Schema.LogEntryEvent__e.BrowserWindowResolution__c.getDescribe().getLength() + 1);
+        System.Assert.areEqual(0, Logger.saveLogCallCount);
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+
+        ComponentLogger.saveComponentLogEntries(new List<ComponentLogger.ComponentLogEntry>{ componentLogEntry }, null);
+
+        System.Assert.areEqual(1, Logger.saveLogCallCount);
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+        System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+        LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
+        System.Assert.areEqual(
+            componentLogEntry.browserAddress.left(Schema.LogEntryEvent__e.BrowserAddress__c.getDescribe().getLength()),
+            publishedLogEntryEvent.BrowserAddress__c
+        );
+        System.Assert.areEqual(
+            componentLogEntry.browserFormFactor.left(Schema.LogEntryEvent__e.BrowserFormFactor__c.getDescribe().getLength()),
+            publishedLogEntryEvent.BrowserFormFactor__c
+        );
+        System.Assert.areEqual(
+            componentLogEntry.browserLanguage.left(Schema.LogEntryEvent__e.BrowserLanguage__c.getDescribe().getLength()),
+            publishedLogEntryEvent.BrowserLanguage__c
+        );
+        System.Assert.areEqual(
+            componentLogEntry.browserScreenResolution.left(Schema.LogEntryEvent__e.BrowserScreenResolution__c.getDescribe().getLength()),
+            publishedLogEntryEvent.BrowserScreenResolution__c
+        );
+        System.Assert.areEqual(
+            componentLogEntry.browserAddress.left(Schema.LogEntryEvent__e.BrowserUrl__c.getDescribe().getLength()),
+            publishedLogEntryEvent.BrowserUrl__c
+        );
+        System.Assert.areEqual(
+            componentLogEntry.browserUserAgent.left(Schema.LogEntryEvent__e.BrowserUserAgent__c.getDescribe().getLength()),
+            publishedLogEntryEvent.BrowserUserAgent__c
+        );
+        System.Assert.areEqual(
+            componentLogEntry.browserWindowResolution.left(Schema.LogEntryEvent__e.BrowserWindowResolution__c.getDescribe().getLength()),
+            publishedLogEntryEvent.BrowserWindowResolution__c
+        );
+    }
+
+    @IsTest
     static void it_should_set_logger_scenario() {
         LoggerStackTrace.ignoreOrigin(ComponentLogger_Tests.class);
         LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
@@ -344,10 +399,11 @@ private class ComponentLogger_Tests {
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserAddress__c);
         System.Assert.areEqual(componentLogEntry.browserFormFactor, publishedLogEntryEvent.BrowserFormFactor__c);
         System.Assert.areEqual(componentLogEntry.browserLanguage, publishedLogEntryEvent.BrowserLanguage__c);
         System.Assert.areEqual(componentLogEntry.browserScreenResolution, publishedLogEntryEvent.BrowserScreenResolution__c);
-        System.Assert.areEqual(componentLogEntry.browserUrl, publishedLogEntryEvent.BrowserUrl__c);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserUrl__c);
         System.Assert.areEqual(componentLogEntry.browserUserAgent, publishedLogEntryEvent.BrowserUserAgent__c);
         System.Assert.areEqual(componentLogEntry.browserWindowResolution, publishedLogEntryEvent.BrowserWindowResolution__c);
         System.Assert.areEqual(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
@@ -381,10 +437,11 @@ private class ComponentLogger_Tests {
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserAddress__c);
         System.Assert.areEqual(componentLogEntry.browserFormFactor, publishedLogEntryEvent.BrowserFormFactor__c);
         System.Assert.areEqual(componentLogEntry.browserLanguage, publishedLogEntryEvent.BrowserLanguage__c);
         System.Assert.areEqual(componentLogEntry.browserScreenResolution, publishedLogEntryEvent.BrowserScreenResolution__c);
-        System.Assert.areEqual(componentLogEntry.browserUrl, publishedLogEntryEvent.BrowserUrl__c);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserUrl__c);
         System.Assert.areEqual(componentLogEntry.browserUserAgent, publishedLogEntryEvent.BrowserUserAgent__c);
         System.Assert.areEqual(componentLogEntry.browserWindowResolution, publishedLogEntryEvent.BrowserWindowResolution__c);
         System.Assert.areEqual(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
@@ -418,10 +475,11 @@ private class ComponentLogger_Tests {
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
         System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
         LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserAddress__c);
         System.Assert.areEqual(componentLogEntry.browserFormFactor, publishedLogEntryEvent.BrowserFormFactor__c);
         System.Assert.areEqual(componentLogEntry.browserLanguage, publishedLogEntryEvent.BrowserLanguage__c);
         System.Assert.areEqual(componentLogEntry.browserScreenResolution, publishedLogEntryEvent.BrowserScreenResolution__c);
-        System.Assert.areEqual(componentLogEntry.browserUrl, publishedLogEntryEvent.BrowserUrl__c);
+        System.Assert.areEqual(componentLogEntry.browserAddress, publishedLogEntryEvent.BrowserUrl__c);
         System.Assert.areEqual(componentLogEntry.browserUserAgent, publishedLogEntryEvent.BrowserUserAgent__c);
         System.Assert.areEqual(componentLogEntry.browserWindowResolution, publishedLogEntryEvent.BrowserWindowResolution__c);
         System.Assert.areEqual(componentLogEntry.loggingLevel, publishedLogEntryEvent.LoggingLevel__c);
@@ -442,10 +500,10 @@ private class ComponentLogger_Tests {
             ProfileId = System.UserInfo.getProfileId()
         );
         ComponentLogger.ComponentLogEntry componentLogEntry = new ComponentLogger.ComponentLogEntry();
+        componentLogEntry.browserAddress = 'https://flow-ruby-5228.scratch.lightning.force.com/lightning/n/Logger_lwc_demo?c__asdfsdf=asdf';
         componentLogEntry.browserFormFactor = 'Large';
         componentLogEntry.browserLanguage = 'en-US';
         componentLogEntry.browserScreenResolution = '1536 x 824';
-        componentLogEntry.browserUrl = 'https://flow-ruby-5228.scratch.lightning.force.com/lightning/n/Logger_lwc_demo?c__asdfsdf=asdf';
         componentLogEntry.browserUserAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/113.0';
         componentLogEntry.browserWindowResolution = '1536 x 474';
         componentLogEntry.loggingLevel = System.LoggingLevel.INFO.name();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.13.14",
+    "version": "4.13.15",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
             "scopeProfiles": true,
-            "versionNumber": "4.13.14.NEXT",
-            "versionName": "Custom Field Mappings Support",
-            "versionDescription": "Added the ability to set & map custom fields, using new instance method overloads LogEntryEventBuilder.setField(), and a new CMDT LoggerFieldMapping__mdt",
+            "versionNumber": "4.13.15.NEXT",
+            "versionName": "Replaced BrowserUrl__c with BrowserAddress__c",
+            "versionDescription": "Deprecated the BrowserUrl__c fields on LogEntryEvent__e and LogEntry__c, and replaced them with new BrowserAddress__c that have a much longer max length (2,000 vs 255)",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -177,6 +177,7 @@
         "Nebula Logger - Core@4.13.12-added-refresh-button-on-relatedlogentries-lwc": "04t5Y0000015oCkQAI",
         "Nebula Logger - Core@4.13.13-improved-fully-qualified-references": "04t5Y0000015oDsQAI",
         "Nebula Logger - Core@4.13.14-custom-field-mappings-support": "04t5Y0000015oE2QAI",
+        "Nebula Logger - Core@4.13.15-replaced-browserurl__c-with-browseraddress__c": "04t5Y0000015oF5QAI",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
Fixed #696 by making a couple of changes to how the browser's address is captured when logging in lightning components
- Updated the Apex class `ComponentLogger` to auto-truncate JS browser fields (including `LogEntryEvent__c.BrowserUrl__c`)
  - The `public` property `ComponentLogger.ComponentLogEntry.browserUrl` is now deprecated & will be deleted in a future release. It's only intended to be used internally by Nebula Logger, so this hopefully doesn't impact anyone - but mentioning it here, just in case 😉 
- Replaced the text (255) fields `BrowserUrl__c` on `LogEntryEvent__e` and `LogEntry__c` with new long textarea (2000) fields `BrowserAddress__c`
  - The existing `BrowserUrl__c` fields are too short to store some long URLs (such as URLs with a lot of parameters), and the existing fields can't be converted from text(255) to long text area fields, so new fields are needed
  - The existing `BrowserUrl__c` fields will still be populated for foreseeable future (with a truncated value), but they are now considered deprecated - any references in reports, list views, queries, etc. should be updated to use the new `BrowserAddress__c` fields
- Documentation: added missing [data classification metadata](https://help.salesforce.com/s/articleView?id=sf.data_classification_metadata_fields.htm&type=5) to several existing browser fields on `LogEntryEvent__e` and `LogEntry__c`
  - This doesn't impact any functionality, it's just for documentation purposes
