### PR TITLE
Slightly tweaks async context to account for additional finalizer fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust observability solution for Salesforce experts. Built 100% native
 
 ## Unlocked Package - v4.14.15
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oWIQAY)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oWIQAY)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015obxQAA)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015obxQAA)
 [![View Documentation](./images/btn-view-documentation.png)](https://github.com/jongpie/NebulaLogger/wiki)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oWIQAY`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015obxQAA`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015oWIQAY`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015obxQAA`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust observability solution for Salesforce experts. Built 100% natively on the platform, and designed to work seamlessly with Apex, Lightning Components, Flow, OmniStudio, and integrations.
 
-## Unlocked Package - v4.14.14
+## Unlocked Package - v4.14.15
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oWIQAY)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oWIQAY)

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -3586,13 +3586,31 @@ global with sharing class Logger {
 
   // Inner class for tracking details about the current transaction's async context
   @SuppressWarnings('PMD.ApexDoc')
+  @TestVisible
   private class AsyncContext {
     public final String type;
     public final String parentJobId;
     public final String childJobId;
     public final String triggerId;
     public final String finalizerResult;
-    public final Exception finalizerException;
+    // Instances of Exception can't be serialized, but instances of AsyncContext
+    // are sometimes serialized - so, the AsyncContext's Exception is transient,
+    // and an extra getter for Map<String, Object>, containing the exception's data,
+    // is used to provide a quick & easy serializable version
+    public transient final Exception finalizerException;
+    public Map<String, Object> finalizerUnhandledException {
+      get {
+        return finalizerException == null
+          ? null
+          : new Map<String, Object>{
+              'cause' => this.finalizerException.getCause(),
+              'lineNumber' => this.finalizerException.getLineNumber(),
+              'message' => this.finalizerException.getMessage(),
+              'stackTraceString' => this.finalizerException.getStackTraceString(),
+              'typeName' => this.finalizerException.getTypeName()
+            };
+      }
+    }
 
     public AsyncContext(Database.BatchableContext batchableContext) {
       this.childJobId = batchableContext?.getChildJobId();
@@ -3603,7 +3621,7 @@ global with sharing class Logger {
     public AsyncContext(System.FinalizerContext finalizerContext) {
       if (finalizerContext != null) {
         this.finalizerException = finalizerContext.getException();
-        this.finalizerResult = finalizerContext.getResult().name();
+        this.finalizerResult = finalizerContext.getResult()?.name();
         this.parentJobId = finalizerContext.getAsyncApexJobId();
       }
       this.type = System.FinalizerContext.class.getName();

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -3473,7 +3473,7 @@ global with sharing class Logger {
     // intended behavior
     if (currentAsyncContext == null) {
       currentAsyncContext = asyncContext;
-      System.debug(System.LoggingLevel.INFO, 'Nebula Logger - Async Context: ' + System.JSON.serializePretty(asyncContext));
+      info('Nebula Logger - Async Context: ' + System.JSON.serializePretty(asyncContext, true));
     }
   }
 
@@ -3589,6 +3589,8 @@ global with sharing class Logger {
     public final String parentJobId;
     public final String childJobId;
     public final String triggerId;
+    public final String finalizerResult;
+    public final String finalizerException;
 
     public AsyncContext(Database.BatchableContext batchableContext) {
       this.childJobId = batchableContext?.getChildJobId();
@@ -3597,7 +3599,11 @@ global with sharing class Logger {
     }
 
     public AsyncContext(System.FinalizerContext finalizerContext) {
-      this.parentJobId = finalizerContext?.getAsyncApexJobId();
+      if (finalizerContext != null) {
+        this.finalizerException = finalizerContext.getException()?.getMessage() + '\n' + finalizerContext.getException()?.getStackTraceString() ?? null;
+        this.finalizerResult = finalizerContext.getResult().name();
+        this.parentJobId = finalizerContext.getAsyncApexJobId();
+      }
       this.type = System.FinalizerContext.class.getName();
     }
 

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
   // There's no reliable way to get the version number dynamically in Apex
   @TestVisible
-  private static final String CURRENT_VERSION_NUMBER = 'v4.14.14';
+  private static final String CURRENT_VERSION_NUMBER = 'v4.14.15';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
   private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';
@@ -3473,7 +3473,9 @@ global with sharing class Logger {
     // intended behavior
     if (currentAsyncContext == null) {
       currentAsyncContext = asyncContext;
-      info('Nebula Logger - Async Context: ' + System.JSON.serializePretty(asyncContext, true));
+      if (LoggerParameter.ENABLE_SYSTEM_MESSAGES) {
+        info('Nebula Logger - Async Context: ' + System.JSON.serializePretty(asyncContext, true)).setExceptionDetails(asyncContext.finalizerException);
+      }
     }
   }
 
@@ -3590,7 +3592,7 @@ global with sharing class Logger {
     public final String childJobId;
     public final String triggerId;
     public final String finalizerResult;
-    public final String finalizerException;
+    public final Exception finalizerException;
 
     public AsyncContext(Database.BatchableContext batchableContext) {
       this.childJobId = batchableContext?.getChildJobId();
@@ -3600,7 +3602,7 @@ global with sharing class Logger {
 
     public AsyncContext(System.FinalizerContext finalizerContext) {
       if (finalizerContext != null) {
-        this.finalizerException = finalizerContext.getException()?.getMessage() + '\n' + finalizerContext.getException()?.getStackTraceString() ?? null;
+        this.finalizerException = finalizerContext.getException();
         this.finalizerResult = finalizerContext.getResult().name();
         this.parentJobId = finalizerContext.getAsyncApexJobId();
       }

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
@@ -10,7 +10,7 @@ import LoggerServiceTaskQueue from './loggerServiceTaskQueue';
 import getSettings from '@salesforce/apex/ComponentLogger.getSettings';
 import saveComponentLogEntries from '@salesforce/apex/ComponentLogger.saveComponentLogEntries';
 
-const CURRENT_VERSION_NUMBER = 'v4.14.14';
+const CURRENT_VERSION_NUMBER = 'v4.14.15';
 
 const CONSOLE_OUTPUT_CONFIG = {
   messagePrefix: `%c  Nebula Logger ${CURRENT_VERSION_NUMBER}  `,

--- a/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
+++ b/nebula-logger/core/tests/configuration/utilities/LoggerMockDataCreator.cls
@@ -323,7 +323,7 @@ public class LoggerMockDataCreator {
   public static Schema.Organization getOrganization() {
     // TODO Switch to creating mock instance of Schema.Organization with sensible defaults that tests can then update as needed for different scenarios
     if (cachedOrganization == null) {
-      cachedOrganization = [SELECT Id, Name, InstanceName, IsSandbox, NamespacePrefix, OrganizationType, TrialExpirationDate FROM Organization];
+      cachedOrganization = [SELECT Id, Name, InstanceName, IsSandbox, NamespacePrefix, OrganizationType, TrialExpirationDate FROM Organization LIMIT 1];
     }
     return cachedOrganization;
   }
@@ -457,6 +457,7 @@ public class LoggerMockDataCreator {
 
   @SuppressWarnings('PMD.ApexDoc')
   public class MockFinalizerContext implements System.FinalizerContext {
+    private Exception apexException;
     private Id asyncApexJobId;
 
     public MockFinalizerContext() {
@@ -467,19 +468,24 @@ public class LoggerMockDataCreator {
       this.asyncApexJobId = asyncApexJobId;
     }
 
+    public MockFinalizerContext(Exception ex) {
+      this();
+      this.apexException = ex;
+    }
+
     public Id getAsyncApexJobId() {
       return this.asyncApexJobId;
     }
 
     public Exception getException() {
-      return null;
+      return this.apexException;
     }
 
     public System.ParentJobResult getResult() {
-      return System.ParentJobResult.SUCCESS;
+      return this.apexException == null ? System.ParentJobResult.SUCCESS : System.ParentJobResult.UNHANDLED_EXCEPTION;
     }
 
-    public Id getRequestId() {
+    public String getRequestId() {
       return System.Request.getCurrent().getRequestId();
     }
   }

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -826,6 +826,41 @@ private class Logger_Tests {
   }
 
   @IsTest
+  static void it_should_auto_create_log_entry_event_for_batchable_async_context_details_when_system_messages_are_enabled() {
+    Database.BatchableContext mockContext = new LoggerMockDataCreator.MockBatchableContext();
+    LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+    LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'EnableLoggerSystemMessages', Value__c = 'true'));
+    System.Assert.isTrue(LoggerParameter.ENABLE_SYSTEM_MESSAGES, 'System messages should be enabled');
+    System.Assert.areEqual(0, Logger.getBufferSize());
+    System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+
+    Logger.setAsyncContext(mockContext);
+    Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
+
+    System.Assert.areEqual(0, Logger.getBufferSize());
+    Integer publishedEventsCount = LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size();
+    System.Assert.isTrue(
+      publishedEventsCount >= 1,
+      publishedEventsCount +
+        ' events published, but at least 1 should have been auto-created & published\n\n' +
+        System.JSON.serializePretty(LoggerMockDataStore.getEventBus().getPublishedPlatformEvents())
+    );
+    LogEntryEvent__e expectedLogEntryEvent = new LogEntryEvent__e(
+      LoggingLevel__c = System.LoggingLevel.INFO.name(),
+      Message__c = 'Nebula Logger - Async Context: ' + System.JSON.serializePretty(new Logger.AsyncContext(mockContext), true)
+    );
+    List<LogEntryEvent__e> matchingPublishedLogEntryEvents = (List<LogEntryEvent__e>) LoggerMockDataStore.getEventBus()
+      .getMatchingPublishedPlatformEvents(expectedLogEntryEvent);
+    System.Assert.areEqual(1, matchingPublishedLogEntryEvents.size());
+    LogEntryEvent__e matchingPublishedLogEntryEvent = matchingPublishedLogEntryEvents.get(0);
+    System.Assert.areEqual(Database.BatchableContext.class.getName(), matchingPublishedLogEntryEvent.AsyncContextType__c);
+    System.Assert.areEqual(expectedLogEntryEvent.LoggingLevel__c, matchingPublishedLogEntryEvent.LoggingLevel__c);
+    System.Assert.areEqual(expectedLogEntryEvent.Message__c, matchingPublishedLogEntryEvent.Message__c);
+    System.Assert.isNull(matchingPublishedLogEntryEvent.ExceptionMessage__c);
+    System.Assert.isNull(matchingPublishedLogEntryEvent.ExceptionType__c);
+  }
+
+  @IsTest
   static void it_should_set_async_context_details_for_finalizer_context_when_event_published() {
     Id mockParentAsyncApexJobId = LoggerMockDataCreator.createId(Schema.AsyncApexJob.SObjectType);
     System.FinalizerContext mockContext = new LoggerMockDataCreator.MockFinalizerContext(mockParentAsyncApexJobId);
@@ -882,6 +917,81 @@ private class Logger_Tests {
     System.Assert.areEqual(firstNonNullMockContext.getAsyncApexJobId(), logEntryEvent.AsyncContextParentJobId__c);
     System.Assert.isNull(logEntryEvent.AsyncContextTriggerId__c);
     System.Assert.areEqual(System.FinalizerContext.class.getName(), logEntryEvent.AsyncContextType__c);
+  }
+
+  @IsTest
+  static void it_should_auto_create_log_entry_event_for_success_finalizer_async_context_details_when_system_messages_are_enabled() {
+    System.FinalizerContext mockContext = new LoggerMockDataCreator.MockFinalizerContext();
+    System.Assert.isNull(mockContext.getException());
+    System.Assert.areEqual(System.ParentJobResult.SUCCESS, mockContext.getResult());
+    LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+    LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'EnableLoggerSystemMessages', Value__c = 'true'));
+    System.Assert.isTrue(LoggerParameter.ENABLE_SYSTEM_MESSAGES, 'System messages should be enabled');
+    System.Assert.areEqual(0, Logger.getBufferSize());
+    System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+
+    Logger.setAsyncContext(mockContext);
+    Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
+
+    System.Assert.areEqual(0, Logger.getBufferSize());
+    Integer publishedEventsCount = LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size();
+    System.Assert.isTrue(
+      publishedEventsCount >= 1,
+      publishedEventsCount +
+        ' events published, but at least 1 should have been auto-created & published\n\n' +
+        System.JSON.serializePretty(LoggerMockDataStore.getEventBus().getPublishedPlatformEvents())
+    );
+    LogEntryEvent__e expectedLogEntryEvent = new LogEntryEvent__e(
+      LoggingLevel__c = System.LoggingLevel.INFO.name(),
+      Message__c = 'Nebula Logger - Async Context: ' + System.JSON.serializePretty(new Logger.AsyncContext(mockContext), true)
+    );
+    List<LogEntryEvent__e> matchingPublishedLogEntryEvents = (List<LogEntryEvent__e>) LoggerMockDataStore.getEventBus()
+      .getMatchingPublishedPlatformEvents(expectedLogEntryEvent);
+    System.Assert.areEqual(1, matchingPublishedLogEntryEvents.size());
+    LogEntryEvent__e matchingPublishedLogEntryEvent = matchingPublishedLogEntryEvents.get(0);
+    System.Assert.areEqual(System.FinalizerContext.class.getName(), matchingPublishedLogEntryEvent.AsyncContextType__c);
+    System.Assert.areEqual(expectedLogEntryEvent.LoggingLevel__c, matchingPublishedLogEntryEvent.LoggingLevel__c);
+    System.Assert.areEqual(expectedLogEntryEvent.Message__c, matchingPublishedLogEntryEvent.Message__c);
+    System.Assert.isNull(matchingPublishedLogEntryEvent.ExceptionMessage__c);
+    System.Assert.isNull(matchingPublishedLogEntryEvent.ExceptionType__c);
+  }
+
+  @IsTest
+  static void it_should_auto_create_log_entry_event_for_unhandled_exception_finalizer_async_context_details_when_system_messages_are_enabled() {
+    System.DmlException mockFinalizerUnhandledException = new System.DmlException('Oops');
+    System.FinalizerContext mockContext = new LoggerMockDataCreator.MockFinalizerContext(mockFinalizerUnhandledException);
+    System.Assert.isNotNull(mockContext.getException());
+    System.Assert.areEqual(System.ParentJobResult.UNHANDLED_EXCEPTION, mockContext.getResult());
+    LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+    LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'EnableLoggerSystemMessages', Value__c = 'true'));
+    System.Assert.isTrue(LoggerParameter.ENABLE_SYSTEM_MESSAGES, 'System messages should be enabled');
+    System.Assert.areEqual(0, Logger.getBufferSize());
+    System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+
+    Logger.setAsyncContext(mockContext);
+    Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
+
+    System.Assert.areEqual(0, Logger.getBufferSize());
+    Integer publishedEventsCount = LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size();
+    System.Assert.isTrue(
+      publishedEventsCount >= 1,
+      publishedEventsCount +
+        ' events published, but at least 1 should have been auto-created & published\n\n' +
+        System.JSON.serializePretty(LoggerMockDataStore.getEventBus().getPublishedPlatformEvents())
+    );
+    LogEntryEvent__e expectedLogEntryEvent = new LogEntryEvent__e(
+      LoggingLevel__c = System.LoggingLevel.INFO.name(),
+      Message__c = 'Nebula Logger - Async Context: ' + System.JSON.serializePretty(new Logger.AsyncContext(mockContext), true)
+    );
+    List<LogEntryEvent__e> matchingPublishedLogEntryEvents = (List<LogEntryEvent__e>) LoggerMockDataStore.getEventBus()
+      .getMatchingPublishedPlatformEvents(expectedLogEntryEvent);
+    System.Assert.areEqual(1, matchingPublishedLogEntryEvents.size());
+    LogEntryEvent__e matchingPublishedLogEntryEvent = matchingPublishedLogEntryEvents.get(0);
+    System.Assert.areEqual(System.FinalizerContext.class.getName(), matchingPublishedLogEntryEvent.AsyncContextType__c);
+    System.Assert.areEqual(expectedLogEntryEvent.LoggingLevel__c, matchingPublishedLogEntryEvent.LoggingLevel__c);
+    System.Assert.areEqual(expectedLogEntryEvent.Message__c, matchingPublishedLogEntryEvent.Message__c);
+    System.Assert.areEqual(mockFinalizerUnhandledException.getMessage(), matchingPublishedLogEntryEvent.ExceptionMessage__c);
+    System.Assert.areEqual(mockFinalizerUnhandledException.getTypeName(), matchingPublishedLogEntryEvent.ExceptionType__c);
   }
 
   @IsTest
@@ -944,6 +1054,41 @@ private class Logger_Tests {
   }
 
   @IsTest
+  static void it_should_auto_create_log_entry_event_for_queueable_async_context_details_when_system_messages_are_enabled() {
+    System.QueueableContext mockContext = new LoggerMockDataCreator.MockQueueableContext();
+    LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+    LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'EnableLoggerSystemMessages', Value__c = 'true'));
+    System.Assert.isTrue(LoggerParameter.ENABLE_SYSTEM_MESSAGES, 'System messages should be enabled');
+    System.Assert.areEqual(0, Logger.getBufferSize());
+    System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+
+    Logger.setAsyncContext(mockContext);
+    Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
+
+    System.Assert.areEqual(0, Logger.getBufferSize());
+    Integer publishedEventsCount = LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size();
+    System.Assert.isTrue(
+      publishedEventsCount >= 1,
+      publishedEventsCount +
+        ' events published, but at least 1 should have been auto-created & published\n\n' +
+        System.JSON.serializePretty(LoggerMockDataStore.getEventBus().getPublishedPlatformEvents())
+    );
+    LogEntryEvent__e expectedLogEntryEvent = new LogEntryEvent__e(
+      LoggingLevel__c = System.LoggingLevel.INFO.name(),
+      Message__c = 'Nebula Logger - Async Context: ' + System.JSON.serializePretty(new Logger.AsyncContext(mockContext), true)
+    );
+    List<LogEntryEvent__e> matchingPublishedLogEntryEvents = (List<LogEntryEvent__e>) LoggerMockDataStore.getEventBus()
+      .getMatchingPublishedPlatformEvents(expectedLogEntryEvent);
+    System.Assert.areEqual(1, matchingPublishedLogEntryEvents.size());
+    LogEntryEvent__e matchingPublishedLogEntryEvent = matchingPublishedLogEntryEvents.get(0);
+    System.Assert.areEqual(System.QueueableContext.class.getName(), matchingPublishedLogEntryEvent.AsyncContextType__c);
+    System.Assert.areEqual(expectedLogEntryEvent.LoggingLevel__c, matchingPublishedLogEntryEvent.LoggingLevel__c);
+    System.Assert.areEqual(expectedLogEntryEvent.Message__c, matchingPublishedLogEntryEvent.Message__c);
+    System.Assert.isNull(matchingPublishedLogEntryEvent.ExceptionMessage__c);
+    System.Assert.isNull(matchingPublishedLogEntryEvent.ExceptionType__c);
+  }
+
+  @IsTest
   static void it_should_set_async_context_details_for_schedulable_context_when_event_published() {
     Id mockCronTriggerId = LoggerMockDataCreator.createId(Schema.CronTrigger.SObjectType);
     System.SchedulableContext mockContext = new LoggerMockDataCreator.MockSchedulableContext(mockCronTriggerId);
@@ -999,6 +1144,41 @@ private class Logger_Tests {
     System.Assert.isNull(logEntryEvent.AsyncContextParentJobId__c);
     System.Assert.areEqual(firstNonNullMockContext.getTriggerId(), logEntryEvent.AsyncContextTriggerId__c);
     System.Assert.areEqual(System.SchedulableContext.class.getName(), logEntryEvent.AsyncContextType__c);
+  }
+
+  @IsTest
+  static void it_should_auto_create_log_entry_event_for_scheduleable_async_context_details_when_system_messages_are_enabled() {
+    System.SchedulableContext mockContext = new LoggerMockDataCreator.MockSchedulableContext();
+    LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+    LoggerTestConfigurator.setMock(new LoggerParameter__mdt(DeveloperName = 'EnableLoggerSystemMessages', Value__c = 'true'));
+    System.Assert.isTrue(LoggerParameter.ENABLE_SYSTEM_MESSAGES, 'System messages should be enabled');
+    System.Assert.areEqual(0, Logger.getBufferSize());
+    System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+
+    Logger.setAsyncContext(mockContext);
+    Logger.saveLog(Logger.SaveMethod.EVENT_BUS);
+
+    System.Assert.areEqual(0, Logger.getBufferSize());
+    Integer publishedEventsCount = LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size();
+    System.Assert.isTrue(
+      publishedEventsCount >= 1,
+      publishedEventsCount +
+        ' events published, but at least 1 should have been auto-created & published\n\n' +
+        System.JSON.serializePretty(LoggerMockDataStore.getEventBus().getPublishedPlatformEvents())
+    );
+    LogEntryEvent__e expectedLogEntryEvent = new LogEntryEvent__e(
+      LoggingLevel__c = System.LoggingLevel.INFO.name(),
+      Message__c = 'Nebula Logger - Async Context: ' + System.JSON.serializePretty(new Logger.AsyncContext(mockContext), true)
+    );
+    List<LogEntryEvent__e> matchingPublishedLogEntryEvents = (List<LogEntryEvent__e>) LoggerMockDataStore.getEventBus()
+      .getMatchingPublishedPlatformEvents(expectedLogEntryEvent);
+    System.Assert.areEqual(1, matchingPublishedLogEntryEvents.size());
+    LogEntryEvent__e matchingPublishedLogEntryEvent = matchingPublishedLogEntryEvents.get(0);
+    System.Assert.areEqual(System.SchedulableContext.class.getName(), matchingPublishedLogEntryEvent.AsyncContextType__c);
+    System.Assert.areEqual(expectedLogEntryEvent.LoggingLevel__c, matchingPublishedLogEntryEvent.LoggingLevel__c);
+    System.Assert.areEqual(expectedLogEntryEvent.Message__c, matchingPublishedLogEntryEvent.Message__c);
+    System.Assert.isNull(matchingPublishedLogEntryEvent.ExceptionMessage__c);
+    System.Assert.isNull(matchingPublishedLogEntryEvent.ExceptionType__c);
   }
 
   @IsTest

--- a/nebula-logger/core/tests/logger-engine/utilities/LoggerMockDataStore.cls
+++ b/nebula-logger/core/tests/logger-engine/utilities/LoggerMockDataStore.cls
@@ -83,6 +83,39 @@ public without sharing class LoggerMockDataStore {
       return this.publishedPlatformEvents;
     }
 
+    /**
+     * @description Returns a list of published platform events that have the same field values
+     *              as the provided platform event record `comparisonPlatformEvent`. This is useful for
+     *              easily filtering to only the `LogEntryEvent__e` records relevant to a particular test method
+     *              in a transaction/test scenario where multiple `LogEntryEvent__e` are being generated.
+     *              Long-term, this helper method might be moved elsewhere, or replaced with something else,
+     *              but for now, the mock event bus is a good-enough spot for it.
+     * @param  comparisonPlatformEvent An instance of the platform event record to use for comparing
+     *                                 against the list of platform event records that have been published
+     * @return                         A list containing any matches. When no matches are found, the list is empty.
+     */
+    public List<SObject> getMatchingPublishedPlatformEvents(SObject comparisonPlatformEvent) {
+      Map<String, Object> comparisonFieldToValue = comparisonPlatformEvent.getPopulatedFieldsAsMap();
+      List<SObject> matchingRecords = new List<SObject>();
+      for (SObject eventToCheck : this.getPublishedPlatformEvents()) {
+        Boolean isMatchingRecord = true;
+        Map<String, Object> targetFieldToValue = eventToCheck.getPopulatedFieldsAsMap();
+
+        for (String populatedField : comparisonFieldToValue.keySet()) {
+          Object expectedValue = comparisonFieldToValue.get(populatedField);
+          if (targetFieldToValue.containsKey(populatedField) == false || eventToCheck.get(populatedField) != expectedValue) {
+            isMatchingRecord = false;
+            break;
+          }
+        }
+
+        if (isMatchingRecord) {
+          matchingRecords.add(eventToCheck);
+        }
+      }
+      return matchingRecords;
+    }
+
     public override Database.SaveResult publishRecord(SObject platformEvent) {
       return this.publishRecords(new List<SObject>{ platformEvent }).get(0);
     }

--- a/nebula-logger/extra-tests/classes/name-shadowing/System/ParentJobResult.cls
+++ b/nebula-logger/extra-tests/classes/name-shadowing/System/ParentJobResult.cls
@@ -1,0 +1,10 @@
+//------------------------------------------------------------------------------------------------//
+// This file is part of the Nebula Logger project, released under the MIT License.                //
+// See LICENSE file or go to https://github.com/jongpie/NebulaLogger for full license details.    //
+//------------------------------------------------------------------------------------------------//
+
+// This class intentionally does nothing - it's here to ensure that any references
+// in Nebula Logger's codebase use `System.ParentJobResult` instead of just `ParentJobResult`
+@SuppressWarnings('PMD.ApexDoc, PMD.EmptyStatementBlock')
+public without sharing class ParentJobResult {
+}

--- a/nebula-logger/extra-tests/classes/name-shadowing/System/ParentJobResult.cls-meta.xml
+++ b/nebula-logger/extra-tests/classes/name-shadowing/System/ParentJobResult.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebula-logger",
-  "version": "4.14.14",
+  "version": "4.14.15",
   "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
   "author": "Jonathan Gillespie",
   "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -199,6 +199,7 @@
     "Nebula Logger - Core@4.14.12-replaced-httprequestendpoint__c-with-httprequestendpointaddress__c": "04t5Y0000015oV0QAI",
     "Nebula Logger - Core@4.14.13-new-getlogger()-js-function": "04t5Y0000015oW3QAI",
     "Nebula Logger - Core@4.14.14-new-apex-static-method-&-javascript-function-logger.setfield()": "04t5Y0000015oWIQAY",
+    "Nebula Logger - Core@4.14.15-create-log-entry-for-asyncapexcontext": "04t5Y0000015obxQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
       "path": "./nebula-logger/core",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "scopeProfiles": true,
-      "versionNumber": "4.14.14.NEXT",
-      "versionName": "New Apex Static Method & JavaScript Function Logger.setField()",
-      "versionDescription": "Added a new Apex static method Logger.setField() and LWC function logger.setField() so custom fields can be set once --> auto-populated on all subsequent LogEntryEvent__e records",
+      "versionNumber": "4.14.15.NEXT",
+      "versionName": "Create log entry for AsyncApexContext",
+      "versionDescription": "Adds additional details to the AsyncApexContext object being logged to expose System.Finalizer-specific details",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {
         "path": "./nebula-logger/extra-tests"


### PR DESCRIPTION
@jongpie wanted to get your thoughts on these changes:

* potentially also creating a log entry for async context when it's first set (possibly _always_ logging? or also reporting on when it's been called with the current context _already_ set?)
* appending some additional properties to the `Logger.AsyncContext` inner class to capture more data about finalizers. This leads to an INFO message like such:


```
INFO|FinalizerExample.execute
Nebula Logger - Async Context: {
  "type" : "System.FinalizerContext",
  "parentJobId" : "7076g0000B6tiGgAQI",
  "finalizerResult" : "UNHANDLED_EXCEPTION",
  "finalizerException" : "Oops!\nExternal entry point"
}
```

Not terribly pleased with the existing "stacktrace" string there (as far as I can tell, at the moment it always seems to be reported as an external entry point) but it might be good to leave in (in the hopes that we can get that worked on internally).