### PR TITLE
Added new Apex method & JS function Logger.setField() 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust observability solution for Salesforce experts. Built 100% native
 
 ## Unlocked Package - v4.14.14
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oW3QAI)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oW3QAI)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oWIQAY)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oWIQAY)
 [![View Documentation](./images/btn-view-documentation.png)](https://github.com/jongpie/NebulaLogger/wiki)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oW3QAI`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oWIQAY`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015oW3QAI`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015oWIQAY`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -694,12 +694,12 @@ The first step is to add a field to the platform event `LogEntryEvent__e`
   ```javascript
   import { getLogger } from 'c/logger';
 
-  export default class LoggerLWCImportDemo extends LightningElement {
+  export default class LoggerDemo extends LightningElement {
     logger = getLogger();
 
     connectedCallback() {
       // Set My_Field__c on every log entry event created in this component with the same value
-      this.logger.setField(LogEntryEvent__e.My_Field__c, 'some value that applies to any subsequent entry');
+      this.logger.setField({My_Field__c, 'some value that applies to any subsequent entry'});
 
       // Set fields on specific entries
       this.logger.warn('hello, world - "a value" set for Some_Other_Field__c').setField({ Some_Other_Field__c: 'a value' });

--- a/docs/apex/Logger-Engine/LogEntryEventBuilder.md
+++ b/docs/apex/Logger-Engine/LogEntryEventBuilder.md
@@ -402,7 +402,7 @@ The same instance of `LogEntryEventBuilder`, useful for chaining methods
 
 #### `setField(Schema.SObjectField field, Object fieldValue)` → `LogEntryEventBuilder`
 
-Sets a field values on the builder&apos;s `LogEntryEvent__e` record
+Sets a field value on the builder&apos;s `LogEntryEvent__e` record
 
 ##### Parameters
 

--- a/docs/apex/Logger-Engine/Logger.md
+++ b/docs/apex/Logger-Engine/Logger.md
@@ -4948,6 +4948,27 @@ Stores additional details about the current transacation&apos;s async context
 | -------------------- | ------------------------------------------------------ |
 | `schedulableContext` | - The instance of `System.SchedulableContext` to track |
 
+#### `setField(Schema.SObjectField field, Object fieldValue)` → `void`
+
+Sets a field value on every generated `LogEntryEvent__e` record
+
+##### Parameters
+
+| Param        | Description                                              |
+| ------------ | -------------------------------------------------------- |
+| `field`      | The `Schema.SObjectField` token of the field to populate |
+| `fieldValue` | The `Object` value to populate in the provided field     |
+
+#### `setField(Map<Schema.SObjectField, Object> fieldToValue)` → `void`
+
+Sets multiple field values oon every generated `LogEntryEvent__e` record
+
+##### Parameters
+
+| Param          | Description                                                            |
+| -------------- | ---------------------------------------------------------------------- |
+| `fieldToValue` | An instance of `Map&lt;Schema.SObjectField, Object&gt;` containing the |
+
 #### `setParentLogTransactionId(String parentTransactionId)` → `void`
 
 Relates the current transaction&apos;s log to a parent log via the field Log**c.ParentLog**c This is useful for relating multiple asynchronous operations together, such as batch &amp; queueable jobs.

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,6 @@ module.exports = {
     '^lightning/empApi$': '<rootDir>/config/jest/mocks/lightning/empApi',
     '^lightning/navigation$': '<rootDir>/config/jest/mocks/lightning/navigation'
   },
-  modulePathIgnorePatterns: ['recipes'],
+  // modulePathIgnorePatterns: ['recipes'],
   testPathIgnorePatterns: ['<rootDir>/temp/']
 };

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -629,7 +629,7 @@ global with sharing class LogEntryEventBuilder {
   }
 
   /**
-   * @description Sets a field values on the builder's `LogEntryEvent__e` record
+   * @description Sets a field value on the builder's `LogEntryEvent__e` record
    * @param  field      The `Schema.SObjectField` token of the field to populate
    *                    on the builder's `LogEntryEvent__e` record
    * @param  fieldValue The `Object` value to populate in the provided field
@@ -646,7 +646,7 @@ global with sharing class LogEntryEventBuilder {
   /**
    * @description Sets multiple field values on the builder's `LogEntryEvent__e` record
    * @param  fieldToValue An instance of `Map<Schema.SObjectField, Object>` containing the
-   *                      the fields & values to populate the builder's `LogEntryEvent__e` record
+   *                      the fields & values to populate on the builder's `LogEntryEvent__e` record
    * @return The same instance of `LogEntryEventBuilder`, useful for chaining methods
    */
   @SuppressWarnings('PMD.AvoidDebugStatements')

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -22,6 +22,7 @@ global with sharing class Logger {
   private static final String ORGANIZATION_DOMAIN_URL = System.URL.getOrgDomainUrl()?.toExternalForm();
   private static final String REQUEST_ID = System.Request.getCurrent().getRequestId();
   private static final Map<String, SaveMethod> SAVE_METHOD_NAME_TO_SAVE_METHOD = new Map<String, SaveMethod>();
+  private static final Map<Schema.SObjectField, Object> TRANSACTION_FIELD_TO_VALUE = new Map<Schema.SObjectField, Object>();
   private static final String TRANSACTION_ID = System.UUID.randomUUID().toString();
 
   private static AsyncContext currentAsyncContext;
@@ -248,6 +249,30 @@ global with sharing class Logger {
    */
   global static String getParentLogTransactionId() {
     return parentLogTransactionId;
+  }
+
+  /**
+   * @description Sets a field value on every generated `LogEntryEvent__e` record
+   * @param  field      The `Schema.SObjectField` token of the field to populate
+   *                    on each `LogEntryEvent__e` record in the current transaction
+   * @param  fieldValue The `Object` value to populate in the provided field
+   */
+  global static void setField(Schema.SObjectField field, Object fieldValue) {
+    setField(new Map<Schema.SObjectField, Object>{ field => fieldValue });
+  }
+
+  /**
+   * @description Sets multiple field values oon every generated `LogEntryEvent__e` record
+   * @param  fieldToValue An instance of `Map<Schema.SObjectField, Object>` containing the
+   *                      the fields & values to populate on each `LogEntryEvent__e` record in the current transaction
+   */
+  global static void setField(Map<Schema.SObjectField, Object> fieldToValue) {
+    if (getUserSettings().IsEnabled__c == false) {
+      return;
+    }
+
+    TRANSACTION_FIELD_TO_VALUE.putAll(fieldToValue);
+    TRANSACTION_FIELD_TO_VALUE.remove(null);
   }
 
   /**
@@ -3390,8 +3415,9 @@ global with sharing class Logger {
 
     return logEntryEventBuilder;
   }
-
   private static void finalizeEntry(LogEntryEvent__e logEntryEvent) {
+    setTransactionFields(logEntryEvent);
+
     logEntryEvent.ParentLogTransactionId__c = getParentLogTransactionId();
     logEntryEvent.TransactionScenario__c = transactionScenario;
 
@@ -3400,6 +3426,25 @@ global with sharing class Logger {
       logEntryEvent.AsyncContextParentJobId__c = currentAsyncContext.parentJobId;
       logEntryEvent.AsyncContextTriggerId__c = currentAsyncContext.triggerId;
       logEntryEvent.AsyncContextType__c = currentAsyncContext.type;
+    }
+  }
+
+  @SuppressWarnings('PMD.AvoidDebugStatements')
+  private static void setTransactionFields(LogEntryEvent__e logEntryEvent) {
+    for (Schema.SObjectField field : TRANSACTION_FIELD_TO_VALUE.keySet()) {
+      Object value = TRANSACTION_FIELD_TO_VALUE.get(field);
+
+      try {
+        Schema.DescribeFieldResult fieldDescribe = field.getDescribe();
+        if (fieldDescribe.getSoapType() == Schema.SoapType.STRING) {
+          value = LoggerDataStore.truncateFieldValue(field, (String) value);
+        }
+
+        logEntryEvent.put(field, value);
+      } catch (System.Exception ex) {
+        LogMessage logMessage = new LogMessage('Could not set field {0} with value {1}', field, value);
+        System.debug(System.LoggingLevel.WARN, logMessage.getMessage());
+      }
     }
   }
 

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
   // There's no reliable way to get the version number dynamically in Apex
   @TestVisible
-  private static final String CURRENT_VERSION_NUMBER = 'v4.14.13';
+  private static final String CURRENT_VERSION_NUMBER = 'v4.14.14';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
   private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/__tests__/logger.test.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/__tests__/logger.test.js
@@ -543,7 +543,6 @@ describe('logger lwc recommended sync getLogger() import approach tests', () => 
     // getLogger() is built to be sync, but internally, some async tasks must execute
     // before some sync tasks are executed
     await flushPromises('Resolve async task queue');
-    await logger.getUserSettings();
 
     const logEntry = logger.info('example log entry').getComponentLogEntry();
 
@@ -555,13 +554,36 @@ describe('logger lwc recommended sync getLogger() import approach tests', () => 
     expect(logEntry.browser.windowResolution).toEqual(window.innerWidth + ' x ' + window.innerHeight);
   });
 
-  it('sets multiple custom fields', async () => {
+  it('sets multiple custom component fields on subsequent entries', async () => {
     getSettings.mockResolvedValue({ ...MOCK_GET_SETTINGS });
     const logger = getLogger();
     // getLogger() is built to be sync, but internally, some async tasks must execute
     // before some sync tasks are executed
     await flushPromises('Resolve async task queue');
-    await logger.getUserSettings();
+    const firstFakeFieldName = 'SomeField__c';
+    const firstFieldMockValue = 'something';
+    const secondFakeFieldName = 'AnotherField__c';
+    const secondFieldMockValue = 'another value';
+
+    const previousLogEntry = logger.info('example log entry from before setField() is called').getComponentLogEntry();
+    logger.setField({
+      [firstFakeFieldName]: firstFieldMockValue,
+      [secondFakeFieldName]: secondFieldMockValue
+    });
+    const subsequentLogEntry = logger.info('example log entry from after setField() is called').getComponentLogEntry();
+
+    expect(previousLogEntry.fieldToValue[firstFakeFieldName]).toBeUndefined();
+    expect(previousLogEntry.fieldToValue[secondFakeFieldName]).toBeUndefined();
+    expect(subsequentLogEntry.fieldToValue[firstFakeFieldName]).toEqual(firstFieldMockValue);
+    expect(subsequentLogEntry.fieldToValue[secondFakeFieldName]).toEqual(secondFieldMockValue);
+  });
+
+  it('sets multiple custom entry fields on a single entry', async () => {
+    getSettings.mockResolvedValue({ ...MOCK_GET_SETTINGS });
+    const logger = getLogger();
+    // getLogger() is built to be sync, but internally, some async tasks must execute
+    // before some sync tasks are executed
+    await flushPromises('Resolve async task queue');
     const logEntryBuilder = logger.info('example log entry');
     const logEntry = logEntryBuilder.getComponentLogEntry();
     const firstFakeFieldName = 'SomeField__c';
@@ -586,7 +608,6 @@ describe('logger lwc recommended sync getLogger() import approach tests', () => 
     // getLogger() is built to be sync, but internally, some async tasks must execute
     // before some sync tasks are executed
     await flushPromises('Resolve async task queue');
-    await logger.getUserSettings();
     const logEntryBuilder = logger.info('example log entry');
     const logEntry = logEntryBuilder.getComponentLogEntry();
     expect(logEntry.recordId).toBeFalsy();
@@ -603,7 +624,6 @@ describe('logger lwc recommended sync getLogger() import approach tests', () => 
     // getLogger() is built to be sync, but internally, some async tasks must execute
     // before some sync tasks are executed
     await flushPromises('Resolve async task queue');
-    await logger.getUserSettings();
     const logEntryBuilder = logger.info('example log entry');
     const logEntry = logEntryBuilder.getComponentLogEntry();
     expect(logEntry.record).toBeFalsy();
@@ -620,7 +640,6 @@ describe('logger lwc recommended sync getLogger() import approach tests', () => 
     // getLogger() is built to be sync, but internally, some async tasks must execute
     // before some sync tasks are executed
     await flushPromises('Resolve async task queue');
-    await logger.getUserSettings();
     const logEntryBuilder = logger.info('example log entry');
     const logEntry = logEntryBuilder.getComponentLogEntry();
     expect(logEntry.error).toBeFalsy();
@@ -1147,7 +1166,29 @@ describe('logger lwc deprecated async createLogger() import tests', () => {
     expect(logEntry.browser.windowResolution).toEqual(window.innerWidth + ' x ' + window.innerHeight);
   });
 
-  it('sets multiple custom fields when using deprecated async createLogger() import approach', async () => {
+  it('sets multiple custom component fields on subsequent entries when using deprecated async createLogger() import approach', async () => {
+    getSettings.mockResolvedValue({ ...MOCK_GET_SETTINGS });
+    const logger = await createLogger();
+    await logger.getUserSettings();
+    const firstFakeFieldName = 'SomeField__c';
+    const firstFieldMockValue = 'something';
+    const secondFakeFieldName = 'AnotherField__c';
+    const secondFieldMockValue = 'another value';
+
+    const previousLogEntry = logger.info('example log entry from before setField() is called').getComponentLogEntry();
+    logger.setField({
+      [firstFakeFieldName]: firstFieldMockValue,
+      [secondFakeFieldName]: secondFieldMockValue
+    });
+    const subsequentLogEntry = logger.info('example log entry from after setField() is called').getComponentLogEntry();
+
+    expect(previousLogEntry.fieldToValue[firstFakeFieldName]).toBeUndefined();
+    expect(previousLogEntry.fieldToValue[secondFakeFieldName]).toBeUndefined();
+    expect(subsequentLogEntry.fieldToValue[firstFakeFieldName]).toEqual(firstFieldMockValue);
+    expect(subsequentLogEntry.fieldToValue[secondFakeFieldName]).toEqual(secondFieldMockValue);
+  });
+
+  it('sets multiple custom entry fields on a single entry when using deprecated async createLogger() import approach', async () => {
     getSettings.mockResolvedValue({ ...MOCK_GET_SETTINGS });
     const logger = await createLogger();
     await logger.getUserSettings();

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
@@ -23,6 +23,15 @@ export default class Logger extends LightningElement {
   }
 
   /**
+   * @description Sets multiple field values on the builder's `LogEntryEvent__e` record
+   * @param  {Object} fieldToValue An object containing the custom field name as a key, with the corresponding value to store.
+   *                      Example: `{"SomeField__c": "some value", "AnotherField__c": "another value"}`
+   */
+  setField(fieldToValue) {
+    this.#loggerService.setField(fieldToValue);
+  }
+
+  /**
    * @description Sets the scenario name for the current transaction - this is stored in `LogEntryEvent__e.Scenario__c`
    *              and `Log__c.Scenario__c`, and can be used to filter & group logs
    * @param  {String} scenario The name to use for the current transaction's scenario

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
@@ -10,7 +10,7 @@ import LoggerServiceTaskQueue from './loggerServiceTaskQueue';
 import getSettings from '@salesforce/apex/ComponentLogger.getSettings';
 import saveComponentLogEntries from '@salesforce/apex/ComponentLogger.saveComponentLogEntries';
 
-const CURRENT_VERSION_NUMBER = 'v4.14.13';
+const CURRENT_VERSION_NUMBER = 'v4.14.14';
 
 const CONSOLE_OUTPUT_CONFIG = {
   messagePrefix: `%c  Nebula Logger ${CURRENT_VERSION_NUMBER}  `,

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
@@ -49,6 +49,7 @@ export class BrowserContext {
 export default class LoggerService {
   static hasInitialized = false;
 
+  #componentFieldToValue = {};
   #componentLogEntries = [];
   #settings;
   #scenario;
@@ -67,6 +68,17 @@ export default class LoggerService {
   // TODO deprecate? Or make it async?
   getUserSettings() {
     return this.#settings;
+  }
+
+  /**
+   * @description Sets multiple field values on every generated `LogEntryEvent__e` record
+   * @param  {Object} fieldToValue An object containing the custom field name as a key, with the corresponding value to store.
+   *                      Example: `{"SomeField__c": "some value", "AnotherField__c": "another value"}`
+   */
+  setField(fieldToValue) {
+    if (!!fieldToValue && typeof fieldToValue === 'object' && !Array.isArray(fieldToValue)) {
+      Object.assign(this.#componentFieldToValue, fieldToValue);
+    }
   }
 
   setScenario(scenario) {
@@ -176,6 +188,7 @@ export default class LoggerService {
       .setMessage(message)
       .setScenario(this.#scenario);
     const logEntry = logEntryBuilder.getComponentLogEntry();
+    Object.assign(logEntry.fieldToValue, this.#componentFieldToValue);
 
     const loggingLevelCheckTask = providedLoggingLevel => {
       if (this._meetsUserLoggingLevel(providedLoggingLevel)) {

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -1019,6 +1019,66 @@ private class Logger_Tests {
     System.Assert.isNull(Logger.getParentLogTransactionId());
   }
 
+  // Start setField() test methods
+  @IsTest
+  static void it_should_set_single_transaction_field_on_all_entries_when_events_published() {
+    LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+    System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+    // HttpRequestBody__c is used as an example here since it's provided out of the box, and doesn't
+    // have a default value set.
+    // But realisticially, this functionality is intended to be used with custom fields that are added to
+    // Nebula Logger's data model.
+    Schema.SObjectField field = Schema.LogEntryEvent__e.HttpRequestBody__c;
+    String fieldValue = 'Some_value';
+    Integer countOfEntriesToAdd = 3;
+
+    for (Integer i = 0; i < countOfEntriesToAdd; i++) {
+      LogEntryEventBuilder builder = Logger.info('hello, world');
+      System.Assert.isNull(builder.getLogEntryEvent().get(field), 'Field ' + field + ' should be null until the event is published');
+      // Call setField() after some entries have been added (and before other entries are added)
+      // to ensure that all entries have the fields populated on publish
+      if (i == 1) {
+        Logger.setField(field, fieldValue);
+      }
+    }
+    Logger.saveLog();
+
+    System.Assert.areEqual(countOfEntriesToAdd, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+    for (LogEntryEvent__e publishedLogEntryEvent : (List<LogEntryEvent__e>) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents()) {
+      System.Assert.areEqual(fieldValue, publishedLogEntryEvent.get(field));
+    }
+  }
+
+  @IsTest
+  static void it_should_set_map_of_transaction_fields_on_all_entries_when_events_published() {
+    LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+    System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+    // HttpRequestBody__c is used as an example here since it's provided out of the box, and doesn't
+    // have a default value set.
+    // But realisticially, this functionality is intended to be used with custom fields that are added to
+    // Nebula Logger's data model.
+    Schema.SObjectField field = Schema.LogEntryEvent__e.HttpRequestBody__c;
+    String fieldValue = 'Some_value';
+    Integer countOfEntriesToAdd = 3;
+
+    for (Integer i = 0; i < countOfEntriesToAdd; i++) {
+      LogEntryEventBuilder builder = Logger.info('hello, world');
+      System.Assert.isNull(builder.getLogEntryEvent().get(field), 'Field ' + field + ' should be null until the event is published');
+      // Call setField() after some entries have been added (and before other entries are added)
+      // to ensure that all entries have the fields populated on publish
+      if (i == 1) {
+        Logger.setField(new Map<Schema.SObjectField, Object>{ field => fieldValue });
+      }
+    }
+    Logger.saveLog();
+
+    System.Assert.areEqual(countOfEntriesToAdd, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+    for (LogEntryEvent__e publishedLogEntryEvent : (List<LogEntryEvent__e>) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents()) {
+      System.Assert.areEqual(fieldValue, publishedLogEntryEvent.get(field));
+    }
+  }
+  // End setField() test methods
+
   @IsTest
   static void it_should_return_quiddity_level() {
     List<System.Quiddity> acceptableDefaultQuidditiesForTests = new List<System.Quiddity>{

--- a/nebula-logger/recipes/lwc/loggerLWCCreateLoggerImportDemo/__tests__/loggerLWCCreateLoggerImportDemo.test.js
+++ b/nebula-logger/recipes/lwc/loggerLWCCreateLoggerImportDemo/__tests__/loggerLWCCreateLoggerImportDemo.test.js
@@ -1,4 +1,5 @@
 import { createElement } from 'lwc';
+import { getLogger } from 'c/logger';
 import loggerLWCCreateLoggerImportDemo from 'c/loggerLWCCreateLoggerImportDemo';
 
 import getSettings from '@salesforce/apex/ComponentLogger.getSettings';
@@ -14,6 +15,10 @@ const MOCK_GET_SETTINGS = {
   supportedLoggingLevels: { FINEST: 2, FINER: 3, FINE: 4, DEBUG: 5, INFO: 6, WARN: 7, ERROR: 8 },
   userLoggingLevel: { ordinal: 2, name: 'FINEST' }
 };
+
+jest.mock('lightning/logger', () => ({ log: jest.fn() }), {
+  virtual: true
+});
 
 jest.mock(
   '@salesforce/apex/ComponentLogger.getSettings',
@@ -36,10 +41,11 @@ describe('logger demo tests', () => {
   it('mounts and saves log correctly in one go', async () => {
     getSettings.mockResolvedValue({ ...MOCK_GET_SETTINGS });
     const demo = createElement('c-logger-demo', { is: loggerLWCCreateLoggerImportDemo });
+
     document.body.appendChild(demo);
+    await flushPromises('Resolve async tasks from mounting component');
 
-    await flushPromises();
-
-    expect(demo.logger?.getBufferSize()).toBe(0);
+    expect(demo.logger).toBeDefined();
+    expect(demo.logger.getBufferSize()).toBe(0);
   });
 });

--- a/nebula-logger/recipes/lwc/loggerLWCCreateLoggerImportDemo/loggerLWCCreateLoggerImportDemo.js
+++ b/nebula-logger/recipes/lwc/loggerLWCCreateLoggerImportDemo/loggerLWCCreateLoggerImportDemo.js
@@ -4,20 +4,21 @@
 //------------------------------------------------------------------------------------------------//
 
 /* eslint-disable no-console */
-import { LightningElement, wire } from 'lwc';
+import { LightningElement, api, wire } from 'lwc';
 import returnSomeString from '@salesforce/apex/LoggerLWCDemoController.returnSomeString';
 import throwSomeError from '@salesforce/apex/LoggerLWCDemoController.throwSomeError';
 import { createLogger } from 'c/logger';
 
 export default class LoggerLWCCreateLoggerImportDemo extends LightningElement {
-  someBoolean = false;
+  @api logger;
 
   message = 'Hello, world!';
   scenario = 'Some demo scenario';
+  someBoolean = false;
   tagsString = 'Tag-one, Another tag here';
-  logger;
 
   async connectedCallback() {
+    /* eslint-disable-next-line @lwc/lwc/no-api-reassignments */
     this.logger = await createLogger();
     console.log('>>> start of connectedCallback()');
     try {

--- a/nebula-logger/recipes/lwc/loggerLWCGetLoggerImportDemo/__tests__/loggerLWCGetLoggerImportDemo.test.js
+++ b/nebula-logger/recipes/lwc/loggerLWCGetLoggerImportDemo/__tests__/loggerLWCGetLoggerImportDemo.test.js
@@ -15,6 +15,10 @@ const MOCK_GET_SETTINGS = {
   userLoggingLevel: { ordinal: 2, name: 'FINEST' }
 };
 
+jest.mock('lightning/logger', () => ({ log: jest.fn() }), {
+  virtual: true
+});
+
 jest.mock(
   '@salesforce/apex/ComponentLogger.getSettings',
   () => {
@@ -36,10 +40,11 @@ describe('logger demo tests', () => {
   it('mounts and saves log correctly in one go', async () => {
     getSettings.mockResolvedValue({ ...MOCK_GET_SETTINGS });
     const demo = createElement('c-logger-demo', { is: loggerLWCGetLoggerImportDemo });
+
     document.body.appendChild(demo);
+    await flushPromises('Resolve async tasks from mounting component');
 
-    await flushPromises();
-
-    expect(demo.logger?.getBufferSize()).toBe(0);
+    expect(demo.logger).toBeDefined();
+    expect(demo.logger.getBufferSize()).toBe(0);
   });
 });

--- a/nebula-logger/recipes/lwc/loggerLWCGetLoggerImportDemo/loggerLWCGetLoggerImportDemo.js
+++ b/nebula-logger/recipes/lwc/loggerLWCGetLoggerImportDemo/loggerLWCGetLoggerImportDemo.js
@@ -4,18 +4,18 @@
 //------------------------------------------------------------------------------------------------//
 
 /* eslint-disable no-console */
-import { LightningElement, wire } from 'lwc';
+import { LightningElement, api, wire } from 'lwc';
 import returnSomeString from '@salesforce/apex/LoggerLWCDemoController.returnSomeString';
 import throwSomeError from '@salesforce/apex/LoggerLWCDemoController.throwSomeError';
 import { getLogger } from 'c/logger';
 
 export default class LoggerLWCGetLoggerImportDemo extends LightningElement {
-  someBoolean = false;
+  @api logger = getLogger();
 
   message = 'Hello, world!';
   scenario = 'Some demo scenario';
+  someBoolean = false;
   tagsString = 'Tag-one, Another tag here';
-  logger = getLogger();
 
   connectedCallback() {
     try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebula-logger",
-  "version": "4.14.13",
+  "version": "4.14.14",
   "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
   "author": "Jonathan Gillespie",
   "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -10,8 +10,8 @@
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "scopeProfiles": true,
       "versionNumber": "4.14.14.NEXT",
-      "versionName": "New Apex Static Method Logger.setField()",
-      "versionDescription": "Added a new Apex static method Logger.setField() so custom fields can be set once per transaction --> auto-populated on all LogEntryEvent__e records",
+      "versionName": "New Apex Static Method & JavaScript Function Logger.setField()",
+      "versionDescription": "Added a new Apex static method Logger.setField() and LWC function logger.setField() so custom fields can be set once --> auto-populated on all subsequent LogEntryEvent__e records",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {
         "path": "./nebula-logger/extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
       "path": "./nebula-logger/core",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "scopeProfiles": true,
-      "versionNumber": "4.14.13.NEXT",
-      "versionName": "New getLogger() JS Function",
-      "versionDescription": "Added a new function getLogger() in c/logger that can be called synchronously (createLogger() was async). This simplifies how developers use it, and avoids some lingering JS stack trace issues that occur in async functions.",
+      "versionNumber": "4.14.14.NEXT",
+      "versionName": "New Apex Static Method Logger.setField()",
+      "versionDescription": "Added a new Apex static method Logger.setField() so custom fields can be set once per transaction --> auto-populated on all LogEntryEvent__e records",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {
         "path": "./nebula-logger/extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -198,6 +198,7 @@
     "Nebula Logger - Core@4.14.11-updated-behavior-of-logger.setasynccontext()": "04t5Y0000015oUgQAI",
     "Nebula Logger - Core@4.14.12-replaced-httprequestendpoint__c-with-httprequestendpointaddress__c": "04t5Y0000015oV0QAI",
     "Nebula Logger - Core@4.14.13-new-getlogger()-js-function": "04t5Y0000015oW3QAI",
+    "Nebula Logger - Core@4.14.14-new-apex-static-method-&-javascript-function-logger.setfield()": "04t5Y0000015oWIQAY",
     "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
## New Apex Method `Logger.setField()`
Resolved #769 by adding a new static method, `Logger.setField()`. This gives Apex developers a way to set field(s) once per transaction, and the fields will be auto-populated on all `LogEntryEvent__e` records generated in that transaction.
- The `setField()` method has 2 overloads (same as the instance method overloads `LogEntryEventBuilder.setField()` that were introduced in [release `v4.13.14`](https://github.com/jongpie/NebulaLogger/releases/tag/v4.13.14))
  1. `Logger.setField(Schema.SObjectField field, Object fieldValue)` - useful for easily setting the value for a single field
  2. `Logger.setField(Map<Schema.SObjectField, Object> fieldToValue)` - useful for setting the value for multiple fields
- The new method supplements the functionality introduced in [release `v4.13.14`](https://github.com/jongpie/NebulaLogger/releases/tag/v4.13.14), as shown below:

  ```apex
  // 🥳New!
  // Set a custom field on all LogEntryEvent__e records in a transaction,
  // using static method Logger.setField()
  Logger.setField(LogEntryEvent__e.My_Custom_Log_Field__c, 'the value for some Log__c field')

  // ℹ️Existing - introduced in v4.13.14
  // Set a custom field on a single LogEntryEvent__e record,
  // using instance method LogEntryEventBuilder.setField()
  Logger.info('hello, world')
    .setField(LogEntryEvent__e.Some_Custom_Log_Entry_Field__c, 'the value for some LogEntry__c field');
  ```

## New JavaScript Function `logger.setField()`
Added JavaScript support for setting fields once per component instance, using `logger.setField()`. This is the JS equivalent of the new Apex method `Logger.setField()` (above).

  ```javascript
  export default class LoggerLWCImportDemo extends LightningElement {
    logger = getLogger();

    connectedCallback() {
      // 🥳New!
      // Set My_Field__c on every log entry event created in this component with the same value
      this.logger.setField({My_Field__c, 'some value that applies to any subsequent entry'});

        // ℹ️Existing - introduced in v4.14.6
      this.logger.warn('hello, world - "a value" set for Some_Other_Field__c').setField({ Some_Other_Field__c: 'a value' });
    }
  }
  ```