### PR TITLE
Added more details in logger LWC's console statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The most robust observability solution for Salesforce experts. Built 100% native
 
 ## Unlocked Package - v4.14.17
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015ocHQAQ)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015ocHQAQ)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015ocRQAQ)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015ocRQAQ)
 [![View Documentation](./images/btn-view-documentation.png)](https://github.com/jongpie/NebulaLogger/wiki)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015ocHQAQ`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015ocRQAQ`
 
-`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015ocHQAQ`
+`sfdx force:package:install --wait 20 --securitytype AdminsOnly --package 04t5Y0000015ocRQAQ`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust observability solution for Salesforce experts. Built 100% natively on the platform, and designed to work seamlessly with Apex, Lightning Components, Flow, OmniStudio, and integrations.
 
-## Unlocked Package - v4.14.16
+## Unlocked Package - v4.14.17
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015ocHQAQ)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015ocHQAQ)

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
   // There's no reliable way to get the version number dynamically in Apex
   @TestVisible
-  private static final String CURRENT_VERSION_NUMBER = 'v4.14.16';
+  private static final String CURRENT_VERSION_NUMBER = 'v4.14.17';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
   private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/__tests__/logger.test.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/__tests__/logger.test.js
@@ -40,8 +40,9 @@ jest.mock(
 );
 
 describe('logger lwc recommended sync getLogger() import approach tests', () => {
-  beforeEach(() => {
+  beforeAll(() => {
     disableSystemMessages();
+    setTimeout = callbackFunction => callbackFunction();
     // One of logger's features (when enabled) is to auto-call the browser's console
     // so devs can see a log entry easily. But during Jest tests, seeing all of the
     // console statements is... a bit overwhelming, so the global console functions
@@ -651,7 +652,7 @@ describe('logger lwc recommended sync getLogger() import approach tests', () => 
     logEntryBuilder.setExceptionDetails(error);
 
     expect(logEntry.error.message).toEqual(error.message);
-    expect(logEntry.error.stackTrace).toBeTruthy();
+    expect(logEntry.error.stackTrace.stackTraceString).toEqual(error.stackTrace);
     expect(logEntry.error.type).toEqual('JavaScript.TypeError');
   });
 
@@ -679,7 +680,10 @@ describe('logger lwc recommended sync getLogger() import approach tests', () => 
     logEntryBuilder.setExceptionDetails(error);
 
     expect(logEntry.error.message).toEqual(error.body.message);
-    expect(logEntry.error.stackTrace).toBeTruthy();
+    expect(logEntry.error.stackTrace.metadataType).toEqual('ApexClass');
+    expect(logEntry.error.stackTrace.className).toEqual('SomeApexClass');
+    expect(logEntry.error.stackTrace.methodName).toEqual('runSomeMethod');
+    expect(logEntry.error.stackTrace.stackTraceString).toEqual(error.body.stackTrace);
     expect(logEntry.error.type).toEqual(error.body.exceptionType);
   });
 
@@ -1253,7 +1257,7 @@ describe('logger lwc deprecated async createLogger() import tests', () => {
     logEntryBuilder.setError(error);
 
     expect(logEntry.error.message).toEqual(error.message);
-    expect(logEntry.error.stackTrace).toBeTruthy();
+    expect(logEntry.error.stackTrace.stackTraceString).toEqual(error.stackTrace);
     expect(logEntry.error.type).toEqual('JavaScript.TypeError');
   });
 
@@ -1278,7 +1282,10 @@ describe('logger lwc deprecated async createLogger() import tests', () => {
     logEntryBuilder.setError(error);
 
     expect(logEntry.error.message).toEqual(error.body.message);
-    expect(logEntry.error.stackTrace).toBeTruthy();
+    expect(logEntry.error.stackTrace.metadataType).toEqual('ApexClass');
+    expect(logEntry.error.stackTrace.className).toEqual('SomeApexClass');
+    expect(logEntry.error.stackTrace.methodName).toEqual('runSomeMethod');
+    expect(logEntry.error.stackTrace.stackTraceString).toEqual(error.body.stackTrace);
     expect(logEntry.error.type).toEqual(error.body.exceptionType);
   });
 
@@ -1817,7 +1824,7 @@ describe('logger lwc legacy markup tests', () => {
     logEntryBuilder.setError(error);
 
     expect(logEntry.error.message).toEqual(error.message);
-    expect(logEntry.error.stackTrace).toBeTruthy();
+    expect(logEntry.error.stackTrace.stackTraceString).toEqual(error.stackTrace);
     expect(logEntry.error.type).toEqual('JavaScript.TypeError');
   });
 
@@ -1844,7 +1851,10 @@ describe('logger lwc legacy markup tests', () => {
     logEntryBuilder.setError(error);
 
     expect(logEntry.error.message).toEqual(error.body.message);
-    expect(logEntry.error.stackTrace).toEqual(error.body.stackTrace);
+    expect(logEntry.error.stackTrace.metadataType).toEqual('ApexClass');
+    expect(logEntry.error.stackTrace.className).toEqual('SomeApexClass');
+    expect(logEntry.error.stackTrace.methodName).toEqual('runSomeMethod');
+    expect(logEntry.error.stackTrace.stackTraceString).toEqual(error.body.stackTrace);
     expect(logEntry.error.type).toEqual(error.body.exceptionType);
   });
 

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
@@ -10,7 +10,7 @@ import LoggerServiceTaskQueue from './loggerServiceTaskQueue';
 import getSettings from '@salesforce/apex/ComponentLogger.getSettings';
 import saveComponentLogEntries from '@salesforce/apex/ComponentLogger.saveComponentLogEntries';
 
-const CURRENT_VERSION_NUMBER = 'v4.14.16';
+const CURRENT_VERSION_NUMBER = 'v4.14.17';
 
 const CONSOLE_OUTPUT_CONFIG = {
   messagePrefix: `%c  Nebula Logger ${CURRENT_VERSION_NUMBER}  `,
@@ -195,7 +195,11 @@ export default class LoggerService {
         this.#componentLogEntries.push(logEntry);
 
         if (this.#settings.isConsoleLoggingEnabled) {
-          this._logToConsole(logEntry.loggingLevel, logEntry.message, logEntry);
+          // Use setTimeout() so any extra fields included in the log entry are added first before printing to the console
+          // eslint-disable-next-line @lwc/lwc/no-async-operation
+          setTimeout(() => {
+            this._logToConsole(logEntry.loggingLevel, logEntry.message, logEntry);
+          }, 1000);
         }
         if (this.#settings.isLightningLoggerEnabled) {
           lightningLog(logEntry);
@@ -218,22 +222,41 @@ export default class LoggerService {
     const consoleLoggingFunction = console[loggingLevel.toLowerCase()] ?? console.debug;
     const loggingLevelEmoji = LOGGING_LEVEL_EMOJIS[loggingLevel];
     const qualifiedMessage = `${loggingLevelEmoji} ${loggingLevel}: ${message}`;
-    const formattedComponentLogEntryString = !componentLogEntry
-      ? ''
-      : '\n' +
-        JSON.stringify(
-          {
-            origin: {
-              component: componentLogEntry.originStackTrace?.componentName,
-              function: componentLogEntry.originStackTrace?.functionName,
-              metadataType: componentLogEntry.originStackTrace?.metadataType
-            },
-            scenario: componentLogEntry.scenario,
-            timestamp: componentLogEntry.timestamp
+    // Clean up some extra properties for readability
+    console.debug('>>> original componentLogEntry: ', JSON.stringify(componentLogEntry, null, 2));
+    const simplifiedLogEntry = !componentLogEntry
+      ? undefined
+      : {
+          customFieldMappings: componentLogEntry.fieldToValue.length === 0 ? undefined : componentLogEntry.fieldToValue,
+          originSource: {
+            metadataType: componentLogEntry.originStackTrace?.metadataType,
+            componentName: componentLogEntry.originStackTrace?.componentName,
+            functionName: componentLogEntry.originStackTrace?.functionName
           },
-          (_, value) => value ?? undefined,
-          2
-        );
+          error: componentLogEntry.error,
+          scenario: componentLogEntry.scenario,
+          tags: componentLogEntry.tags.length === 0 ? undefined : componentLogEntry.tags,
+          timestamp: !componentLogEntry.timestamp
+            ? undefined
+            : {
+                local: new Date(componentLogEntry.timestamp).toLocaleString(),
+                utc: componentLogEntry.timestamp
+              }
+        };
+    if (simplifiedLogEntry?.error?.stackTrace) {
+      simplifiedLogEntry.error.errorSource = {
+        metadataType: simplifiedLogEntry.error.stackTrace.metadataType,
+        componentName: simplifiedLogEntry.error.stackTrace.componentName,
+        functionName: simplifiedLogEntry.error.stackTrace.functionName,
+        className: simplifiedLogEntry.error.stackTrace.className,
+        methodName: simplifiedLogEntry.error.stackTrace.methodName,
+        triggerName: simplifiedLogEntry.error.stackTrace.triggerName,
+        stackTraceString: simplifiedLogEntry.error.stackTrace.stackTraceString
+      };
+      delete simplifiedLogEntry.error.stackTrace;
+    }
+
+    const formattedComponentLogEntryString = !simplifiedLogEntry ? undefined : '\n' + JSON.stringify(simplifiedLogEntry, (_, value) => value ?? undefined, 2);
 
     consoleLoggingFunction(CONSOLE_OUTPUT_CONFIG.messagePrefix, CONSOLE_OUTPUT_CONFIG.messageFormatting, qualifiedMessage, formattedComponentLogEntryString);
   }

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
@@ -223,7 +223,6 @@ export default class LoggerService {
     const loggingLevelEmoji = LOGGING_LEVEL_EMOJIS[loggingLevel];
     const qualifiedMessage = `${loggingLevelEmoji} ${loggingLevel}: ${message}`;
     // Clean up some extra properties for readability
-    console.debug('>>> original componentLogEntry: ', JSON.stringify(componentLogEntry, null, 2));
     const simplifiedLogEntry = !componentLogEntry
       ? undefined
       : {

--- a/nebula-logger/recipes/lwc/loggerLWCCreateLoggerImportDemo/loggerLWCCreateLoggerImportDemo.js
+++ b/nebula-logger/recipes/lwc/loggerLWCCreateLoggerImportDemo/loggerLWCCreateLoggerImportDemo.js
@@ -82,6 +82,7 @@ export default class LoggerLWCCreateLoggerImportDemo extends LightningElement {
 
   scenarioChange(event) {
     this.scenario = event.target.value;
+    this.logger.setScenario(this.scenario);
   }
 
   tagsStringChange(event) {
@@ -156,7 +157,6 @@ export default class LoggerLWCCreateLoggerImportDemo extends LightningElement {
 
   saveLogExample() {
     console.log('running saveLog for btn');
-    this.logger.setScenario(this.scenario);
     console.log(this.logger);
     // this.logger.saveLog('QUEUEABLE');
     this.logger.saveLog();

--- a/nebula-logger/recipes/lwc/loggerLWCGetLoggerImportDemo/loggerLWCGetLoggerImportDemo.js
+++ b/nebula-logger/recipes/lwc/loggerLWCGetLoggerImportDemo/loggerLWCGetLoggerImportDemo.js
@@ -19,6 +19,7 @@ export default class LoggerLWCGetLoggerImportDemo extends LightningElement {
 
   connectedCallback() {
     try {
+      this.logger.setScenario(this.scenario);
       this.logger.error('test error entry').setField({ SomeLogEntryField__c: 'some text from loggerLWCGetLoggerImportDemo' });
       this.logger.warn('test warn entry').setField({ SomeLogEntryField__c: 'some text from loggerLWCGetLoggerImportDemo' });
       this.logger.info('test info entry').setField({ SomeLogEntryField__c: 'some text from loggerLWCGetLoggerImportDemo' });
@@ -83,6 +84,7 @@ export default class LoggerLWCGetLoggerImportDemo extends LightningElement {
 
   scenarioChange(event) {
     this.scenario = event.target.value;
+    this.logger.setScenario(this.scenario);
   }
 
   tagsStringChange(event) {
@@ -157,7 +159,6 @@ export default class LoggerLWCGetLoggerImportDemo extends LightningElement {
 
   saveLogExample() {
     console.log('running saveLog for btn');
-    this.logger.setScenario(this.scenario);
     console.log(this.logger);
     // this.logger.saveLog('QUEUEABLE');
     this.logger.saveLog();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebula-logger",
-  "version": "4.14.16",
+  "version": "4.14.17",
   "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
   "author": "Jonathan Gillespie",
   "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -201,6 +201,7 @@
     "Nebula Logger - Core@4.14.14-new-apex-static-method-&-javascript-function-logger.setfield()": "04t5Y0000015oWIQAY",
     "Nebula Logger - Core@4.14.15-create-log-entry-for-asyncapexcontext": "04t5Y0000015obxQAA",
     "Nebula Logger - Core@4.14.16-callablelogger-enhancements": "04t5Y0000015ocHQAQ",
+    "Nebula Logger - Core@4.14.17-improved-javascript-console-output": "04t5Y0000015ocRQAQ",
     "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
       "path": "./nebula-logger/core",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "scopeProfiles": true,
-      "versionNumber": "4.14.16.NEXT",
-      "versionName": "CallableLogger Enhancements",
-      "versionDescription": "Added 3 enhancements to the CallableLogger class (used for OmniStudio logging & loosely-coupled dependencies)\n\n    1. It now automatically appends OmniStudio's input data for OmniScript steps as JSON to the Message__c fields on LogEntryEvent__e and LogEntry__c.\n    2. The 'newEntry' action now also supports setting the parent log transaction ID, using the argument 'parentLogTransactionId'.\n    3. Transaction details are now returned in the output for all actions, including the current transaction ID, the parent log transaction ID, and the Salesforce-generated request ID.",
+      "versionNumber": "4.14.17.NEXT",
+      "versionName": "Improved JavaScript Console Output",
+      "versionDescription": "Added more details to the component log entry JSON that's printed using console statements. The stringified object now includes more details, such as the exception, tags, and scenario.",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {
         "path": "./nebula-logger/extra-tests"


### PR DESCRIPTION
When using the `logger` LWC and JavaScript console logging is enabled (via `LoggerSettings__c.IsJavaScriptConsoleLoggingEnabled__c`), Nebula Logger automatically calls functions in the browser's `console` so devs can easily see the generated log entry directly in their browser (instead of having to find it in `LogEntry__c`). This PR improves the component log entry JSON that's printed using `console` statements - the stringified object now includes more details, such as details about the logged error/exception (when an error is logged), any tags added to the entry, and the user's localized version of the entry's `timestamp`.

- This includes a change to how Nebula Logger internally calls the browser's `console` functions: now, `console` functions are called with a 1 second delay (using `setTimeout()`) so that additional details can be added to the log entry (using the builder methods) before the log entry is stringified & printed out. This may not be a perfect solution, but seems to work in most cases of using the JS builder methods.

To show the difference in the changes, this JavaScript was used to generate some example log entries:
 ```javascript
this.logger.setScenario('Some demo scenario')
const someError = new TypeError('oops');
this.logger.error('Hello, world!')
    .setExceptionDetails(someError)
    .setField({ SomeLogEntryField__c: 'some text from loggerLWCGetLoggerImportDemo' })
    .addTags(['Tag-one', 'Another tag here']);
```

In the screenshot below, 2 versions of the output are shown:
1. **Before**:
    - No details are included in the output about the error, the tags, or the custom field mappings.
    - The timestamp is only shown in UTC.
2. **After**:
    - The output now includes details about any errors/exceptions logged using the builder function `setExceptionDetails()`.
        - Previously the output only included the logged message - _no_ details were included about the logged exception/error, which made it _much_ harder to troubleshoot whatever the relevant error was 🙃 
        - The error output includes details about the metadata source, making it easy to tell if the error was caused by another LWC, an Apex controller method, or an Apex trigger.
    - When devs use any of Nebula Logger's optional JS features (scenarios, tags, and custom field mappings), the details are automatically included in the `console` statements' output
     - For devs that do not leverage these optional features, the relevant properties are automatically excluded from the `console` output. This keeps the output slimmer & easier to read.
     - Each entry's timestamp is now shown both in UTC time (using `new Date().toISOString()`) and in the user's local format (using `new Date().toLocaleString()`). This makes it a little easier for devs to troubleshoot exactly when an entry was generated in their browser.

![image](https://github.com/user-attachments/assets/53459734-587e-443e-9338-0fa55a681530)