### PR TITLE
Fix "The field value for ExceptionMessage__c is too long" exception for long flow error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The most robust observability solution for Salesforce experts. Built 100% native
 
 ## Unlocked Package - v4.15.4
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015ok2QAA)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015ok2QAA)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oklQAA)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015oklQAA)
 [![View Documentation](./images/btn-view-documentation.png)](https://github.com/jongpie/NebulaLogger/wiki)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015ok2QAA`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015oklQAA`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust observability solution for Salesforce experts. Built 100% natively on the platform, and designed to work seamlessly with Apex, Lightning Components, Flow, OmniStudio, and integrations.
 
-## Unlocked Package - v4.15.3
+## Unlocked Package - v4.15.4
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015ok2QAA)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015ok2QAA)

--- a/nebula-logger/core/main/logger-engine/classes/FlowLogger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/FlowLogger.cls
@@ -108,11 +108,7 @@ public inherited sharing class FlowLogger {
 
       // Set the logging level if it's blank
       if (String.isBlank(this.loggingLevelName)) {
-        if (String.isNotBlank(this.faultMessage)) {
-          this.loggingLevelName = System.LoggingLevel.ERROR.name();
-        } else {
-          this.loggingLevelName = System.LoggingLevel.DEBUG.name();
-        }
+        this.loggingLevelName = (String.isNotBlank(this.faultMessage) ? System.LoggingLevel.ERROR : System.LoggingLevel.DEBUG).name();
       }
 
       // In Flow, using comma-separated String is easier than List<String>
@@ -148,7 +144,10 @@ public inherited sharing class FlowLogger {
         //
         // TODO Need to revisit this to see if there is a way to determine this programatically, or if new
         // Flow parameter(s) would be needed.
-        this.logEntryEvent.ExceptionMessage__c = hasFaultMessage ? this.faultMessage : FLOW_FAULT_ERROR_DEFAULT_EXCEPTION_MESSAGE;
+        this.logEntryEvent.ExceptionMessage__c = LoggerDataStore.truncateFieldValue(
+          Schema.LogEntryEvent__e.ExceptionMessage__c,
+          hasFaultMessage ? this.faultMessage : FLOW_FAULT_ERROR_DEFAULT_EXCEPTION_MESSAGE
+        );
         this.logEntryEvent.ExceptionSourceApiName__c = this.flowName;
         this.logEntryEvent.ExceptionSourceMetadataType__c = FLOW_SOURCE_METADATA_TYPE;
         this.logEntryEvent.ExceptionType__c = FLOW_EXCEPTION_TYPE_NAME;

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
   // There's no reliable way to get the version number dynamically in Apex
   @TestVisible
-  private static final String CURRENT_VERSION_NUMBER = 'v4.15.3';
+  private static final String CURRENT_VERSION_NUMBER = 'v4.15.4';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
   private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
@@ -10,7 +10,7 @@ import LoggerServiceTaskQueue from './loggerServiceTaskQueue';
 import getSettings from '@salesforce/apex/ComponentLogger.getSettings';
 import saveComponentLogEntries from '@salesforce/apex/ComponentLogger.saveComponentLogEntries';
 
-const CURRENT_VERSION_NUMBER = 'v4.15.3';
+const CURRENT_VERSION_NUMBER = 'v4.15.4';
 
 const CONSOLE_OUTPUT_CONFIG = {
   messagePrefix: `%c  Nebula Logger ${CURRENT_VERSION_NUMBER}  `,

--- a/nebula-logger/core/tests/logger-engine/classes/FlowLogger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/FlowLogger_Tests.cls
@@ -245,4 +245,32 @@ private class FlowLogger_Tests {
     System.Assert.isNull(publishedLogEntryEvent.StackTrace__c, 'Flow does not have a stack trace, so expect null');
     System.Assert.areEqual(flowEntry.timestamp, publishedLogEntryEvent.Timestamp__c);
   }
+
+  @IsTest
+  static void it_truncates_too_long_exception_messages() {
+    LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+    System.LoggingLevel entryLoggingLevel = System.LoggingLevel.ERROR;
+    Logger.getUserSettings().LoggingLevel__c = entryLoggingLevel.name();
+    LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
+    Integer maxLengthForExceptionMessage = Schema.LogEntryEvent__e.ExceptionMessage__c.getDescribe().getLength();
+    FlowLogger.LogEntry flowEntry = new FlowLogger.LogEntry();
+    flowEntry.flowName = 'MyFlow';
+    flowEntry.message = 'hello from Flow';
+    flowEntry.loggingLevelName = entryLoggingLevel.name();
+    flowEntry.saveLog = true;
+    flowEntry.faultMessage = '0'.repeat(maxLengthForExceptionMessage + 1);
+    flowEntry.timestamp = System.now();
+    System.Assert.areEqual(0, Logger.saveLogCallCount);
+    System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishCallCount());
+    System.Assert.areEqual(0, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+
+    FlowLogger.addEntries(new List<FlowLogger.LogEntry>{ flowEntry });
+
+    System.Assert.areEqual(0, Logger.getBufferSize());
+    System.Assert.areEqual(1, Logger.saveLogCallCount);
+    System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishCallCount());
+    System.Assert.areEqual(1, LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().size());
+    LogEntryEvent__e publishedLogEntryEvent = (LogEntryEvent__e) LoggerMockDataStore.getEventBus().getPublishedPlatformEvents().get(0);
+    System.Assert.areEqual(maxLengthForExceptionMessage, publishedLogEntryEvent.ExceptionMessage__c.length());
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebula-logger",
-  "version": "4.15.3",
+  "version": "4.15.4",
   "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
   "author": "Jonathan Gillespie",
   "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -208,6 +208,7 @@
     "Nebula Logger - Core@4.15.1-system.orglimits-optimisations": "04t5Y0000015ohhQAA",
     "Nebula Logger - Core@4.15.2-added-support-for-logging-emptyrecylebinresult": "04t5Y0000015oifQAA",
     "Nebula Logger - Core@4.15.3-improved-testability-of-queries": "04t5Y0000015ok2QAA",
+    "Nebula Logger - Core@4.15.4-flowlogger-exception-message-handling": "04t5Y0000015oklQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
       "path": "./nebula-logger/core",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "scopeProfiles": true,
-      "versionNumber": "4.15.3.NEXT",
-      "versionName": "Improved Testability of Queries",
-      "versionDescription": "Enhanced the internals of the existing selector classes LoggerEngineDataSelector and LogManagementDataSelector + introducted a new class LoggerConfigurationSelector to provide improve testability of queries",
+      "versionNumber": "4.15.4.NEXT",
+      "versionName": "FlowLogger exception message handling",
+      "versionDescription": "FlowLogger now properly truncates the LogEntryEvent__e.ExceptionMessage__c field",
       "postInstallUrl": "https://github.com/jongpie/NebulaLogger/wiki",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {


### PR DESCRIPTION
* Fix #827 by truncating the passed in fault message properly prior to publishing the saved `LogEntryEvent__e`