### PR TITLE
Origin Location Parsing Improvement

### DIFF
--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -515,7 +515,7 @@ global with sharing class LogEntryEventBuilder {
    * @return                  The same instance of `LogEntryEventBuilder`, useful for chaining methods
    */
   global LogEntryEventBuilder setRecord(Map<Id, SObject> recordIdToRecord) {
-    if (this.shouldSave == false) {
+    if (this.shouldSave() == false) {
       return this;
     }
 

--- a/nebula-logger/core/main/logger-engine/classes/LoggerStackTrace.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerStackTrace.cls
@@ -134,6 +134,10 @@ public without sharing class LoggerStackTrace {
     }
 
     String firstStackTraceLine = cleansedStackTraceLines.get(0);
+    if (firstStackTraceLine == 'External entry point' && cleansedStackTraceLines.size() > 1) {
+      firstStackTraceLine = cleansedStackTraceLines.get(1);
+    }
+
     String cleanedLocation = firstStackTraceLine;
     if (cleanedLocation.contains(':')) {
       cleanedLocation = cleanedLocation.substringBefore(':');

--- a/nebula-logger/core/tests/logger-engine/classes/LoggerStackTrace_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LoggerStackTrace_Tests.cls
@@ -237,6 +237,18 @@ private class LoggerStackTrace_Tests {
     System.Assert.isNull(stackTrace.Source);
   }
 
+  @IsTest
+  static void it_should_ignore_external_entry_point_stack_trace_line() {
+    String externalEntryPointStackTrace = 'External entry point';
+    String mockStackTrace = externalEntryPointStackTrace + '\n' + 'Class.SomeClass.someMethod: line 1, column 1';
+
+    LoggerStackTrace stackTrace = new LoggerStackTrace(mockStackTrace);
+
+    System.Assert.areEqual(LoggerStackTrace.SourceLanguage.Apex, stackTrace.Language);
+    System.Assert.areEqual('SomeClass.someMethod', stackTrace.Location);
+    System.Assert.areEqual(mockStackTrace, stackTrace.ParsedStackTraceString);
+  }
+
   private class DebugStringExample {
     private System.Exception constructorStackTraceGenerator;
     private System.Exception methodStackTraceGenerator;

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -10,8 +10,8 @@
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "scopeProfiles": true,
       "versionNumber": "4.16.0.NEXT",
-      "versionName": "Spring '25 Release",
-      "versionDescription": "Updated all metadata to API v63.0, made some bugfixes & improvements to CallableLogger",
+      "versionName": "Origin Location Parsing Improvements",
+      "versionDescription": "Tweaked how origin location is parsed when External entry point is the first line of a stack trace",
       "postInstallUrl": "https://github.com/jongpie/NebulaLogger/wiki",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {


### PR DESCRIPTION
Slight tweak to origin location stack trace parsing in Apex to improve how origin location is displayed

Noticed while we were cross-checking the following issue: https://github.com/jamessimone/apex-rollup/issues/683#issuecomment-2905926830