### PR TITLE
Fix Stacktrace Parsing & Reduce logger.test.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The most robust observability solution for Salesforce experts. Built 100% native
 
 ## Unlocked Package - v4.15.7
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015pEdQAI)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015pEdQAI)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015pEnQAI)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015pEnQAI)
 [![View Documentation](./images/btn-view-documentation.png)](https://github.com/jongpie/NebulaLogger/wiki)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015pEdQAI`
+`sf package install --wait 20 --security-type AdminsOnly --package 04t5Y0000015pEnQAI`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust observability solution for Salesforce experts. Built 100% natively on the platform, and designed to work seamlessly with Apex, Lightning Components, Flow, OmniStudio, and integrations.
 
-## Unlocked Package - v4.15.6
+## Unlocked Package - v4.15.7
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015pEdQAI)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015pEdQAI)

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
   // There's no reliable way to get the version number dynamically in Apex
   @TestVisible
-  private static final String CURRENT_VERSION_NUMBER = 'v4.15.6';
+  private static final String CURRENT_VERSION_NUMBER = 'v4.15.7';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
   private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/__tests__/loggerStackTrace.test.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/__tests__/loggerStackTrace.test.js
@@ -20,6 +20,29 @@ describe('logger stack trace parsing tests', () => {
     jest.clearAllMocks();
   });
 
+  it('correctly handles undefined error', async () => {
+    const originStackTraceError = undefined;
+    const loggerStackTrace = new LoggerStackTrace();
+
+    const originStackTrace = loggerStackTrace.parse(originStackTraceError);
+
+    expect(originStackTrace.componentName).toBeUndefined();
+    expect(originStackTrace.functionName).toBeUndefined();
+    expect(originStackTrace.metadataType).toBeUndefined();
+  });
+
+  it('correctly handles non-null error with undefined stack trace', async () => {
+    const originStackTraceError = new Error();
+    originStackTraceError.stack = undefined;
+    const loggerStackTrace = new LoggerStackTrace();
+
+    const originStackTrace = loggerStackTrace.parse(originStackTraceError);
+
+    expect(originStackTrace.componentName).toBeUndefined();
+    expect(originStackTrace.functionName).toBeUndefined();
+    expect(originStackTrace.metadataType).toBeUndefined();
+  });
+
   it('correctly parses Chrome stack trace when debug mode is enabled', async () => {
     const loggerStackTrace = new LoggerStackTrace();
 

--- a/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/logger.js
@@ -27,6 +27,7 @@ export default class Logger extends LightningElement {
    * @param  {Object} fieldToValue An object containing the custom field name as a key, with the corresponding value to store.
    *                      Example: `{"SomeField__c": "some value", "AnotherField__c": "another value"}`
    */
+  @api
   setField(fieldToValue) {
     this.#loggerService.setField(fieldToValue);
   }

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
@@ -10,7 +10,7 @@ import LoggerServiceTaskQueue from './loggerServiceTaskQueue';
 import getSettings from '@salesforce/apex/ComponentLogger.getSettings';
 import saveComponentLogEntries from '@salesforce/apex/ComponentLogger.saveComponentLogEntries';
 
-const CURRENT_VERSION_NUMBER = 'v4.15.6';
+const CURRENT_VERSION_NUMBER = 'v4.15.7';
 
 const CONSOLE_OUTPUT_CONFIG = {
   messagePrefix: `%c  Nebula Logger ${CURRENT_VERSION_NUMBER}  `,

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerStackTrace.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerStackTrace.js
@@ -49,13 +49,11 @@ const SAFARI_NATIVE_CODE_REGEXP = /^(eval@)?(\[native code])?$/;
 
 class ErrorStackParser {
   parse(error) {
-    let stackTraceParticles;
+    let stackTraceParticles = [];
     if (error.stack && error.stack.match(CHROME_IE_STACK_REGEXP)) {
       stackTraceParticles = this.parseV8OrIE(error);
     } else if (error.stack) {
       stackTraceParticles = this.parseFFOrSafari(error);
-    } else {
-      throw new Error('Cannot parse given Error object');
     }
 
     return stackTraceParticles;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebula-logger",
-  "version": "4.15.6",
+  "version": "4.15.7",
   "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
   "author": "Jonathan Gillespie",
   "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
       "path": "./nebula-logger/core",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "scopeProfiles": true,
-      "versionNumber": "4.15.6.NEXT",
-      "versionName": "Adds tryCatch CallableLogger method",
-      "versionDescription": "tryCatch CallableLogger method for OmniStudio and other decoupled logging usages",
+      "versionNumber": "4.15.7.NEXT",
+      "versionName": "Jest test cleanup and stacktrace parsing bugfix",
+      "versionDescription": "Fixed an issue in LoggerStackTrace.js that would cause an unintended exception when there isn't a valid JS stack trace",
       "postInstallUrl": "https://github.com/jongpie/NebulaLogger/wiki",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -211,6 +211,7 @@
     "Nebula Logger - Core@4.15.4-flowlogger-exception-message-handling": "04t5Y0000015oklQAA",
     "Nebula Logger - Core@4.15.5-bugfix-for-authsession-with-null-loginhistory-exception-message-handling": "04t5Y0000015p5jQAA",
     "Nebula Logger - Core@4.15.6-adds-trycatch-callablelogger-method": "04t5Y0000015pEdQAI",
+    "Nebula Logger - Core@4.15.7-jest-test-cleanup-and-stacktrace-parsing-bugfix": "04t5Y0000015pEnQAI",
     "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
* Fixes #780 by cleaning up `logger.test.js`
* Fixes an issue in `LoggerStackTrace.js` that would cause an unintended exception when there isn't a valid JS stacktrace