### PR TITLE
Added the ability to capture HttpRequest headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,8 +126,9 @@ jobs:
       - name: 'Upload LWC code coverage to Codecov.io'
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
           flags: LWC
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   base-scratch-org-tests:
     environment: 'Base Scratch Org'
@@ -318,8 +319,9 @@ jobs:
       - name: 'Upload Apex test code coverage to Codecov.io'
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
           flags: Apex
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: 'Delete Experience Cloud Scratch Org'
         run: npx sf org delete scratch --no-prompt

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust observability solution for Salesforce experts. Built 100% natively on the platform, and designed to work seamlessly with Apex, Lightning Components, Flow, Process Builder & integrations.
 
-## Unlocked Package - v4.14.7
+## Unlocked Package - v4.14.8
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oRrQAI)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oRrQAI)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust observability solution for Salesforce experts. Built 100% native
 
 ## Unlocked Package - v4.14.8
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oRrQAI)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oRrQAI)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oS1QAI)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oS1QAI)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oRrQAI`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oS1QAI`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015oRrQAI`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015oS1QAI`
 
 ---
 

--- a/docs/apex/Configuration/LoggerParameter.md
+++ b/docs/apex/Configuration/LoggerParameter.md
@@ -106,9 +106,13 @@ Indicates if Nebula Logger will send an error email notification if any internal
 
 Indicates if Nebula Logger will store the transaction heap limits on `LogEntry__c`, retrieved from the class `System.Limits`. Controlled by the custom metadata record `LoggerParameter.StoreApexHeapSizeLimit`, or `true` as the default. Relies on `LoggerParameter.StoreTransactionLimits` to be true, as well.
 
+#### `STORE_HTTP_REQUEST_HEADER_VALUES` → `Boolean`
+
+Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpRequest`. Controlled by the custom metadata record `LoggerParameter.StoreHttpRequestHeaderValues`, or `true` as the default. Regardless of how this parameter is configured, Nebula Logger will still log the header keys of any instance of `System.HttpRequest` that is logged - this parameter only controls if the header values are stored.
+
 #### `STORE_HTTP_RESPONSE_HEADER_VALUES` → `Boolean`
 
-Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpResponse`. Controlled by the custom metadata record `LoggerParameter.StoreHttpResponseHeaderValues`, or `true` as the default. Regardless of how this parameter is configured, Nebula Logger will still log the header keys of any instance of `System.HttpResponse` that is logged - this parameter only controls if the header values are stored.
+Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpRequest`. Controlled by the custom metadata record `LoggerParameter.StoreHttpResponseHeaderValues`, or `true` as the default. Regardless of how this parameter is configured, Nebula Logger will still log the header keys of any instance of `System.HttpResponse` that is logged - this parameter only controls if the header values are stored.
 
 #### `STORE_ORGANIZATION_LIMITS` → `Boolean`
 

--- a/docs/apex/Configuration/LoggerParameter.md
+++ b/docs/apex/Configuration/LoggerParameter.md
@@ -108,11 +108,11 @@ Indicates if Nebula Logger will store the transaction heap limits on `LogEntry__
 
 #### `STORE_HTTP_REQUEST_HEADER_VALUES` → `Boolean`
 
-Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpRequest`. Controlled by the custom metadata record `LoggerParameter.StoreHttpRequestHeaderValues`, or `true` as the default. Regardless of how this parameter is configured, Nebula Logger will still log the header keys of any instance of `System.HttpRequest` that is logged - this parameter only controls if the header values are stored.
+Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpRequest`. Controlled by the custom metadata record `LoggerParameter.StoreHttpRequestHeaderValues`, or `true` as the default. Regardless of how this parameter is configured, Nebula Logger will still log the specified list of header keys of any instance of `System.HttpRequest` that is logged - this parameter only controls if the header values are stored.
 
 #### `STORE_HTTP_RESPONSE_HEADER_VALUES` → `Boolean`
 
-Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpRequest`. Controlled by the custom metadata record `LoggerParameter.StoreHttpResponseHeaderValues`, or `true` as the default. Regardless of how this parameter is configured, Nebula Logger will still log the header keys of any instance of `System.HttpResponse` that is logged - this parameter only controls if the header values are stored.
+Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpResponse`. Controlled by the custom metadata record `LoggerParameter.StoreHttpResponseHeaderValues`, or `true` as the default. Regardless of how this parameter is configured, Nebula Logger will still log the header keys of any instance of `System.HttpResponse` that is logged - this parameter only controls if the header values are stored.
 
 #### `STORE_ORGANIZATION_LIMITS` → `Boolean`
 

--- a/docs/apex/Logger-Engine/LogEntryEventBuilder.md
+++ b/docs/apex/Logger-Engine/LogEntryEventBuilder.md
@@ -461,6 +461,27 @@ LogEntryEventBuilder
 
 The same instance of `LogEntryEventBuilder`, useful for chaining methods
 
+#### `setHttpRequestDetails(System.HttpRequest request, List<String> headersToLog)` → `LogEntryEventBuilder`
+
+Sets the log entry event&apos;s HTTP Request fields
+
+##### Parameters
+
+| Param          | Description                                                           |
+| -------------- | --------------------------------------------------------------------- |
+| `request`      | The instance of `HttpRequest` to log                                  |
+| `headersToLog` | An instance of `List&lt;String&gt;` containing the header keys to log |
+
+##### Return
+
+**Type**
+
+LogEntryEventBuilder
+
+**Description**
+
+The same instance of `LogEntryEventBuilder`, useful for chaining methods
+
 #### `setHttpResponseDetails(System.HttpResponse response)` → `LogEntryEventBuilder`
 
 Sets the log entry event&apos;s HTTP Response fields

--- a/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
@@ -385,7 +385,23 @@ public class LoggerParameter {
   }
 
   /**
-   * @description Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpResponse`.
+   * @description Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpRequest`.
+   *              Controlled by the custom metadata record `LoggerParameter.StoreHttpRequestHeaderValues`, or `true` as the default.
+   *              Regardless of how this parameter is configured, Nebula Logger will still log the header keys of any instance of
+   *              `System.HttpRequest` that is logged - this parameter only controls if the header values are stored.
+   */
+  public static final Boolean STORE_HTTP_REQUEST_HEADER_VALUES {
+    get {
+      if (STORE_HTTP_REQUEST_HEADER_VALUES == null) {
+        STORE_HTTP_REQUEST_HEADER_VALUES = getBoolean('StoreHttpRequestHeaderValues', true);
+      }
+      return STORE_HTTP_REQUEST_HEADER_VALUES;
+    }
+    private set;
+  }
+
+  /**
+   * @description Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpRequest`.
    *              Controlled by the custom metadata record `LoggerParameter.StoreHttpResponseHeaderValues`, or `true` as the default.
    *              Regardless of how this parameter is configured, Nebula Logger will still log the header keys of any instance of
    *              `System.HttpResponse` that is logged - this parameter only controls if the header values are stored.

--- a/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
@@ -387,7 +387,7 @@ public class LoggerParameter {
   /**
    * @description Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpRequest`.
    *              Controlled by the custom metadata record `LoggerParameter.StoreHttpRequestHeaderValues`, or `true` as the default.
-   *              Regardless of how this parameter is configured, Nebula Logger will still log the header keys of any instance of
+   *              Regardless of how this parameter is configured, Nebula Logger will still log the specified list of header keys of any instance of
    *              `System.HttpRequest` that is logged - this parameter only controls if the header values are stored.
    */
   public static final Boolean STORE_HTTP_REQUEST_HEADER_VALUES {
@@ -401,7 +401,7 @@ public class LoggerParameter {
   }
 
   /**
-   * @description Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpRequest`.
+   * @description Indicates if Nebula Logger will store the header values when logging an instance of `System.HttpResponse`.
    *              Controlled by the custom metadata record `LoggerParameter.StoreHttpResponseHeaderValues`, or `true` as the default.
    *              Regardless of how this parameter is configured, Nebula Logger will still log the header keys of any instance of
    *              `System.HttpResponse` that is logged - this parameter only controls if the header values are stored.

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreHttpRequestHeaderValues.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.StoreHttpRequestHeaderValues.md-meta.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Store HTTP Request Header Values</label>
+    <protected>false</protected>
+    <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Description__c</field>
+        <value xsi:type="xsd:string">When set to &apos;true&apos; (default), Nebula Logger will store the header values of any instance of an HttpRequest that is logged using the instance method LogEntryEventBuilder.setHttpRequestDetails().
+
+When set to &apos;false&apos;, the header values are not stored or referenced by Nebula Logger.
+
+Regardless of how this parameter is configured, Nebula Logger will still log the specified list of header keys of any instance of an HttpRequest that is logged - this parameter only controls if the header values are stored.</value>
+    </values>
+    <values>
+        <field>Value__c</field>
+        <value xsi:type="xsd:string">true</value>
+    </values>
+</CustomMetadata>

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
@@ -285,6 +285,8 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
         HttpRequestBodyMasked__c = logEntryEvent.HttpRequestBodyMasked__c,
         HttpRequestCompressed__c = logEntryEvent.HttpRequestCompressed__c,
         HttpRequestEndpoint__c = logEntryEvent.HttpRequestEndpoint__c,
+        HttpRequestHeaderKeys__c = logEntryEvent.HttpRequestHeaderKeys__c,
+        HttpRequestHeaders__c = logEntryEvent.HttpRequestHeaders__c,
         HttpRequestMethod__c = logEntryEvent.HttpRequestMethod__c,
         HttpResponseBody__c = logEntryEvent.HttpResponseBody__c,
         HttpResponseBodyMasked__c = logEntryEvent.HttpResponseBodyMasked__c,

--- a/nebula-logger/core/main/log-management/classes/LogEntryHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryHandler.cls
@@ -302,6 +302,8 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
       logEntry.HasExceptionSourceSnippet__c = logEntry.ExceptionSourceSnippet__c != null;
       logEntry.HasExceptionStackTrace__c = logEntry.ExceptionStackTrace__c != null;
       logEntry.HasHttpRequestBody__c = logEntry.HttpRequestBody__c != null;
+      logEntry.HasHttpRequestHeaderKeys__c = logEntry.HttpRequestHeaderKeys__c != null;
+      logEntry.HasHttpRequestHeaders__c = logEntry.HttpRequestHeaders__c != null;
       logEntry.HasHttpResponseBody__c = logEntry.HttpResponseBody__c != null;
       logEntry.HasHttpResponseHeaderKeys__c = logEntry.HttpResponseHeaderKeys__c != null;
       logEntry.HasHttpResponseHeaders__c = logEntry.HttpResponseHeaders__c != null;

--- a/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
@@ -1145,6 +1145,40 @@
             <fieldInstance>
                 <fieldInstanceProperties>
                     <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.HttpRequestHeaderKeys__c</fieldItem>
+                <identifier>RecordHttpRequestHeaderKeys_cField</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.HasHttpRequestHeaderKeys__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>true</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.HttpRequestHeaders__c</fieldItem>
+                <identifier>RecordHttpRequestHeaders_cField</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!Record.HasHttpRequestHeaders__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>true</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.HttpRequestCompressed__c</fieldItem>

--- a/nebula-logger/core/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
+++ b/nebula-logger/core/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
@@ -358,6 +358,14 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
+                <field>HttpRequestHeaderKeys__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>HttpRequestHeaders__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
                 <field>HttpRequestCompressed__c</field>
             </layoutItems>
             <layoutItems>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpRequestHeaderKeys__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpRequestHeaderKeys__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HasHttpRequestHeaderKeys__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <defaultValue>false</defaultValue>
+    <label>Has HTTP Request Header Keys</label>
+    <securityClassification>Confidential</securityClassification>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpRequestHeaders__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HasHttpRequestHeaders__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HasHttpRequestHeaders__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <defaultValue>false</defaultValue>
+    <label>Has HTTP Request Headers</label>
+    <securityClassification>Confidential</securityClassification>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HttpRequestHeaderKeys__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HttpRequestHeaderKeys__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HttpRequestHeaderKeys__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <label>HTTP Request Header Keys</label>
+    <length>1000</length>
+    <securityClassification>Confidential</securityClassification>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HttpRequestHeaders__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HttpRequestHeaders__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HttpRequestHeaders__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <label>HTTP Request Headers</label>
+    <length>5000</length>
+    <securityClassification>Confidential</securityClassification>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/listViews/AllHttpRequestLogEntries.listView-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/listViews/AllHttpRequestLogEntries.listView-meta.xml
@@ -9,6 +9,7 @@
     <columns>Origin__c</columns>
     <columns>HttpRequestEndpoint__c</columns>
     <columns>HttpRequestMethod__c</columns>
+    <columns>HttpRequestHeaderKeys__c</columns>
     <columns>HttpRequestBody__c</columns>
     <columns>Timestamp__c</columns>
     <filterScope>Everything</filterScope>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/listViews/AllRestRequestLogEntries.listView-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/listViews/AllRestRequestLogEntries.listView-meta.xml
@@ -9,6 +9,7 @@
     <columns>Origin__c</columns>
     <columns>RestRequestUri__c</columns>
     <columns>RestRequestMethod__c</columns>
+    <columns>RestRequestHeaderKeys__c</columns>
     <columns>RestRequestBody__c</columns>
     <columns>Timestamp__c</columns>
     <filterScope>Everything</filterScope>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -473,6 +473,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.HasHttpRequestHeaderKeys__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpRequestHeaders__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.HasHttpResponseBody__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -559,6 +569,16 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>LogEntry__c.HttpRequestEndpoint__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HttpRequestHeaderKeys__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HttpRequestHeaders__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -234,6 +234,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.HasHttpRequestHeaderKeys__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpRequestHeaders__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.HasHttpResponseBody__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -393,6 +393,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.HasHttpRequestHeaderKeys__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HasHttpRequestHeaders__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.HasHttpResponseBody__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -479,6 +489,16 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>LogEntry__c.HttpRequestEndpoint__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HttpRequestHeaderKeys__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>LogEntry__c.HttpRequestHeaders__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -465,9 +465,19 @@ global with sharing class LogEntryEventBuilder {
   /**
    * @description Sets the log entry event's HTTP Request fields
    * @param  request The instance of `HttpRequest` to log
-   * @return              The same instance of `LogEntryEventBuilder`, useful for chaining methods
+   * @return         The same instance of `LogEntryEventBuilder`, useful for chaining methods
    */
   global LogEntryEventBuilder setHttpRequestDetails(System.HttpRequest request) {
+    return this.setHttpRequestDetails(request, new List<String>());
+  }
+
+  /**
+   * @description Sets the log entry event's HTTP Request fields
+   * @param  request The instance of `HttpRequest` to log
+   * @param  headersToLog An instance of `List<String>` containing the header keys to log
+   * @return              The same instance of `LogEntryEventBuilder`, useful for chaining methods
+   */
+  global LogEntryEventBuilder setHttpRequestDetails(System.HttpRequest request, List<String> headersToLog) {
     if (this.shouldSave() == false || request == null) {
       return this;
     }
@@ -476,10 +486,25 @@ global with sharing class LogEntryEventBuilder {
     String cleanedRequestBody = applyDataMaskRules(this.userSettings.IsDataMaskingEnabled__c, truncatedRequestBody);
     Boolean requestBodyMasked = cleanedRequestBody != truncatedRequestBody;
 
+    String formattedHeaderKeysString;
+    String formattedHeadersString;
+    if (headersToLog != null & headersToLog.isEmpty() == false) {
+      formattedHeaderKeysString = String.join(headersToLog, NEW_LINE_DELIMITER);
+      if (LoggerParameter.STORE_HTTP_REQUEST_HEADER_VALUES) {
+        List<String> headers = new List<String>();
+        for (String headerKey : headersToLog) {
+          headers.add(String.format(HTTP_HEADER_FORMAT, new List<String>{ headerKey, request.getHeader(headerKey) }));
+        }
+        formattedHeadersString = String.join(headers, NEW_LINE_DELIMITER);
+      }
+    }
+
     this.logEntryEvent.HttpRequestBody__c = cleanedRequestBody;
     this.logEntryEvent.HttpRequestBodyMasked__c = requestBodyMasked;
     this.logEntryEvent.HttpRequestCompressed__c = request.getCompressed();
     this.logEntryEvent.HttpRequestEndpoint__c = request.getEndpoint();
+    this.logEntryEvent.HttpRequestHeaderKeys__c = formattedHeaderKeysString;
+    this.logEntryEvent.HttpRequestHeaders__c = LoggerDataStore.truncateFieldValue(Schema.LogEntryEvent__e.HttpRequestHeaders__c, formattedHeadersString);
     this.logEntryEvent.HttpRequestMethod__c = request.getMethod();
     return this;
   }

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
   // There's no reliable way to get the version number dynamically in Apex
   @TestVisible
-  private static final String CURRENT_VERSION_NUMBER = 'v4.14.7';
+  private static final String CURRENT_VERSION_NUMBER = 'v4.14.8';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
   private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
@@ -6,7 +6,7 @@ import FORM_FACTOR from '@salesforce/client/formFactor';
 import { log as lightningLog } from 'lightning/logger';
 import { LoggerStackTrace } from './loggerStackTrace';
 
-const CURRENT_VERSION_NUMBER = 'v4.14.7';
+const CURRENT_VERSION_NUMBER = 'v4.14.8';
 
 const LOGGING_LEVEL_EMOJIS = {
   ERROR: '⛔',

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/HttpRequestHeaderKeys__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/HttpRequestHeaderKeys__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HttpRequestHeaderKeys__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>HTTP Request Header Keys</label>
+    <length>1000</length>
+    <securityClassification>Confidential</securityClassification>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/HttpRequestHeaders__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/HttpRequestHeaders__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HttpRequestHeaders__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>HTTP Request Headers</label>
+    <length>5000</length>
+    <securityClassification>Confidential</securityClassification>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
@@ -311,6 +311,17 @@ private class LoggerParameter_Tests {
   }
 
   @IsTest
+  static void it_should_return_constant_value_for_store_http_request_header_values() {
+    Boolean mockValue = false;
+    LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'StoreHttpRequestHeaderValues', Value__c = System.JSON.serialize(mockValue));
+    LoggerParameter.setMock(mockParameter);
+
+    Boolean returnedValue = LoggerParameter.STORE_HTTP_REQUEST_HEADER_VALUES;
+
+    System.Assert.areEqual(mockValue, returnedValue);
+  }
+
+  @IsTest
   static void it_should_return_constant_value_for_store_http_response_header_values() {
     Boolean mockValue = false;
     LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'StoreHttpResponseHeaderValues', Value__c = System.JSON.serialize(mockValue));

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -1386,6 +1386,8 @@ private class LogEntryEventHandler_Tests {
             HttpRequestBodyMasked__c,
             HttpRequestCompressed__c,
             HttpRequestEndpoint__c,
+            HttpRequestHeaderKeys__c,
+            HttpRequestHeaders__c,
             HttpRequestMethod__c,
             HttpResponseBody__c,
             HttpResponseBodyMasked__c,
@@ -1613,6 +1615,8 @@ private class LogEntryEventHandler_Tests {
     System.Assert.areEqual(logEntryEvent.HttpRequestBodyMasked__c, logEntry.HttpRequestBodyMasked__c, 'logEntry.HttpRequestBodyMasked__c was not properly set');
     System.Assert.areEqual(logEntryEvent.HttpRequestCompressed__c, logEntry.HttpRequestCompressed__c, 'logEntry.HttpRequestCompressed__c was not properly set');
     System.Assert.areEqual(logEntryEvent.HttpRequestEndpoint__c, logEntry.HttpRequestEndpoint__c, 'logEntry.HttpRequestEndpoint__c was not properly set');
+    System.Assert.areEqual(logEntryEvent.HttpRequestHeaderKeys__c, logEntry.HttpRequestHeaderKeys__c, 'logEntry.HttpRequestHeaderKeys__c was not properly set');
+    System.Assert.areEqual(logEntryEvent.HttpRequestHeaders__c, logEntry.HttpRequestHeaders__c, 'logEntry.HttpRequestHeaders__c was not properly set');
     System.Assert.areEqual(logEntryEvent.HttpRequestMethod__c, logEntry.HttpRequestMethod__c, 'logEntry.HttpRequestMethod__c was not properly set');
     System.Assert.areEqual(logEntryEvent.HttpResponseBody__c, logEntry.HttpResponseBody__c, 'logEntry.HttpResponseBody__c was not properly set');
     System.Assert.areEqual(

--- a/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryHandler_Tests.cls
@@ -239,6 +239,87 @@ private class LogEntryHandler_Tests {
   }
 
   @IsTest
+  static void it_should_set_hasHttpRequestHeaderKeys_on_before_insert() {
+    LogEntry__c matchingLogEntry = new LogEntry__c(HttpRequestHeaderKeys__c = 'some value');
+    LogEntry__c nonMatchingLogEntry = new LogEntry__c(HttpRequestHeaderKeys__c = null);
+    System.Assert.isNotNull(matchingLogEntry.HttpRequestHeaderKeys__c);
+    System.Assert.isNull(nonMatchingLogEntry.HttpRequestHeaderKeys__c);
+
+    LoggerTriggerableContext context = new LoggerTriggerableContext(
+      Schema.LogEntry__c.SObjectType,
+      System.TriggerOperation.BEFORE_INSERT,
+      new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry }
+    );
+    new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+    System.Assert.isTrue(matchingLogEntry.HasHttpRequestHeaderKeys__c);
+    System.Assert.isFalse(nonMatchingLogEntry.HasHttpRequestHeaderKeys__c);
+  }
+
+  @IsTest
+  static void it_should_set_hasHttpRequestHeaderKeys_on_before_update() {
+    LogEntry__c matchingLogEntry = new LogEntry__c(
+      HttpRequestHeaderKeys__c = 'some value',
+      Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType)
+    );
+    LogEntry__c nonMatchingLogEntry = new LogEntry__c(HttpRequestHeaderKeys__c = null, Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+    List<LogEntry__c> updatedRecords = new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry };
+    System.Assert.isNotNull(matchingLogEntry.HttpRequestHeaderKeys__c);
+    System.Assert.isNull(nonMatchingLogEntry.HttpRequestHeaderKeys__c);
+
+    LoggerTriggerableContext context = new LoggerTriggerableContext(
+      Schema.LogEntry__c.SObjectType,
+      System.TriggerOperation.BEFORE_UPDATE,
+      updatedRecords,
+      new Map<Id, SObject>(updatedRecords),
+      null
+    );
+    new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+    System.Assert.isTrue(matchingLogEntry.HasHttpRequestHeaderKeys__c);
+    System.Assert.isFalse(nonMatchingLogEntry.HasHttpRequestHeaderKeys__c);
+  }
+
+  @IsTest
+  static void it_should_set_hasHttpRequestHeaders_on_before_insert() {
+    LogEntry__c matchingLogEntry = new LogEntry__c(HttpRequestHeaders__c = 'some value');
+    LogEntry__c nonMatchingLogEntry = new LogEntry__c(HttpRequestHeaders__c = null);
+    System.Assert.isNotNull(matchingLogEntry.HttpRequestHeaders__c);
+    System.Assert.isNull(nonMatchingLogEntry.HttpRequestHeaders__c);
+
+    LoggerTriggerableContext context = new LoggerTriggerableContext(
+      Schema.LogEntry__c.SObjectType,
+      System.TriggerOperation.BEFORE_INSERT,
+      new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry }
+    );
+    new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+    System.Assert.isTrue(matchingLogEntry.HasHttpRequestHeaders__c);
+    System.Assert.isFalse(nonMatchingLogEntry.HasHttpRequestHeaders__c);
+  }
+
+  @IsTest
+  static void it_should_set_hasHttpRequestHeaders_on_before_update() {
+    LogEntry__c matchingLogEntry = new LogEntry__c(HttpRequestHeaders__c = 'some value', Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+    LogEntry__c nonMatchingLogEntry = new LogEntry__c(HttpRequestHeaders__c = null, Id = LoggerMockDataCreator.createId(Schema.LogEntry__c.SObjectType));
+    List<LogEntry__c> updatedRecords = new List<LogEntry__c>{ matchingLogEntry, nonMatchingLogEntry };
+    System.Assert.isNotNull(matchingLogEntry.HttpRequestHeaders__c);
+    System.Assert.isNull(nonMatchingLogEntry.HttpRequestHeaders__c);
+
+    LoggerTriggerableContext context = new LoggerTriggerableContext(
+      Schema.LogEntry__c.SObjectType,
+      System.TriggerOperation.BEFORE_UPDATE,
+      updatedRecords,
+      new Map<Id, SObject>(updatedRecords),
+      null
+    );
+    new LogEntryHandler().overrideTriggerableContext(context).execute();
+
+    System.Assert.isTrue(matchingLogEntry.HasHttpRequestHeaders__c);
+    System.Assert.isFalse(nonMatchingLogEntry.HasHttpRequestHeaders__c);
+  }
+
+  @IsTest
   static void it_should_set_hasHttpResponseBody_on_before_insert() {
     LogEntry__c matchingLogEntry = new LogEntry__c(HttpResponseBody__c = 'some value');
     LogEntry__c nonMatchingLogEntry = new LogEntry__c(HttpResponseBody__c = null);

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -1271,9 +1271,12 @@ private class LogEntryEventBuilder_Tests {
   @IsTest
   static void it_should_set_http_request_fields_when_request_is_populated() {
     LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true);
-    System.Assert.isNull(builder.getLogEntryEvent().HttpRequestBody__c);
-    System.Assert.isNull(builder.getLogEntryEvent().HttpRequestEndpoint__c);
-    System.Assert.isNull(builder.getLogEntryEvent().HttpRequestMethod__c);
+    LogEntryEvent__e event = builder.getLogEntryEvent();
+    System.Assert.isNull(event.HttpRequestBody__c);
+    System.Assert.isNull(event.HttpRequestEndpoint__c);
+    System.Assert.isNull(event.HttpRequestHeaderKeys__c);
+    System.Assert.isNull(event.HttpRequestHeaders__c);
+    System.Assert.isNull(event.HttpRequestMethod__c);
     System.HttpRequest request = new System.HttpRequest();
     request.setBody('Hello, world!');
     request.setCompressed(true);
@@ -1282,10 +1285,76 @@ private class LogEntryEventBuilder_Tests {
 
     builder.setHttpRequestDetails(request);
 
-    System.Assert.areEqual(request.getBody(), builder.getLogEntryEvent().HttpRequestBody__c);
-    System.Assert.areEqual(request.getCompressed(), builder.getLogEntryEvent().HttpRequestCompressed__c);
-    System.Assert.areEqual(request.getEndpoint(), builder.getLogEntryEvent().HttpRequestEndpoint__c);
-    System.Assert.areEqual(request.getMethod(), builder.getLogEntryEvent().HttpRequestMethod__c);
+    System.Assert.areEqual(request.getBody(), event.HttpRequestBody__c);
+    System.Assert.areEqual(request.getCompressed(), event.HttpRequestCompressed__c);
+    System.Assert.areEqual(request.getEndpoint(), event.HttpRequestEndpoint__c);
+    System.Assert.isNull(event.HttpRequestHeaderKeys__c);
+    System.Assert.isNull(event.HttpRequestHeaders__c);
+    System.Assert.areEqual(request.getMethod(), event.HttpRequestMethod__c);
+  }
+
+  @IsTest
+  static void it_should_set_http_request_fields_when_header_keys_are_provided_and_storing_header_values_is_enabled() {
+    LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'StoreHttpRequestHeaderValues', Value__c = String.valueOf(true));
+    LoggerParameter.setMock(mockParameter);
+    System.Assert.isTrue(LoggerParameter.STORE_HTTP_REQUEST_HEADER_VALUES);
+    LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true);
+    LogEntryEvent__e event = builder.getLogEntryEvent();
+    System.Assert.isNull(event.HttpRequestBody__c);
+    System.Assert.isNull(event.HttpRequestEndpoint__c);
+    System.Assert.isNull(event.HttpRequestHeaderKeys__c);
+    System.Assert.isNull(event.HttpRequestHeaders__c);
+    System.Assert.isNull(event.HttpRequestMethod__c);
+    System.HttpRequest request = new System.HttpRequest();
+    request.setBody('Hello, world!');
+    request.setCompressed(true);
+    request.setEndpoint('https://fake.salesforce.com');
+    request.setHeader('header-1-to-log', 'some value to log');
+    request.setHeader('a-header-to-ignore', 'ignore this value, it won\'t be logged');
+    request.setHeader('header-2-to-log', 'another value to log');
+    request.setHeader('another-header-to-ignore', 'ignore this too');
+    request.setMethod('GET');
+
+    builder.setHttpRequestDetails(request, new List<String>{ 'header-1-to-log', 'header-2-to-log' });
+
+    System.Assert.areEqual(request.getBody(), event.HttpRequestBody__c);
+    System.Assert.areEqual(request.getCompressed(), event.HttpRequestCompressed__c);
+    System.Assert.areEqual(request.getEndpoint(), event.HttpRequestEndpoint__c);
+    System.Assert.areEqual('header-1-to-log\nheader-2-to-log', event.HttpRequestHeaderKeys__c);
+    System.Assert.areEqual('header-1-to-log: some value to log\nheader-2-to-log: another value to log', event.HttpRequestHeaders__c);
+    System.Assert.areEqual(request.getMethod(), event.HttpRequestMethod__c);
+  }
+
+  @IsTest
+  static void it_should_set_http_request_fields_when_header_keys_are_provided_and_storing_header_values_is_disabled() {
+    LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'StoreHttpRequestHeaderValues', Value__c = String.valueOf(false));
+    LoggerParameter.setMock(mockParameter);
+    System.Assert.isFalse(LoggerParameter.STORE_HTTP_REQUEST_HEADER_VALUES);
+    LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true);
+    LogEntryEvent__e event = builder.getLogEntryEvent();
+    System.Assert.isNull(event.HttpRequestBody__c);
+    System.Assert.isNull(event.HttpRequestEndpoint__c);
+    System.Assert.isNull(event.HttpRequestHeaderKeys__c);
+    System.Assert.isNull(event.HttpRequestHeaders__c);
+    System.Assert.isNull(event.HttpRequestMethod__c);
+    System.HttpRequest request = new System.HttpRequest();
+    request.setBody('Hello, world!');
+    request.setCompressed(true);
+    request.setEndpoint('https://fake.salesforce.com');
+    request.setHeader('header-1-to-log', 'some value to log');
+    request.setHeader('a-header-to-ignore', 'ignore this value, it won\'t be logged');
+    request.setHeader('header-2-to-log', 'another value to log');
+    request.setHeader('another-header-to-ignore', 'ignore this too');
+    request.setMethod('GET');
+
+    builder.setHttpRequestDetails(request, new List<String>{ 'header-1-to-log', 'header-2-to-log' });
+
+    System.Assert.areEqual(request.getBody(), event.HttpRequestBody__c);
+    System.Assert.areEqual(request.getCompressed(), event.HttpRequestCompressed__c);
+    System.Assert.areEqual(request.getEndpoint(), event.HttpRequestEndpoint__c);
+    System.Assert.areEqual('header-1-to-log\nheader-2-to-log', event.HttpRequestHeaderKeys__c);
+    System.Assert.isNull(event.HttpRequestHeaders__c);
+    System.Assert.areEqual(request.getMethod(), event.HttpRequestMethod__c);
   }
 
   @IsTest

--- a/nebula-logger/plugins/slack/README.md
+++ b/nebula-logger/plugins/slack/README.md
@@ -56,22 +56,27 @@ The Slack integration should now be setup & working - any new logs that meet the
 _Note: these instructions are for setting up the improved Named Credentials, as legacy credentials are deprecated as of Winter '23. For more info, see [Salesforce's documentation](https://help.salesforce.com/s/articleView?id=sf.named_credentials_about.htm&type=5)._
 
 1. **Create a new External Credential.** This will define how Salesforce should authenticate with the Slack webhook (which in this case is no authentication).
+
    - Go to the Named Credentials page in setup, click `New` under the External Credentials tab.
    - Enter a name (for example, `Nebula Slack Webhook (No Auth)`)
    - Select `No Authentication` for the Authentication Protocol.
-1. **Create a Principle for the External Credential.** This will define the credentials that should be used when calling out to the Slack webhook (again, in this case, no credentials are needed, but we will still need to grant access to the principal).
+
+2. **Create a Principle for the External Credential.** This will define the credentials that should be used when calling out to the Slack webhook (again, in this case, no credentials are needed, but we will still need to grant access to the principal).
 
    - In the Principals section of the External Credential you just created, click `New`.
    - Enter a parameter name (for example: `Default` or `Standard`, as there will only ever be one principal for this credential).
 
    ![Slack plugin: external credential](./.images/slack-plugin-external-credential.png)
 
-1. **Create a new Named Credential.** This is where the webhook URL will be stored.
+3. **Create a new Named Credential.** This is where the webhook URL will be stored.
+
    - Go back to the main Named Credentials page and click `New` in the Named Credentials tab.
    - Enter a name for the Named Credential (for example: `Nebula Slack Webhook`).
    - Paste the Slack webhook URL into the URL field.
    - In the External Credential dropdown, select the one you created in step 1.
-1. **Grant the Platform Integration User access to the External Credential.** This will allow the Platform Integration user (the running user listening for Log Platform Events) to make callouts to the Slack webhook.
+
+4. **Grant the Platform Integration User access to the External Credential.** This will allow the Platform Integration user (the running user listening for Log Platform Events) to make callouts to the Slack webhook.
+
    - Create a new permission set or open an existing one
    - Go to the External Credential Principal Access section of the permissions set and grant access to the External Credential you created in step 1.
    - Assign the permission set to the Platform Integration User handles Log Platform events.

--- a/nebula-logger/plugins/slack/README.md
+++ b/nebula-logger/plugins/slack/README.md
@@ -52,27 +52,28 @@ The Slack integration should now be setup & working - any new logs that meet the
 ![Slack plugin: parameters](./.images/slack-plugin-parameters.png)
 
 #### Setting up Named Credentials
-*Note: these instructions are for setting up the improved Named Credentials, as legacy credentials are deprecated as of Winter '23. For more info, see [Salesforce's documentation](https://help.salesforce.com/s/articleView?id=sf.named_credentials_about.htm&type=5).*
+
+_Note: these instructions are for setting up the improved Named Credentials, as legacy credentials are deprecated as of Winter '23. For more info, see [Salesforce's documentation](https://help.salesforce.com/s/articleView?id=sf.named_credentials_about.htm&type=5)._
 
 1. **Create a new External Credential.** This will define how Salesforce should authenticate with the Slack webhook (which in this case is no authentication).
-   - Go to the Named Credentials page in setup, click  `New` under the External Credentials tab.
+   - Go to the Named Credentials page in setup, click `New` under the External Credentials tab.
    - Enter a name (for example, `Nebula Slack Webhook (No Auth)`)
    - Select `No Authentication` for the Authentication Protocol.
 1. **Create a Principle for the External Credential.** This will define the credentials that should be used when calling out to the Slack webhook (again, in this case, no credentials are needed, but we will still need to grant access to the principal).
-   - In the Principals section of the External Credential you just created, click `New`. 
-   - Enter a parameter name (for example: `Default` or `Standard`, as there will only ever be one principal for this credential). 
+
+   - In the Principals section of the External Credential you just created, click `New`.
+   - Enter a parameter name (for example: `Default` or `Standard`, as there will only ever be one principal for this credential).
 
    ![Slack plugin: external credential](./.images/slack-plugin-external-credential.png)
 
-3. **Create a new Named Credential.** This is where the webhook URL will be stored.
-   - Go back to the main Named Credentials page and click `New` in the Named Credentials tab. 
+1. **Create a new Named Credential.** This is where the webhook URL will be stored.
+   - Go back to the main Named Credentials page and click `New` in the Named Credentials tab.
    - Enter a name for the Named Credential (for example: `Nebula Slack Webhook`).
    - Paste the Slack webhook URL into the URL field.
    - In the External Credential dropdown, select the one you created in step 1.
-4. **Grant the Platform Integration User access to the External Credential.** This will allow the Platform Integration user (the running user listening for Log Platform Events) to make callouts to the Slack webhook.
+1. **Grant the Platform Integration User access to the External Credential.** This will allow the Platform Integration user (the running user listening for Log Platform Events) to make callouts to the Slack webhook.
    - Create a new permission set or open an existing one
-   - Go to the External Credential Principal Access section of the permissions set and grant access to the External Credential you created in step 1. 
-   - Assign the permission set to the Platform Integration User handles Log Platform events. 
+   - Go to the External Credential Principal Access section of the permissions set and grant access to the External Credential you created in step 1.
+   - Assign the permission set to the Platform Integration User handles Log Platform events.
      - There are often multiple platform integration users. The easiest way to determine the correct one is to run this query: `SELECT CreatedBy.Username from Log__c LIMIT 1`, then assign the permission set to the user with the username returned in the query.
-     
-    ![Slack plugin: named credential](./.images/slack-plugin-named-credential.png)
+       ![Slack plugin: named credential](./.images/slack-plugin-named-credential.png)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebula-logger",
-  "version": "4.14.7",
+  "version": "4.14.8",
   "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
   "author": "Jonathan Gillespie",
   "license": "MIT",

--- a/scripts/data/create-sample-log-entries.apex
+++ b/scripts/data/create-sample-log-entries.apex
@@ -38,8 +38,10 @@ Logger.finest('Example FINEST entry');
 System.HttpRequest httpRequest = new System.HttpRequest();
 httpRequest.setBody('Hello, world! Here is my credit card number 5000-1111-2222-0005');
 httpRequest.setEndpoint('https://fake.salesforce.com');
+httpRequest.setHeader('some-header', 'some value');
+httpRequest.setHeader('another-header', 'another value');
 httpRequest.setMethod('GET');
-Logger.info('logging an HTTP request').setHttpRequestDetails(httpRequest);
+Logger.info('logging an HTTP request').setHttpRequestDetails(httpRequest, new List<String>{ 'some-header' });
 
 System.HttpResponse httpResponse = new System.HttpResponse();
 httpResponse.setBody('Hello, world! Here is my credit card number 5000-1111-2222-0005');

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
       "path": "./nebula-logger/core",
       "definitionFile": "./config/scratch-orgs/build-base-scratch-def.json",
       "scopeProfiles": true,
-      "versionNumber": "4.14.7.NEXT",
-      "versionName": "Bugfix: US Social Security Number Data Mask Rule",
-      "versionDescription": "Corrected the regular expressions used in data mask rule 'SocialSecurityNumber' to be stricter to avoid incorrectly masking credit card numbers as social security numbers",
+      "versionNumber": "4.14.8.NEXT",
+      "versionName": " Store HttpRequest header keys & values",
+      "versionDescription": "Added method overload setHttpRequestDetails(HttpRequest request, List<String> headersToLog) in LogEntryEventBuilder to capture the specified list of header keys & values when logging an instance of HttpRequest",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {
         "path": "./nebula-logger/extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -192,6 +192,7 @@
     "Nebula Logger - Core@4.14.5-added-logger-settings-to-utility-bar": "04t5Y0000015oRXQAY",
     "Nebula Logger - Core@4.14.6-custom-field-mappings-support-for-lightning-components": "04t5Y0000015oRhQAI",
     "Nebula Logger - Core@4.14.7-bugfix:-us-social-security-number-data-mask-rule": "04t5Y0000015oRrQAI",
+    "Nebula Logger - Core@4.14.8--store-httprequest-header-keys-&-values": "04t5Y0000015oS1QAI",
     "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
Resolved #701 by providing a way to indicate which `HttpRequest` headers (and values) should be logged - previously, no header information was stored for `HttpRequest` objects.

Conceptually, this is the same idea as logging headers when calling the other `LogEntryBuilder` methods below:
- `setHttpResponseDetails(System.HttpResponse response)`
- `setRestRequestDetails(System.RestRequest request)`
- `setRestResponseDetails(System.RestResponse response)`

However, there is one notable difference in the new behavior for logging `HttpRequest` headers - [the `HttpRequest` class](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_classes_restful_http_httprequest.htm) does not have a method to get all of the header keys, so you must explicitly tell Nebula Logger which header keys you want to log.

# Core Unlocked Package Changes
- Added instance method overload `LogEntryEventBuilder.setHttpRequestDetails(System.HttpRequest request, List<String> headersToLog)`
  - Any header keys provided in `headersToLog` will now be logged
  - The existing overload, `setHttpRequestDetails(System.HttpRequest request)`, will _not_ log any header information
- Added new `LogEntryEvent__e` fields `HttpRequestHeaderKeys__c` and `HttpRequestHeaders__c` to capture the specified list of header keys
  - The new fields mimic these existing fields:
    - `HttpResponse` header data stored in `HttpResponseHeaderKeys__c` and `HttpResponseHeaders__c`
    - `RestRequest` header data stored in `RestRequestHeaderKeys__c` and `RestRequestHeaders__c`
    - `RestResponse` header data stored in `RestResponseHeaderKeys__c` and `RestRequestHeaders__c`
- Added new `LoggerParameter__mdt` record `StoreHttpRequestHeaderValues` to globally control if `HttpResponse` header values are stored when calling `setHttpRequestDetails(System.HttpRequest request, List<String> headersToLog)`
  - This new record mimics the existing record `StoreHttpResponseHeaderValues` (used for responses)
- Added new `LogEntry__c` fields to store the `HttpRequest` header keys & values captured on `LogEntryEvent__e`, as well as some checkbox fields to aid with filtering in SOQL, list views, etc.
  - `HttpRequestHeaderKeys__c`
  - `HasHttpRequestHeaderKeys__c` - set to `true` when `HttpRequestHeaderKeys__c` is not null
  - `HttpRequestHeaders__c`
  - `HasHttpRequestHeaders__c` - set to `true` when `HttpRequestHeaders__c` is not null
- Updated the flexipage `LogEntryRecordPage` to add the 2 new `LogEntry__c` fields `HttpRequestHeaderKeys__c` and `HttpRequestHeaders__c`
  - Both fields are conditionally displayed when populated, based on their corresponding checkbox fields `HasHttpRequestHeaderKeys__c` and `HasHttpRequestHeaders__c` (respectively)
- Updated the existing list view `AllHttpRequestLogEntries` to include the new field `HttpRequestHeaderKeys__c` (`HttpRequestHeader__c` is intentionally not included at this time)

## Example

This example Apex script will create a `LogEntry__c` record with data about the `HttpRequest` - including the 2 specified header keys & their values.

```apex
System.HttpRequest httpRequest = new System.HttpRequest();
httpRequest.setBody('{ "hello": "world" }');
httpRequest.setEndpoint('https://fake.salesforce.com');
httpRequest.setHeader('some-header', 'some value');
httpRequest.setHeader('another-header', 'another value');
httpRequest.setMethod('GET');

List<String> headersToLog = new List<String>{ 'some-header', 'another-header' };
Logger.info('logging an HTTP request').setHttpRequestDetails(httpRequest, headersToLog);
Logger.saveLog();
```

![image](https://github.com/user-attachments/assets/41bea4c5-c739-4ebb-a92d-a3963a3abb93)
