### PR TITLE
Deprecated & replaced HttpRequestEndpoint__c fields with new HttpRequestEndpointAddress__c fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust observability solution for Salesforce experts. Built 100% natively on the platform, and designed to work seamlessly with Apex, Lightning Components, Flow, Process Builder & integrations.
 
-## Unlocked Package - v4.14.11
+## Unlocked Package - v4.14.12
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oUgQAI)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oUgQAI)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust observability solution for Salesforce experts. Built 100% native
 
 ## Unlocked Package - v4.14.12
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oUgQAI)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oUgQAI)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oV0QAI)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oV0QAI)
 [![View Documentation](./images/btn-view-documentation.png)](https://github.com/jongpie/NebulaLogger/wiki)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oUgQAI`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oV0QAI`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015oUgQAI`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015oV0QAI`
 
 ---
 

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
@@ -285,6 +285,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
         HttpRequestBodyMasked__c = logEntryEvent.HttpRequestBodyMasked__c,
         HttpRequestCompressed__c = logEntryEvent.HttpRequestCompressed__c,
         HttpRequestEndpoint__c = logEntryEvent.HttpRequestEndpoint__c,
+        HttpRequestEndpointAddress__c = logEntryEvent.HttpRequestEndpointAddress__c,
         HttpRequestHeaderKeys__c = logEntryEvent.HttpRequestHeaderKeys__c,
         HttpRequestHeaders__c = logEntryEvent.HttpRequestHeaders__c,
         HttpRequestMethod__c = logEntryEvent.HttpRequestMethod__c,

--- a/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
@@ -1137,6 +1137,16 @@
                     <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
+                <fieldItem>Record.HttpRequestEndpointAddress__c</fieldItem>
+                <identifier>RecordHttpRequestEndpointAddress_cField1</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>readonly</value>
+                </fieldInstanceProperties>
                 <fieldItem>Record.HttpRequestMethod__c</fieldItem>
                 <identifier>RecordHttpRequestMethod_cField1</identifier>
             </fieldInstance>

--- a/nebula-logger/core/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
+++ b/nebula-logger/core/main/log-management/layouts/LogEntry__c-Log Entry Layout.layout-meta.xml
@@ -354,6 +354,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Readonly</behavior>
+                <field>HttpRequestEndpointAddress__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
                 <field>HttpRequestMethod__c</field>
             </layoutItems>
             <layoutItems>

--- a/nebula-logger/core/main/log-management/lwc/logBatchPurge/__tests__/data/getSchemaForName.logEntry.json
+++ b/nebula-logger/core/main/log-management/lwc/logBatchPurge/__tests__/data/getSchemaForName.logEntry.json
@@ -221,6 +221,12 @@
       "localApiName": "HttpRequestEndpoint__c",
       "type": "string"
     },
+    "HttpRequestEndpointAddress__c": {
+      "apiName": "HttpRequestEndpointAddress__c",
+      "label": "HTTP Request Endpoint Address",
+      "localApiName": "HttpRequestEndpointAddress__c",
+      "type": "string"
+    },
     "HttpRequestMethod__c": {
       "apiName": "HttpRequestMethod__c",
       "label": "HTTP Request Method",

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HttpRequestEndpointAddress__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HttpRequestEndpointAddress__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HttpRequestEndpointAddress__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>PII;GDPR;CCPA</complianceGroup>
+    <label>HTTP Request Endpoint Address</label>
+    <length>2000</length>
+    <securityClassification>Confidential</securityClassification>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HttpRequestEndpoint__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/HttpRequestEndpoint__c.field-meta.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>HttpRequestEndpoint__c</fullName>
-    <businessStatus>Active</businessStatus>
+    <businessStatus>DeprecateCandidate</businessStatus>
     <complianceGroup>None</complianceGroup>
     <externalId>false</externalId>
-    <label>HTTP Request Endpoint</label>
+    <inlineHelpText>Deprecated: instead use the field HttpRequestEndpointAddress__c</inlineHelpText>
+    <label>DEPRECATED: HTTP Request Endpoint</label>
     <length>255</length>
     <required>false</required>
     <securityClassification>Confidential</securityClassification>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -573,6 +573,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.HttpRequestEndpointAddress__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.HttpRequestHeaderKeys__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -493,6 +493,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.HttpRequestEndpointAddress__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.HttpRequestHeaderKeys__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -502,7 +502,11 @@ global with sharing class LogEntryEventBuilder {
     this.logEntryEvent.HttpRequestBody__c = cleanedRequestBody;
     this.logEntryEvent.HttpRequestBodyMasked__c = requestBodyMasked;
     this.logEntryEvent.HttpRequestCompressed__c = request.getCompressed();
-    this.logEntryEvent.HttpRequestEndpoint__c = request.getEndpoint();
+    this.logEntryEvent.HttpRequestEndpoint__c = LoggerDataStore.truncateFieldValue(Schema.LogEntryEvent__e.HttpRequestEndpoint__c, request.getEndpoint());
+    this.logEntryEvent.HttpRequestEndpointAddress__c = LoggerDataStore.truncateFieldValue(
+      Schema.LogEntryEvent__e.HttpRequestEndpointAddress__c,
+      request.getEndpoint()
+    );
     this.logEntryEvent.HttpRequestHeaderKeys__c = formattedHeaderKeysString;
     this.logEntryEvent.HttpRequestHeaders__c = LoggerDataStore.truncateFieldValue(Schema.LogEntryEvent__e.HttpRequestHeaders__c, formattedHeadersString);
     this.logEntryEvent.HttpRequestMethod__c = request.getMethod();

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
   // There's no reliable way to get the version number dynamically in Apex
   @TestVisible
-  private static final String CURRENT_VERSION_NUMBER = 'v4.14.11';
+  private static final String CURRENT_VERSION_NUMBER = 'v4.14.12';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
   private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logEntryBuilder.js
@@ -6,7 +6,7 @@ import FORM_FACTOR from '@salesforce/client/formFactor';
 import { log as lightningLog } from 'lightning/logger';
 import { LoggerStackTrace } from './loggerStackTrace';
 
-const CURRENT_VERSION_NUMBER = 'v4.14.11';
+const CURRENT_VERSION_NUMBER = 'v4.14.12';
 
 const LOGGING_LEVEL_EMOJIS = {
   ERROR: '⛔',

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/HttpRequestEndpointAddress__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/HttpRequestEndpointAddress__c.field-meta.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>HttpRequestEndpoint__c</fullName>
-    <businessStatus>DeprecateCandidate</businessStatus>
+    <fullName>HttpRequestEndpointAddress__c</fullName>
+    <businessStatus>Active</businessStatus>
     <complianceGroup>None</complianceGroup>
-    <externalId>false</externalId>
     <isFilteringDisabled>false</isFilteringDisabled>
     <isNameField>false</isNameField>
     <isSortingDisabled>false</isSortingDisabled>
-    <label>DEPRECATED: HTTP Request Endpoint</label>
-    <length>255</length>
-    <required>false</required>
+    <label>HTTP Request Endpoint Address</label>
+    <length>2000</length>
     <securityClassification>Confidential</securityClassification>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
 </CustomField>

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -1386,6 +1386,7 @@ private class LogEntryEventHandler_Tests {
             HttpRequestBodyMasked__c,
             HttpRequestCompressed__c,
             HttpRequestEndpoint__c,
+            HttpRequestEndpointAddress__c,
             HttpRequestHeaderKeys__c,
             HttpRequestHeaders__c,
             HttpRequestMethod__c,
@@ -1616,6 +1617,11 @@ private class LogEntryEventHandler_Tests {
     System.Assert.areEqual(logEntryEvent.HttpRequestBodyMasked__c, logEntry.HttpRequestBodyMasked__c, 'logEntry.HttpRequestBodyMasked__c was not properly set');
     System.Assert.areEqual(logEntryEvent.HttpRequestCompressed__c, logEntry.HttpRequestCompressed__c, 'logEntry.HttpRequestCompressed__c was not properly set');
     System.Assert.areEqual(logEntryEvent.HttpRequestEndpoint__c, logEntry.HttpRequestEndpoint__c, 'logEntry.HttpRequestEndpoint__c was not properly set');
+    System.Assert.areEqual(
+      logEntryEvent.HttpRequestEndpointAddress__c,
+      logEntry.HttpRequestEndpointAddress__c,
+      'logEntry.HttpRequestEndpointAddress__c was not properly set'
+    );
     System.Assert.areEqual(logEntryEvent.HttpRequestHeaderKeys__c, logEntry.HttpRequestHeaderKeys__c, 'logEntry.HttpRequestHeaderKeys__c was not properly set');
     System.Assert.areEqual(logEntryEvent.HttpRequestHeaders__c, logEntry.HttpRequestHeaders__c, 'logEntry.HttpRequestHeaders__c was not properly set');
     System.Assert.areEqual(logEntryEvent.HttpRequestMethod__c, logEntry.HttpRequestMethod__c, 'logEntry.HttpRequestMethod__c was not properly set');

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -1280,14 +1280,20 @@ private class LogEntryEventBuilder_Tests {
     System.HttpRequest request = new System.HttpRequest();
     request.setBody('Hello, world!');
     request.setCompressed(true);
-    request.setEndpoint('https://fake.salesforce.com');
+
+    String reallyLongEndpointAddress = 'https://fake.salesforce.com/' + 'A'.repeat(LogEntryEvent__e.HttpRequestEndpoint__c.getDescribe().getLength() + 1);
+    request.setEndpoint(reallyLongEndpointAddress);
     request.setMethod('GET');
 
     builder.setHttpRequestDetails(request);
 
     System.Assert.areEqual(request.getBody(), event.HttpRequestBody__c);
     System.Assert.areEqual(request.getCompressed(), event.HttpRequestCompressed__c);
-    System.Assert.areEqual(request.getEndpoint(), event.HttpRequestEndpoint__c);
+    System.Assert.areEqual(reallyLongEndpointAddress.left(LogEntryEvent__e.HttpRequestEndpoint__c.getDescribe().getLength()), event.HttpRequestEndpoint__c);
+    System.Assert.areEqual(
+      reallyLongEndpointAddress.left(LogEntryEvent__e.HttpRequestEndpointAddress__c.getDescribe().getLength()),
+      event.HttpRequestEndpointAddress__c
+    );
     System.Assert.isNull(event.HttpRequestHeaderKeys__c);
     System.Assert.isNull(event.HttpRequestHeaders__c);
     System.Assert.areEqual(request.getMethod(), event.HttpRequestMethod__c);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebula-logger",
-  "version": "4.14.11",
+  "version": "4.14.12",
   "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
   "author": "Jonathan Gillespie",
   "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
       "path": "./nebula-logger/core",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "scopeProfiles": true,
-      "versionNumber": "4.14.11.NEXT",
-      "versionName": "Updated Behavior of Logger.setAsyncContext()",
-      "versionDescription": "Updated the behavior of Logger.setAsyncContext() to only set the context the first time a non-null context value is provided. Previously, subsequent calls would overwrite the context value, which wasn't really the intended behaviour.",
+      "versionNumber": "4.14.12.NEXT",
+      "versionName": "Replaced HttpRequestEndpoint__c with HttpRequestEndpointAddress__c",
+      "versionDescription": "Deprecated the HttpRequestEndpoint__c fields on LogEntryEvent__e and LogEntry__c, and replaced them with new HttpRequestEndpointAddress__c fields that have a much longer max length (2,000 vs 255)",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {
         "path": "./nebula-logger/extra-tests"

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -196,6 +196,7 @@
     "Nebula Logger - Core@4.14.9-bugfix:-apex-code-snippets-auto-truncated": "04t5Y0000015oSQQAY",
     "Nebula Logger - Core@4.14.10-new-callablelogger-apex-class": "04t5Y0000015oTdQAI",
     "Nebula Logger - Core@4.14.11-updated-behavior-of-logger.setasynccontext()": "04t5Y0000015oUgQAI",
+    "Nebula Logger - Core@4.14.12-replaced-httprequestendpoint__c-with-httprequestendpointaddress__c": "04t5Y0000015oV0QAI",
     "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
Fixed #768 by deprecating the `HttpRequestEndpoint__c` fields on `LogEntryEvent__e` and `LogEntry__c`, and replaced them with new `HttpRequestEndpointAddress__c` fields that have a much longer max length (2,000 vs 255).
- `HttpRequestEndpoint__c` fields are now considered deprecated since they're not capable of storing the full value of long endpoints
  - The `HttpRequestEndpoint__c` fields will continue to be populated for the time being, and the value is now auto-truncated to 255 characters to fix the `STRING_TOO_LONG` error that was reported in #768
  - The `businessStatus` on the fields has been updated to `DeprecateCandidate`
  - The `inlineHelpText` on the fields has been update to `Deprecated: instead use the field HttpRequestEndpointAddress__c`
  - The `label` on the fields has been update to `DEPRECATED: HTTP Request Endpoint`
- Updated `LogEntryRecordPage` flexipage to have both `HttpRequestEndpoint__c` (existing) and `HttpRequestEndpointAddress__c` fields
  - Both fields will be shown for now, and eventually `HttpRequestEndpoint__c` will be removed

Related context: this is essentially the same issue & solution used in [release `v4.13.15`](https://github.com/jongpie/NebulaLogger/releases/tag/v4.13.15) for the now-deprecated text(255) fields `BrowserUrl__c` not being long enough, and they were replaced with new long textarea(2000) field `BrowserAddress__c` (PR #720). It's probably worth reviewing all of the text fields in the data model (especially some of the older fields) to see if it would make sense to take the same approach for any other existing fields.