### PR TITLE
Bugfix: entry save override is not always used

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust observability solution for Salesforce experts. Built 100% natively on the platform, and designed to work seamlessly with Apex, Lightning Components, Flow, OmniStudio, and integrations.
 
-## Unlocked Package - v4.15.8
+## Unlocked Package - v4.15.9
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015pFCQAY)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5Y0000015pFCQAY)

--- a/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
+++ b/nebula-logger/core/main/log-management/classes/LogEntryEventHandler.cls
@@ -85,8 +85,11 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
         continue;
       }
 
-      if (String.isBlank(loggingUserSettings.DefaultPlatformEventStorageLoggingLevel__c)) {
-        // DefaultPlatformEventStorageLoggingLevel__c is optional - if it's null, then always save the event
+      // DefaultPlatformEventStorageLoggingLevel__c is optional - if it's null, then always save the event
+      if (
+        logEntryEvent.EntrySaveReason__c == LogEntryEventBuilder.ENTRY_SAVE_REASON_OVERRIDE ||
+        String.isBlank(loggingUserSettings.DefaultPlatformEventStorageLoggingLevel__c)
+      ) {
         logEntryEventsToSave.add(logEntryEvent);
       } else {
         System.LoggingLevel userStorageLoggingLevel = System.LoggingLevel.valueOf(loggingUserSettings.DefaultPlatformEventStorageLoggingLevel__c);
@@ -272,6 +275,7 @@ public without sharing class LogEntryEventHandler extends LoggerSObjectHandler {
         DatabaseResultCollectionType__c = logEntryEvent.DatabaseResultCollectionType__c,
         DatabaseResultJson__c = logEntryEvent.DatabaseResultJson__c,
         DatabaseResultType__c = logEntryEvent.DatabaseResultType__c,
+        EntrySaveReason__c = logEntryEvent.EntrySaveReason__c,
         EpochTimestamp__c = logEntryEvent.EpochTimestamp__c,
         EventUuid__c = logEntryEvent.EventUuid,
         ExceptionLocation__c = logEntryEvent.ExceptionLocation__c,

--- a/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
+++ b/nebula-logger/core/main/log-management/flexipages/LogEntryRecordPage.flexipage-meta.xml
@@ -2072,6 +2072,29 @@
             <fieldInstance>
                 <fieldInstanceProperties>
                     <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.EntrySaveReason__c</fieldItem>
+                <identifier>RecordEntrySaveReason_cField</identifier>
+                <visibilityRule>
+                    <booleanFilter>1 OR 2</booleanFilter>
+                    <criteria>
+                        <leftValue>{!Record.EntrySaveReason__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Logging Level Met</rightValue>
+                    </criteria>
+                    <criteria>
+                        <leftValue>{!Record.EntrySaveReason__c}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Override</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
                     <value>readonly</value>
                 </fieldInstanceProperties>
                 <fieldItem>Record.EntryScenario__c</fieldItem>

--- a/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/EntrySaveReason__c.field-meta.xml
+++ b/nebula-logger/core/main/log-management/objects/LogEntry__c/fields/EntrySaveReason__c.field-meta.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EntrySaveReason__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <inlineHelpText>Indicates if entry was saved based on the logging user's settings, or based on a developer override in code</inlineHelpText>
+    <label>Entry Save Reason</label>
+    <required>false</required>
+    <securityClassification>Confidential</securityClassification>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Logging Level Met</fullName>
+                <default>false</default>
+                <label>Logging Level Met</label>
+            </value>
+            <value>
+                <fullName>Override</fullName>
+                <default>false</default>
+                <label>Override</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerAdmin.permissionset-meta.xml
@@ -268,6 +268,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.EntrySaveReason__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.EntryScenarioLink__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerEndUser.permissionset-meta.xml
@@ -119,6 +119,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.EntrySaveReason__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.EntryScenarioLink__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
+++ b/nebula-logger/core/main/log-management/permissionsets/LoggerLogViewer.permissionset-meta.xml
@@ -188,6 +188,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>LogEntry__c.EntrySaveReason__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>LogEntry__c.EntryScenarioLink__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -12,6 +12,9 @@
   'PMD.AvoidGlobalModifier, PMD.CognitiveComplexity, PMD.CyclomaticComplexity, PMD.ExcessiveClassLength, PMD.ExcessivePublicCount, PMD.NcssTypeCount, PMD.PropertyNamingConventions, PMD.StdCyclomaticComplexity'
 )
 global with sharing class LogEntryEventBuilder {
+  public static final String ENTRY_SAVE_REASON_LOGGING_LEVEL_MET = 'Logging Level Met';
+  public static final String ENTRY_SAVE_REASON_OVERRIDE = 'Override';
+
   private static final Map<String, String> CACHED_SOBJECT_NAME_TO_CLASSIFICATION = new Map<String, String>();
   private static final Schema.User CURRENT_USER = new Schema.User(Id = System.UserInfo.getUserId(), ProfileId = System.UserInfo.getProfileId());
   private static final String HTTP_HEADER_FORMAT = '{0}: {1}';
@@ -128,6 +131,7 @@ global with sharing class LogEntryEventBuilder {
       this.entryLoggingLevel = entryLoggingLevel;
 
       this.logEntryEvent = getLogEntryEventTemplate(entryLoggingLevel);
+      this.setSaveReason();
       this.setTimestamp(System.now());
     }
   }
@@ -848,6 +852,13 @@ global with sharing class LogEntryEventBuilder {
     return this.logEntryEvent;
   }
 
+  private void setSaveReason() {
+    System.LoggingLevel userLoggingLevel = System.LoggingLevel.valueOf(this.userSettings.LoggingLevel__c);
+    Boolean isEntryLoggingLevelEnabled = this.entryLoggingLevel.ordinal() >= userLoggingLevel.ordinal();
+
+    this.logEntryEvent.EntrySaveReason__c = isEntryLoggingLevelEnabled ? ENTRY_SAVE_REASON_LOGGING_LEVEL_MET : ENTRY_SAVE_REASON_OVERRIDE;
+  }
+
   @SuppressWarnings('PMD.AvoidDebugStatements')
   private void logToApexDebug(String message) {
     if (this.userSettings.IsApexSystemDebugLoggingEnabled__c == false) {
@@ -861,6 +872,7 @@ global with sharing class LogEntryEventBuilder {
         if (String.isBlank(possibleReplacement)) {
           continue;
         }
+
         String logEntryFieldName = possibleReplacement.substringBefore('}');
         Object logEntryFieldValue = this.logEntryEvent.get(logEntryFieldName);
         if (logEntryFieldValue == null) {

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
   // There's no reliable way to get the version number dynamically in Apex
   @TestVisible
-  private static final String CURRENT_VERSION_NUMBER = 'v4.15.8';
+  private static final String CURRENT_VERSION_NUMBER = 'v4.15.9';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
   private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -366,7 +366,7 @@ global with sharing class Logger {
    * @return Boolean
    */
   global static Boolean meetsUserLoggingLevel(System.LoggingLevel logEntryLoggingLevel) {
-    return userLoggingLevel.ordinal() <= logEntryLoggingLevel.ordinal();
+    return logEntryLoggingLevel.ordinal() >= userLoggingLevel.ordinal();
   }
 
   /**

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
@@ -10,7 +10,7 @@ import LoggerServiceTaskQueue from './loggerServiceTaskQueue';
 import getSettings from '@salesforce/apex/ComponentLogger.getSettings';
 import saveComponentLogEntries from '@salesforce/apex/ComponentLogger.saveComponentLogEntries';
 
-const CURRENT_VERSION_NUMBER = 'v4.15.8';
+const CURRENT_VERSION_NUMBER = 'v4.15.9';
 
 const CONSOLE_OUTPUT_CONFIG = {
   messagePrefix: `%c  Nebula Logger ${CURRENT_VERSION_NUMBER}  `,

--- a/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/EntrySaveReason__c.field-meta.xml
+++ b/nebula-logger/core/main/logger-engine/objects/LogEntryEvent__e/fields/EntrySaveReason__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EntrySaveReason__c</fullName>
+    <businessStatus>Active</businessStatus>
+    <complianceGroup>None</complianceGroup>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Entry Save Reason</label>
+    <length>255</length>
+    <required>false</required>
+    <securityClassification>Confidential</securityClassification>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LogEntryEventHandler_Tests.cls
@@ -231,6 +231,51 @@ private class LogEntryEventHandler_Tests {
   }
 
   @IsTest
+  static void it_should_create_log_and_log_entry_data_when_event_save_reason_is_override() {
+    LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
+    LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
+    LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.Log__c.SObjectType).IsEnabled__c = false;
+    LoggerTestConfigurator.getSObjectHandlerConfiguration(Schema.LogEntry__c.SObjectType).IsEnabled__c = false;
+    Integer countOfLogs = [SELECT COUNT() FROM Log__c];
+    System.Assert.areEqual(0, countOfLogs);
+    Integer countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
+    System.Assert.areEqual(0, countOfLogEntries);
+    LoggerSettings__c settings = Logger.getUserSettings();
+    settings.IsEnabled__c = true;
+    settings.IsSavingEnabled__c = true;
+    settings.DefaultPlatformEventStorageLocation__c = LogEntryEventHandler.DEFAULT_STORAGE_LOCATION_NAME;
+    settings.DefaultPlatformEventStorageLoggingLevel__c = System.LoggingLevel.ERROR.name();
+    settings.LoggingLevel__c = System.LoggingLevel.WARN.name();
+    upsert settings;
+    LogEntryEvent__e logEntryEventWithOverride = createLogEntryEvent();
+    logEntryEventWithOverride.EntrySaveReason__c = 'Override';
+    logEntryEventWithOverride.LoggingLevel__c = System.LoggingLevel.FINEST.name();
+    logEntryEventWithOverride.Message__c = 'Entry with save reason == Override';
+    LogEntryEvent__e logEntryEventWithoutOverride = createLogEntryEvent();
+    logEntryEventWithoutOverride.EntrySaveReason__c = 'Any other value';
+    logEntryEventWithoutOverride.LoggingLevel__c = System.LoggingLevel.FINEST.name();
+    logEntryEventWithoutOverride.Message__c = 'Entry with a different save reason';
+
+    List<Database.SaveResult> saveResults = LoggerMockDataStore.getEventBus()
+      .publishRecords(new List<SObject>{ logEntryEventWithOverride, logEntryEventWithoutOverride });
+    LoggerMockDataStore.getEventBus().deliver(new LogEntryEventHandler());
+
+    System.Assert.areEqual(2, saveResults.size());
+    System.Assert.isTrue(saveResults.get(0).isSuccess(), saveResults.get(0).getErrors().toString());
+    System.Assert.isTrue(saveResults.get(1).isSuccess(), saveResults.get(1).getErrors().toString());
+    System.Assert.areEqual(
+      1,
+      LoggerSObjectHandler.getExecutedHandlers().get(Schema.LogEntryEvent__e.SObjectType).size(),
+      'Handler class should have executed one time for AFTER_INSERT'
+    );
+    countOfLogs = [SELECT COUNT() FROM Log__c];
+    System.Assert.areEqual(1, countOfLogs);
+    countOfLogEntries = [SELECT COUNT() FROM LogEntry__c];
+    System.Assert.areEqual(1, countOfLogEntries);
+    System.Assert.areEqual(logEntryEventWithOverride.Message__c, [SELECT Message__c FROM LogEntry__c].Message__c);
+  }
+
+  @IsTest
   static void it_should_normalize_event_data_into_log_and_log_entry_when_no_scenario_specified() {
     LoggerDataStore.setMock(LoggerMockDataStore.getEventBus());
     LoggerTestConfigurator.setupMockSObjectHandlerConfigurations();
@@ -1430,6 +1475,7 @@ private class LogEntryEventHandler_Tests {
             DatabaseResultCollectionType__c,
             DatabaseResultJson__c,
             DatabaseResultType__c,
+            EntrySaveReason__c,
             EntryScenario__c,
             EntryScenario__r.Name,
             EntryScenario__r.UniqueId__c,
@@ -1653,6 +1699,7 @@ private class LogEntryEventHandler_Tests {
     );
     System.Assert.areEqual(logEntryEvent.DatabaseResultJson__c, logEntry.DatabaseResultJson__c, 'logEntry.DatabaseResultJson__c was not properly set');
     System.Assert.areEqual(logEntryEvent.DatabaseResultType__c, logEntry.DatabaseResultType__c, 'logEntry.DatabaseResultType__c was not properly set');
+    System.Assert.areEqual(logEntryEvent.EntrySaveReason__c, logEntry.EntrySaveReason__c, 'logEntry.EntrySaveReason__c was not properly set');
     System.Assert.areEqual(logEntryEvent.EpochTimestamp__c, logEntry.EpochTimestamp__c, 'logEntry.EpochTimestamp__c was not properly set');
     System.Assert.areEqual(logEntryEvent.ExceptionLocation__c, logEntry.ExceptionLocation__c, 'logEntry.ExceptionLocation__c was not properly set');
     System.Assert.areEqual(

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -1912,13 +1912,51 @@ private class LogEntryEventBuilder_Tests {
   @IsTest
   static void it_should_return_value_of_shouldSave_when_true() {
     LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, true);
+
     System.Assert.isTrue(builder.shouldSave());
+    System.Assert.isNotNull(builder.getLogEntryEvent().EntrySaveReason__c);
   }
 
   @IsTest
   static void it_should_return_value_of_shouldSave_when_false() {
     LogEntryEventBuilder builder = new LogEntryEventBuilder(getUserSettings(), System.LoggingLevel.INFO, false);
+
     System.Assert.isFalse(builder.shouldSave());
+    System.Assert.isNull(builder.getLogEntryEvent());
+  }
+
+  @IsTest
+  static void it_should_set_save_reason_when_user_logging_level_met() {
+    System.LoggingLevel userLoggingLevel = System.LoggingLevel.INFO;
+    System.LoggingLevel entryLoggingLevel = System.LoggingLevel.WARN;
+    System.Assert.isTrue(
+      entryLoggingLevel.ordinal() > userLoggingLevel.ordinal(),
+      'Test has started under the wrong conditions, the entry logging level should meet the user logging level'
+    );
+    LoggerSettings__c userSettings = getUserSettings();
+    userSettings.LoggingLevel__c = userLoggingLevel.name();
+
+    LogEntryEventBuilder builder = new LogEntryEventBuilder(userSettings, entryLoggingLevel, true);
+
+    System.Assert.isTrue(builder.shouldSave());
+    System.Assert.areEqual('Logging Level Match', builder.getLogEntryEvent().EntrySaveReason__c);
+  }
+
+  @IsTest
+  static void it_should_set_save_reason_when_entry_saving_is_overridden() {
+    System.LoggingLevel userLoggingLevel = System.LoggingLevel.INFO;
+    System.LoggingLevel entryLoggingLevel = System.LoggingLevel.FINE;
+    System.Assert.isTrue(
+      entryLoggingLevel.ordinal() < userLoggingLevel.ordinal(),
+      'Test has started under the wrong conditions, the entry logging level should NOT meet the user logging level'
+    );
+    LoggerSettings__c userSettings = getUserSettings();
+    userSettings.LoggingLevel__c = userLoggingLevel.name();
+
+    LogEntryEventBuilder builder = new LogEntryEventBuilder(userSettings, entryLoggingLevel, true);
+
+    System.Assert.isTrue(builder.shouldSave());
+    System.Assert.areEqual('Override', builder.getLogEntryEvent().EntrySaveReason__c);
   }
 
   @IsTest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebula-logger",
-  "version": "4.15.8",
+  "version": "4.15.9",
   "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
   "author": "Jonathan Gillespie",
   "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
       "path": "./nebula-logger/core",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "scopeProfiles": true,
-      "versionNumber": "4.15.8.NEXT",
-      "versionName": "Log__c.ParentLogTransactionId__c Custom Index",
-      "versionDescription": "Fixes an issue with high-volume calls to LogManagementDataSelector.getLogsWithoutParentLogByParentTransactionId()",
+      "versionNumber": "4.15.9.NEXT",
+      "versionName": "New EntrySaveReason__c Fields on LogEntryEvent__e and LogEntry__c",
+      "versionDescription": "Added new fields EntrySaveReason__c on LogEntryEvent__e & LogEntry__c to explicitly track why an entry is saved. This is now also used in LogEntryEventHandler.filterLogEntryEventsToSave() to ensure these types of entries are saved in LogEntry__c.",
       "postInstallUrl": "https://github.com/jongpie/NebulaLogger/wiki",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {


### PR DESCRIPTION
Fixed #856 by adding a few code & config changes to ensure that entries are correctly saved when developers have overridden the `shouldSave` flag on entries when calling one of the `Logger.newEntry()` method overloads.

- Added new fields `EntrySaveReason__c` on `LogEntryEvent__e` & `LogEntry__c` to explicitly track why an entry is saved, with 2 possible values:
    1. `Logging Level Met`: indicates that the entry was saved because the entry's specified logging level meets the logging user's configured logging level settings, stored in `LoggerSettings__c.LoggingLevel__c`.
    2. `Override`: indicates that the entry was saved because a developer has overridden in code the `shouldSave` flag for the entry. This is done by developers to ensure certain entries are always logged, regardless of the user's configured logging level.
- Updated `LogEntryEventBuilder` and `LogEntryEventHandler` to set the new fields on `LogEntryEvent__e` and `LogEntry__c`.
    - Going forward, all new `LogEntryEvent__e` and `LogEntry__c` records will now have a value populated in `EntrySaveReason__c`.
    - Existing `LogEntry__c` records will still have `null` - no changes are being introduced to backfill the data.
- Updated the logic in `LogEntryEventHandler.filterLogEntryEventsToSave()` to check the value of the new field `LogEntryEvent__e.EntrySaveReason__c`. Any entries with a save reason of `Override` are always saved in `LogEntry__c` (which is the piece that directly fixes #856).
- The flexipage `LogEntryRecordPage` has also been updated to display the new field `LogEntry__c.EntrySaveReason__c` when it's populated. For any existing `LogEntry__c` records with a `null` value, the flexipage will hide the field.

    ![image](https://github.com/user-attachments/assets/da9381be-43d2-4004-bd2b-e8ec75ca4ded)

    ![image](https://github.com/user-attachments/assets/5e28779c-d361-47f4-bbf8-3795b0550109)


