### PR TITLE
Bugfixes for Scenario Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust logger for Salesforce. Works with Apex, Lightning Components, Fl
 
 ## Unlocked Package - v4.13.16
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oF5QAI)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oF5QAI)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oFjQAI)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oFjQAI)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oF5QAI`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oFjQAI`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015oF5QAI`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015oFjQAI`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.
 
-## Unlocked Package - v4.13.15
+## Unlocked Package - v4.13.16
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oF5QAI)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oF5QAI)

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
@@ -78,14 +78,18 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
                     platformEventStorageLocation = scenarioRule.PlatformEventStorageLocation__c;
                 }
             }
-            // Filter first based on storage logging location
-            if (platformEventStorageLocation == DEFAULT_STORAGE_LOCATION_NAME) {
-                // Then filter further based on storage logging level
-                String userStorageLoggingLevelName = loggingUserSettings.DefaultPlatformEventStorageLoggingLevel__c;
-                if (String.isBlank(userStorageLoggingLevelName)) {
-                    userStorageLoggingLevelName = loggingUserSettings.LoggingLevel__c;
-                }
-                System.LoggingLevel userStorageLoggingLevel = System.LoggingLevel.valueOf(userStorageLoggingLevelName);
+
+            if (platformEventStorageLocation != DEFAULT_STORAGE_LOCATION_NAME) {
+                // For any other storage location (besides CUSTOM_OBJECTS), it's assumed that a plugin will be handling everything,
+                // so there's nothing else to do here
+                continue;
+            }
+
+            if (String.isBlank(loggingUserSettings.DefaultPlatformEventStorageLoggingLevel__c)) {
+                // DefaultPlatformEventStorageLoggingLevel__c is optional - if it's null, then always save the event
+                logEntryEventsToSave.add(logEntryEvent);
+            } else {
+                System.LoggingLevel userStorageLoggingLevel = System.LoggingLevel.valueOf(loggingUserSettings.DefaultPlatformEventStorageLoggingLevel__c);
                 System.LoggingLevel entryLoggingLevel = System.LoggingLevel.valueOf(logEntryEvent.LoggingLevel__c);
                 if (userStorageLoggingLevel.ordinal() <= entryLoggingLevel.ordinal()) {
                     logEntryEventsToSave.add(logEntryEvent);

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -27,6 +27,7 @@ global with sharing class Logger {
 
     private static AsyncContext currentAsyncContext;
     private static String currentEntryScenario;
+    private static LoggerSettings__c currentUserSettings;
     @TestVisible
     private static String lastSaveMethodNameUsed;
     private static List<String> orderedScenarios = new List<String>();
@@ -35,7 +36,6 @@ global with sharing class Logger {
     private static Integer saveLogCallCount = 0;
     private static Boolean suspendSaving = false;
     private static String transactionScenario;
-    private static LoggerSettings__c userSettings;
 
     private static final List<String> CLASSES_TO_IGNORE {
         get {
@@ -347,11 +347,11 @@ global with sharing class Logger {
      */
     public static LoggerSettings__c getUserSettings() {
         // Only load the current user's settings once - this allows the instance to be modified in memory (as well as upserted if any changes should be persisted)
-        if (userSettings == null) {
+        if (currentUserSettings == null) {
             Schema.User currentUser = new Schema.User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
-            userSettings = getUserSettings(currentUser);
+            currentUserSettings = getUserSettings(currentUser);
         }
-        return userSettings;
+        return currentUserSettings;
     }
 
     /**
@@ -3088,6 +3088,8 @@ global with sharing class Logger {
         }
         LoggerScenarioRule__mdt matchingScenarioRule = LoggerScenarioRule.getInstance(scenario);
         if (matchingScenarioRule != null) {
+            // Clear & reload the user's settings so that there aren't any lingering changes made by previous scenario rules
+            currentUserSettings = null;
             LoggerSettings__c userSettings = getUserSettings();
             if (String.isNotBlank(matchingScenarioRule.IsLoggerEnabled__c)) {
                 userSettings.IsEnabled__c = Boolean.valueOf(matchingScenarioRule.IsLoggerEnabled__c);
@@ -3138,6 +3140,9 @@ global with sharing class Logger {
         }
         if (String.isBlank(previousScenario)) {
             currentEntryScenario = null;
+            // Clear & reload the user's settings so that there aren't any lingering changes made by previous scenario rules
+            // The settings will then be auto-reloaded when setScenario(previousScenario) is called below
+            currentUserSettings = null;
         }
 
         setScenario(previousScenario);

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
     // There's no reliable way to get the version number dynamically in Apex
     @TestVisible
-    private static final String CURRENT_VERSION_NUMBER = 'v4.13.15';
+    private static final String CURRENT_VERSION_NUMBER = 'v4.13.16';
     private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
     private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
     private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 import FORM_FACTOR from '@salesforce/client/formFactor';
 
-const CURRENT_VERSION_NUMBER = 'v4.13.15';
+const CURRENT_VERSION_NUMBER = 'v4.13.16';
 
 // JavaScript equivalent to the Apex class ComponentLogger.ComponentLogEntry
 const ComponentLogEntry = class {

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -6,6 +6,10 @@
 @SuppressWarnings('PMD.ApexDoc, PMD.CyclomaticComplexity, PMD.ExcessiveParameterList, PMD.MethodNamingConventions, PMD.NcssMethodCount, PMD.NcssTypeCount')
 @IsTest(IsParallel=false)
 private class LogEntryEventHandler_Tests {
+    private static final String MOCK_TRANSACTION_ID = System.UUID.randomUUID().toString();
+
+    private static Integer currentLogEntryNumber = 1;
+
     @IsTest
     static void it_should_return_the_logEntryEvent_sobjectType() {
         System.Assert.areEqual(Schema.LogEntryEvent__e.SObjectType, new LogEntryEventHandler().getSObjectType());
@@ -97,6 +101,60 @@ private class LogEntryEventHandler_Tests {
         System.Assert.areEqual(1, logEntries.size(), System.JSON.serializePretty(logEntries));
         System.Assert.areEqual(matchingLogEntryEvent.LoggingLevel__c, logEntries.get(0).LoggingLevel__c);
         System.Assert.areEqual(matchingLogEntryEvent.Message__c, logEntries.get(0).Message__c);
+    }
+
+    @IsTest
+    static void it_should_create_log_entry_data_with_matching_scenario_rule_when_platform_event_storage_logging_level_is_null() {
+        LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+        LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
+        LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
+        LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
+        System.Assert.areEqual(0, [SELECT COUNT() FROM Log__c]);
+        System.Assert.areEqual(0, [SELECT COUNT() FROM LogEntry__c]);
+        LoggerSettings__c settings = Logger.getUserSettings();
+        settings.LoggingLevel__c = System.LoggingLevel.WARN.name();
+        settings.DefaultPlatformEventStorageLocation__c = 'CUSTOM_OBJECTS';
+        settings.DefaultPlatformEventStorageLoggingLevel__c = null;
+        upsert settings;
+        String someScenario = 'some scenario with a configured rule';
+        LoggerScenarioRule.setMock(new LoggerScenarioRule__mdt(IsEnabled__c = true, Scenario__c = someScenario));
+        LogEntryEvent__e firstMatchingLogEntryEvent = createLogEntryEvent();
+        firstMatchingLogEntryEvent.LoggingLevel__c = System.LoggingLevel.ERROR.name();
+        firstMatchingLogEntryEvent.Message__c = 'This event should be saved in LogEntry__c';
+        firstMatchingLogEntryEvent.TransactionScenario__c = someScenario;
+        LogEntryEvent__e secondMatchingLogEntryEvent = createLogEntryEvent();
+        secondMatchingLogEntryEvent.LoggingLevel__c = System.LoggingLevel.FINEST.name();
+        secondMatchingLogEntryEvent.Message__c = 'This event should ALSO be saved in LogEntry__c';
+        secondMatchingLogEntryEvent.TransactionScenario__c = someScenario;
+        List<LogEntryEvent__e> logEntryEvents = new List<LogEntryEvent__e>{ firstMatchingLogEntryEvent, secondMatchingLogEntryEvent };
+
+        List<Database.SaveResult> saveResults = LoggerMockDataStore.getEventBus().publishRecords(logEntryEvents);
+        LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
+
+        System.Assert.areEqual(logEntryEvents.size(), saveResults.size());
+        for (Database.SaveResult saveResult : saveResults) {
+            System.Assert.isTrue(saveResult.isSuccess(), saveResult.getErrors().toString());
+        }
+        System.Assert.areEqual(
+            1,
+            LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
+            'Handler class should have executed one time for AFTER_INSERT'
+        );
+        System.Assert.areEqual(1, [SELECT COUNT() FROM Log__c]);
+        LogEntry__c firstMatchingLogEntry = [
+            SELECT Id, LoggingLevel__c, Message__c
+            FROM LogEntry__c
+            WHERE LoggingLevel__c = :firstMatchingLogEntryEvent.LoggingLevel__c
+        ];
+        System.Assert.areEqual(firstMatchingLogEntryEvent.LoggingLevel__c, firstMatchingLogEntry.LoggingLevel__c);
+        System.Assert.areEqual(firstMatchingLogEntryEvent.Message__c, firstMatchingLogEntry.Message__c);
+        LogEntry__c secondMatchingLogEntry = [
+            SELECT Id, LoggingLevel__c, Message__c
+            FROM LogEntry__c
+            WHERE LoggingLevel__c = :secondMatchingLogEntryEvent.LoggingLevel__c
+        ];
+        System.Assert.areEqual(secondMatchingLogEntryEvent.LoggingLevel__c, secondMatchingLogEntry.LoggingLevel__c);
+        System.Assert.areEqual(secondMatchingLogEntryEvent.Message__c, secondMatchingLogEntry.Message__c);
     }
 
     @IsTest
@@ -1222,6 +1280,8 @@ private class LogEntryEventHandler_Tests {
         logEntryEvent.RecordCollectionType__c = 'Single';
         logEntryEvent.RecordId__c = System.UserInfo.getUserId();
         logEntryEvent.TimestampString__c = String.valueOf(logEntryEvent.Timestamp__c.getTime());
+        logEntryEvent.TransactionEntryNumber__c = currentLogEntryNumber++;
+        logEntryEvent.TransactionId__c = MOCK_TRANSACTION_ID;
         logEntryEvent.UserLoggingLevel__c = System.LoggingLevel.INFO.name();
         logEntryEvent.UserLoggingLevelOrdinal__c = System.LoggingLevel.INFO.ordinal();
         logEntryEvent = (LogEntryEvent__e) LoggerMockDataCreator.setReadOnlyField(logEntryEvent, Schema.LogEntryEvent__e.EventUuid, System.UUID.randomUUID());

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -477,6 +477,90 @@ private class Logger_Tests {
     }
 
     @IsTest
+    static void it_should_revert_to_previous_user_settings_when_the_only_scenario_is_ended() {
+        LoggerSettings__c userSettingsToCreate = (LoggerSettings__c) Schema.LoggerSettings__c.SObjectType.newSObject(null, true);
+        userSettingsToCreate.IsRecordFieldStrippingEnabled__c = true;
+        userSettingsToCreate.LoggingLevel__c = System.LoggingLevel.INFO.name();
+        userSettingsToCreate.SetupOwnerId = System.UserInfo.getUserId();
+        insert userSettingsToCreate;
+        LoggerSettings__c originalUserSettings = Logger.getUserSettings().clone();
+        System.LoggingLevel originalLoggingLevel = Logger.getUserLoggingLevel();
+        System.Assert.isNull(Logger.getScenario());
+        String mockScenario = 'some test scenario ';
+        LoggerScenarioRule__mdt mockScenarioRule = new LoggerScenarioRule__mdt(
+            IsEnabled__c = true,
+            IsRecordFieldStrippingEnabled__c = String.valueOf(false),
+            Scenario__c = mockScenario,
+            UserLoggingLevel__c = System.LoggingLevel.FINE.name()
+        );
+        LoggerScenarioRule.setMock(mockScenarioRule);
+        System.Assert.areNotEqual(originalLoggingLevel.name(), mockScenarioRule.UserLoggingLevel__c);
+        Logger.setScenario(mockScenario);
+        System.Assert.areEqual(mockScenario, Logger.getScenario());
+        System.Assert.areEqual(mockScenarioRule.UserLoggingLevel__c, Logger.getUserSettings().LoggingLevel__c);
+
+        Logger.endScenario(mockScenario);
+
+        System.Assert.areEqual(originalUserSettings.IsEnabled__c, Logger.getUserSettings().IsEnabled__c);
+        System.Assert.areEqual(originalUserSettings.IsAnonymousModeEnabled__c, Logger.getUserSettings().IsAnonymousModeEnabled__c);
+        System.Assert.areEqual(originalUserSettings.IsApexSystemDebugLoggingEnabled__c, Logger.getUserSettings().IsApexSystemDebugLoggingEnabled__c);
+        System.Assert.areEqual(originalUserSettings.IsDataMaskingEnabled__c, Logger.getUserSettings().IsDataMaskingEnabled__c);
+        System.Assert.areEqual(originalUserSettings.IsJavaScriptConsoleLoggingEnabled__c, Logger.getUserSettings().IsJavaScriptConsoleLoggingEnabled__c);
+        System.Assert.areEqual(originalUserSettings.IsRecordFieldStrippingEnabled__c, Logger.getUserSettings().IsRecordFieldStrippingEnabled__c);
+        System.Assert.areEqual(originalUserSettings.IsSavingEnabled__c, Logger.getUserSettings().IsSavingEnabled__c);
+        System.Assert.areEqual(originalUserSettings.LoggingLevel__c, Logger.getUserSettings().LoggingLevel__c);
+    }
+
+    @IsTest
+    static void it_should_revert_to_previous_user_settings_with_scenario_rule_applied_when_scenario_is_ended_and_other_scenarios_have_been_used() {
+        LoggerSettings__c userSettingsToCreate = (LoggerSettings__c) Schema.LoggerSettings__c.SObjectType.newSObject(null, true);
+        userSettingsToCreate.IsRecordFieldStrippingEnabled__c = true;
+        userSettingsToCreate.LoggingLevel__c = System.LoggingLevel.INFO.name();
+        userSettingsToCreate.SetupOwnerId = System.UserInfo.getUserId();
+        insert userSettingsToCreate;
+        LoggerSettings__c originalUserSettings = Logger.getUserSettings().clone();
+        System.Assert.isNull(Logger.getScenario());
+        String firstMockScenario = 'some test scenario ';
+        LoggerScenarioRule__mdt firstMockScenarioRule = new LoggerScenarioRule__mdt(
+            IsEnabled__c = true,
+            IsRecordFieldStrippingEnabled__c = String.valueOf(false),
+            Scenario__c = firstMockScenario,
+            UserLoggingLevel__c = System.LoggingLevel.FINE.name()
+        );
+        LoggerScenarioRule.setMock(firstMockScenarioRule);
+        Logger.setScenario(firstMockScenario);
+        System.Assert.areEqual(firstMockScenario, Logger.getScenario());
+        System.Assert.areEqual(firstMockScenarioRule.UserLoggingLevel__c, Logger.getUserSettings().LoggingLevel__c);
+        String secondMockScenario = 'another test scenario ';
+        LoggerScenarioRule__mdt secondMockScenarioRule = new LoggerScenarioRule__mdt(
+            IsEnabled__c = true,
+            Scenario__c = secondMockScenario,
+            UserLoggingLevel__c = System.LoggingLevel.DEBUG.name()
+        );
+        LoggerScenarioRule.setMock(secondMockScenarioRule);
+        System.Assert.areNotEqual(firstMockScenarioRule.UserLoggingLevel__c, secondMockScenarioRule.UserLoggingLevel__c);
+        Logger.setScenario(secondMockScenario);
+        System.Assert.areEqual(secondMockScenario, Logger.getScenario());
+        System.Assert.areEqual(originalUserSettings.IsRecordFieldStrippingEnabled__c, Logger.getUserSettings().IsRecordFieldStrippingEnabled__c);
+        System.Assert.areEqual(secondMockScenarioRule.UserLoggingLevel__c, Logger.getUserLoggingLevel().name());
+
+        Logger.endScenario(secondMockScenario);
+
+        System.Assert.areEqual(firstMockScenario, Logger.getScenario());
+        System.Assert.areEqual(firstMockScenarioRule.UserLoggingLevel__c, Logger.getUserSettings().LoggingLevel__c);
+        System.Assert.areEqual(
+            Boolean.valueOf(firstMockScenarioRule.IsRecordFieldStrippingEnabled__c),
+            Logger.getUserSettings().IsRecordFieldStrippingEnabled__c
+        );
+        System.Assert.areEqual(originalUserSettings.IsEnabled__c, Logger.getUserSettings().IsEnabled__c);
+        System.Assert.areEqual(originalUserSettings.IsAnonymousModeEnabled__c, Logger.getUserSettings().IsAnonymousModeEnabled__c);
+        System.Assert.areEqual(originalUserSettings.IsApexSystemDebugLoggingEnabled__c, Logger.getUserSettings().IsApexSystemDebugLoggingEnabled__c);
+        System.Assert.areEqual(originalUserSettings.IsDataMaskingEnabled__c, Logger.getUserSettings().IsDataMaskingEnabled__c);
+        System.Assert.areEqual(originalUserSettings.IsJavaScriptConsoleLoggingEnabled__c, Logger.getUserSettings().IsJavaScriptConsoleLoggingEnabled__c);
+        System.Assert.areEqual(originalUserSettings.IsSavingEnabled__c, Logger.getUserSettings().IsSavingEnabled__c);
+    }
+
+    @IsTest
     static void it_should_not_ignore_origin_when_apex_class_type_not_specified() {
         // Don't bother testing stack trace logic when using a namespace prefix - there are
         // some platform limitations that prevent these tests from behaving as expected

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nebula-logger",
-    "version": "4.13.15",
+    "version": "4.13.16",
     "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
     "author": "Jonathan Gillespie",
     "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -10,8 +10,8 @@
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
             "scopeProfiles": true,
             "versionNumber": "4.13.16.NEXT",
-            "versionName": "Bugfix for Scenario Logging Level Not Being Respected",
-            "versionDescription": "Changed LogEntryEventHandler to always save log entry events with a matching LoggerScenarioRule__mdt when LoggerSettings__c.DefaultPlatformEventStorageLoggingLevel__c is null",
+            "versionName": "Bugfixes for Scenario Rules",
+            "versionDescription": "Fixed a bug where log entry events with a matching LoggerScenarioRule__mdt did not save when LoggerSettings__c.DefaultPlatformEventStorageLoggingLevel__c is null, and fixed a bug where scenario rule overrides weren't properly reverted when a scenario ended",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"
@@ -178,7 +178,7 @@
         "Nebula Logger - Core@4.13.13-improved-fully-qualified-references": "04t5Y0000015oDsQAI",
         "Nebula Logger - Core@4.13.14-custom-field-mappings-support": "04t5Y0000015oE2QAI",
         "Nebula Logger - Core@4.13.15-replaced-browserurl__c-with-browseraddress__c": "04t5Y0000015oF5QAI",
-        "Nebula Logger - Core@4.13.16-bugfix-for-scenario-logging-level-not-being-respected": "04t5Y0000015oFjQAI",
+        "Nebula Logger - Core@4.13.16-bugfixes-for-scenario-rules": "04t5Y0000015oFjQAI",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
             "path": "./nebula-logger/core",
             "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
             "scopeProfiles": true,
-            "versionNumber": "4.13.15.NEXT",
-            "versionName": "Replaced BrowserUrl__c with BrowserAddress__c",
-            "versionDescription": "Deprecated the BrowserUrl__c fields on LogEntryEvent__e and LogEntry__c, and replaced them with new BrowserAddress__c that have a much longer max length (2,000 vs 255)",
+            "versionNumber": "4.13.16.NEXT",
+            "versionName": "Bugfix for Scenario Logging Level Not Being Respected",
+            "versionDescription": "Changed LogEntryEventHandler to always save log entry events with a matching LoggerScenarioRule__mdt when LoggerSettings__c.DefaultPlatformEventStorageLoggingLevel__c is null",
             "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
             "unpackagedMetadata": {
                 "path": "./nebula-logger/extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -178,6 +178,7 @@
         "Nebula Logger - Core@4.13.13-improved-fully-qualified-references": "04t5Y0000015oDsQAI",
         "Nebula Logger - Core@4.13.14-custom-field-mappings-support": "04t5Y0000015oE2QAI",
         "Nebula Logger - Core@4.13.15-replaced-browserurl__c-with-browseraddress__c": "04t5Y0000015oF5QAI",
+        "Nebula Logger - Core@4.13.16-bugfix-for-scenario-logging-level-not-being-respected": "04t5Y0000015oFjQAI",
         "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
         "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
- Fixed #538 by changing `LogEntryEventHandler` to always save `LogEntryEvent__e`  records when `LoggerSettings__c.DefaultPlatformEventStorageLoggingLevel__c` is null
  - When previously using the user's logging level from `LoggerSettings__c.LoggingLevel__c` as a fallback value, it could result in entries being lost if a matching `LoggerScenarioRule__mdt` exists with a lower logging level
- Fixed some unreported issues in `Logger` with `setScenario(String)` and `endScenario(String)` not properly updating the field values returned by `getUserSettings()`
  - Now, both `setScenario(String)` and `endScenario(String)` wipe out & reload the in-memory instance of `LoggerSettings__c` (before applying any matching `LoggerScenarioRule__mdt` records) to ensure that there are not any remnants lingering when multiple `LoggerScenarioRule__mdt` records have been applied to the user's settings in a single transaction
  - The script below demonstrates the issue that occurred in previous versions. The last entries `Debug msg 3` and `Fine msg 3` were previously saved, but should _not_ have been since they don't meet the user's `INFO` logging level configured in `LoggerSettings__c`, and `endScenario(String)` has been called, which _should_ have reverted the user's logging level from `FINE` (configured in the matching `LoggerScenarioRule__mdt`) back to `INFO`.
  
    ```apex
    // Assumption: a LoggerSettings__c record for the user
    // has been configured with LoggingLevel__c = 'INFO'
    Logger.info('Current Scenario: ' + Logger.getScenario());
    Logger.info('Current Logging Level: ' + Logger.getUserLoggingLevel());
    Logger.info('Info msg 1 - expected');
    Logger.debug('Debug msg 1 - unexpected');
    Logger.fine('Fine msg 1 - unexpected');

    // Assumption: a matching LoggerScenarioRule__mdt record 
    // has been configured with UserLoggingLevel__c = 'FINE'
    Logger.setScenario('Some scenario with UserLoggingLevel__c = FINE');
    Logger.info('Current Scenario: ' + Logger.getScenario());
    Logger.info('Current Logging Level: ' + Logger.getUserLoggingLevel());
    Logger.info('Info msg 2 - expected');
    Logger.debug('Debug msg 2 - expected');
    Logger.fine('Fine msg 2 - expected');
    Logger.endScenario('Some scenario with UserLoggingLevel__c = FINE');

    Logger.info('Current Scenario: ' + Logger.getScenario());
    Logger.info('Current Logging Level: ' + Logger.getUserLoggingLevel());
    Logger.info('Info msg 3 - expected');
    Logger.debug('Debug msg 3 - unexpected');
    Logger.fine('Fine msg 3 - unexpected');

    Logger.saveLog();
    ```