### PR TITLE
Bugfix: Apex code snippets auto-truncated

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust observability solution for Salesforce experts. Built 100% natively on the platform, and designed to work seamlessly with Apex, Lightning Components, Flow, Process Builder & integrations.
 
-## Unlocked Package - v4.14.8
+## Unlocked Package - v4.14.9
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oS1QAI)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oS1QAI)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust observability solution for Salesforce experts. Built 100% native
 
 ## Unlocked Package - v4.14.9
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oS1QAI)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oS1QAI)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oSQQAY)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oSQQAY)
 [![View Documentation](./images/btn-view-documentation.png)](https://jongpie.github.io/NebulaLogger/)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oS1QAI`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oSQQAY`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015oS1QAI`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015oSQQAY`
 
 ---
 

--- a/nebula-logger/core/main/log-management/classes/LogEntryHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryHandler.cls
@@ -431,11 +431,15 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
       this.StackTrace = stackTrace;
 
       List<String> allCodeLines = sourceCode.split('\n');
-      this.setLineNumbers(stackTrace.Source.LineNumber, allCodeLines);
+      this.setLineNumbers(stackTrace.Source?.LineNumber, allCodeLines);
       this.setCode(allCodeLines);
     }
 
-    private List<String> setLineNumbers(Integer targetLineNumber, List<String> allCodeLines) {
+    private void setLineNumbers(Integer targetLineNumber, List<String> allCodeLines) {
+      if (targetLineNumber == null) {
+        return;
+      }
+
       Integer numberOfCodeLines = allCodeLines.size();
 
       // TODO consider making these values configurable with 2 new LoggerParameter__mdt records
@@ -456,8 +460,6 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
       this.StartingLineNumber = calculcatedStartingLineNumber;
       this.TargetLineNumber = targetLineNumber;
       this.EndingLineNumber = calculatedEndingLineNumber;
-
-      return allCodeLines;
     }
 
     private void setCode(List<String> allCodeLines) {
@@ -468,7 +470,10 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
         snippetCodeLines.add(allCodeLines.get(targetLineNumberIndex));
       }
 
-      this.Code = String.join(snippetCodeLines, '\n');
+      // The field length for OriginSourceSnippet__c and ExceptionSourceSnippet__c is set to 2,000 - but that includes storing
+      // both the code itself, as well as other JSON data. Using left(1500) should leave room for the other JSON data
+      // while still avoiding exceeding the field's max length.
+      this.Code = String.join(snippetCodeLines, '\n').left(1500);
     }
   }
 
@@ -540,7 +545,6 @@ public without sharing class LogEntryHandler extends LoggerSObjectHandler {
       }
 
       // Newer, general-purpose 'origin source' fields
-      logEntry.OriginSourceActionName__c = originStackTrace.Source.ActionName;
       logEntry.OriginSourceApiVersion__c = 'v' + apexClass.ApiVersion;
       logEntry.OriginSourceCreatedById__c = apexClass.CreatedById;
       logEntry.OriginSourceCreatedByUsername__c = apexClass.CreatedBy.Username;

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
   // There's no reliable way to get the version number dynamically in Apex
   @TestVisible
-  private static final String CURRENT_VERSION_NUMBER = 'v4.14.8';
+  private static final String CURRENT_VERSION_NUMBER = 'v4.14.9';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
   private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
@@ -6,7 +6,7 @@ import FORM_FACTOR from '@salesforce/client/formFactor';
 import { log as lightningLog } from 'lightning/logger';
 import { LoggerStackTrace } from './loggerStackTrace';
 
-const CURRENT_VERSION_NUMBER = 'v4.14.8';
+const CURRENT_VERSION_NUMBER = 'v4.14.9';
 
 const LOGGING_LEVEL_EMOJIS = {
   ERROR: '⛔',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebula-logger",
-  "version": "4.14.8",
+  "version": "4.14.9",
   "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
   "author": "Jonathan Gillespie",
   "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -193,6 +193,7 @@
     "Nebula Logger - Core@4.14.6-custom-field-mappings-support-for-lightning-components": "04t5Y0000015oRhQAI",
     "Nebula Logger - Core@4.14.7-bugfix:-us-social-security-number-data-mask-rule": "04t5Y0000015oRrQAI",
     "Nebula Logger - Core@4.14.8-store-httprequest-header-keys-&-values": "04t5Y0000015oS1QAI",
+    "Nebula Logger - Core@4.14.9-bugfix:-apex-code-snippets-auto-truncated": "04t5Y0000015oSQQAY",
     "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
       "path": "./nebula-logger/core",
       "definitionFile": "./config/scratch-orgs/build-base-scratch-def.json",
       "scopeProfiles": true,
-      "versionNumber": "4.14.8.NEXT",
-      "versionName": " Store HttpRequest header keys & values",
-      "versionDescription": "Added method overload setHttpRequestDetails(HttpRequest request, List<String> headersToLog) in LogEntryEventBuilder to capture the specified list of header keys & values when logging an instance of HttpRequest",
+      "versionNumber": "4.14.9.NEXT",
+      "versionName": "Bugfix: Apex Code Snippets Auto-Truncated",
+      "versionDescription": "Updated LogEntryHandler to automatically truncate the code snippets stored in OriginSourceSnippet__c and ExceptionSourceSnippet__c",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {
         "path": "./nebula-logger/extra-tests"
@@ -192,7 +192,7 @@
     "Nebula Logger - Core@4.14.5-added-logger-settings-to-utility-bar": "04t5Y0000015oRXQAY",
     "Nebula Logger - Core@4.14.6-custom-field-mappings-support-for-lightning-components": "04t5Y0000015oRhQAI",
     "Nebula Logger - Core@4.14.7-bugfix:-us-social-security-number-data-mask-rule": "04t5Y0000015oRrQAI",
-    "Nebula Logger - Core@4.14.8--store-httprequest-header-keys-&-values": "04t5Y0000015oS1QAI",
+    "Nebula Logger - Core@4.14.8-store-httprequest-header-keys-&-values": "04t5Y0000015oS1QAI",
     "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
Fixed #756 by truncating the Apex code snippets that are saved in the `LogEntry__c` fields `OriginSourceSnippet__c` and `ExceptionSourceSnippet__c`
- Previously, the code snippet was only limited by the number of lines of code - but for Apex classes & triggers that have very looooooooooooong code on some lines, the code snippet could cause the JSON value to exceed the corresponding field's max length
- Now, the code snippet only grabs the first 1,500 characters - both fields are set to a max of 2,000 characters, allowing 500 characters for the remaining JSON data