### PR TITLE
Bugfix: logger LWC Initialization Message

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,7 +3,7 @@ coverage:
     project:
       default:
         target: 90%
-        threshold: 2%
+        threshold: 5%
         if_ci_failed: success
       Apex:
         target: 90%

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust observability solution for Salesforce experts. Built 100% natively on the platform, and designed to work seamlessly with Apex, Lightning Components, Flow, OmniStudio, and integrations.
 
-## Unlocked Package - v4.16.3
+## Unlocked Package - v4.16.4
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKe0000011Mr1IAE)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKe0000011Mr1IAE)

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The most robust observability solution for Salesforce experts. Built 100% native
 
 ## Unlocked Package - v4.16.4
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKe0000011Mr1IAE)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKe0000011Mr1IAE)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKe0000011MyWIAU)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKe0000011MyWIAU)
 [![View Documentation](./images/btn-view-documentation.png)](https://github.com/jongpie/NebulaLogger/wiki)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04tKe0000011Mr1IAE`
+`sf package install --wait 20 --security-type AdminsOnly --package 04tKe0000011MyWIAU`
 
 ---
 

--- a/nebula-logger/core/main/configuration/objects/LoggerScenarioRule__mdt/fields/IsLogAssignmentEnabled__c.field-meta.xml
+++ b/nebula-logger/core/main/configuration/objects/LoggerScenarioRule__mdt/fields/IsLogAssignmentEnabled__c.field-meta.xml
@@ -5,7 +5,7 @@
     <complianceGroup>PII;GDPR;CCPA</complianceGroup>
     <fieldManageability>DeveloperControlled</fieldManageability>
     <inlineHelpText>Controls if new Log__c records associated with the scenario (based on Log__c.TransactionScenario__c) are automatically assigned to the owner of the LoggerScenario__c record.</inlineHelpText>
-    <label>Assign Logs To Log Scenario Owner</label>
+    <label>Assign Logs To Logger Scenario Owner</label>
     <required>false</required>
     <securityClassification>Confidential</securityClassification>
     <type>Picklist</type>

--- a/nebula-logger/core/main/log-management/classes/LogBatchPurger.cls
+++ b/nebula-logger/core/main/log-management/classes/LogBatchPurger.cls
@@ -165,11 +165,8 @@ global with sharing class LogBatchPurger implements Database.Batchable<SObject>,
    * @return                  The same instance of `LogBatchPurger`, useful for chaining methods
    */
   public LogBatchPurger setChainedBatchSize(Integer chainedBatchSize) {
-    if (chainedBatchSize != null) {
-      this.chainedBatchSize = chainedBatchSize;
-    } else {
-      this.chainedBatchSize = getDefaultBatchSize();
-    }
+    this.chainedBatchSize = chainedBatchSize ?? LogBatchPurger.getDefaultBatchSize();
+
     return this;
   }
 

--- a/nebula-logger/core/main/log-management/lwc/logBatchPurge/__tests__/logBatchPurge.test.js
+++ b/nebula-logger/core/main/log-management/lwc/logBatchPurge/__tests__/logBatchPurge.test.js
@@ -1,5 +1,5 @@
 // UI
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import LightningConfirm from 'lightning/confirm';
 import logBatchPurge from 'c/logBatchPurge';
 import { when } from 'jest-when';

--- a/nebula-logger/core/main/log-management/lwc/logEntryEventStream/__tests__/logEntryEventStream.test.js
+++ b/nebula-logger/core/main/log-management/lwc/logEntryEventStream/__tests__/logEntryEventStream.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import LogEntryEventStream from 'c/logEntryEventStream';
 import { jestMockPublish } from 'lightning/empApi';
 import getSchemaForName from '@salesforce/apex/LoggerSObjectMetadata.getSchemaForName';

--- a/nebula-logger/core/main/log-management/lwc/logOrganizationLimits/__tests__/logOrganizationLimits.test.js
+++ b/nebula-logger/core/main/log-management/lwc/logOrganizationLimits/__tests__/logOrganizationLimits.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import LogOrganizationLimits from 'c/logOrganizationLimits';
 import { getRecord } from 'lightning/uiRecordApi';
 

--- a/nebula-logger/core/main/log-management/lwc/logViewer/__tests__/logViewer.test.js
+++ b/nebula-logger/core/main/log-management/lwc/logViewer/__tests__/logViewer.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import LogViewer from 'c/logViewer';
 import getLog from '@salesforce/apex/LogViewerController.getLog';
 

--- a/nebula-logger/core/main/log-management/lwc/loggerCodeViewer/__tests__/loggerCodeViewer.test.js
+++ b/nebula-logger/core/main/log-management/lwc/loggerCodeViewer/__tests__/loggerCodeViewer.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import LoggerCodeViewer from 'c/loggerCodeViewer';
 
 jest.mock(

--- a/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/__tests__/loggerHomeHeader.test.js
+++ b/nebula-logger/core/main/log-management/lwc/loggerHomeHeader/__tests__/loggerHomeHeader.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import LoggerHomeHeader from 'c/loggerHomeHeader';
 import getEnvironmentDetails from '@salesforce/apex/LoggerHomeHeaderController.getEnvironmentDetails';
 

--- a/nebula-logger/core/main/log-management/lwc/loggerPageSection/__tests__/loggerPageSection.test.js
+++ b/nebula-logger/core/main/log-management/lwc/loggerPageSection/__tests__/loggerPageSection.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import LoggerPageSection from 'c/loggerPageSection';
 
 describe('c-logger-page-section', () => {

--- a/nebula-logger/core/main/log-management/lwc/loggerSettings/__tests__/loggerSettings.test.js
+++ b/nebula-logger/core/main/log-management/lwc/loggerSettings/__tests__/loggerSettings.test.js
@@ -1,5 +1,5 @@
 // UI
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import LoggerSettings from 'c/loggerSettings';
 
 // LoggerSettings__c metadata

--- a/nebula-logger/core/main/log-management/lwc/relatedLogEntries/__tests__/relatedLogEntries.test.js
+++ b/nebula-logger/core/main/log-management/lwc/relatedLogEntries/__tests__/relatedLogEntries.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import { registerApexTestWireAdapter } from '@salesforce/sfdx-lwc-jest';
 import RelatedLogEntries from 'c/relatedLogEntries';
 import getQueryResult from '@salesforce/apex/RelatedLogEntriesController.getQueryResult';

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
   // There's no reliable way to get the version number dynamically in Apex
   @TestVisible
-  private static final String CURRENT_VERSION_NUMBER = 'v4.16.3';
+  private static final String CURRENT_VERSION_NUMBER = 'v4.16.4';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
   private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/__tests__/logger.test.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/__tests__/logger.test.js
@@ -1,7 +1,6 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import FORM_FACTOR from '@salesforce/client/formFactor';
-import { BrowserContext } from '../loggerService';
-import LoggerService from '../loggerService';
+import LoggerService, { BrowserContext } from '../loggerService';
 // Recommended import getLogger & deprecated import createLogger
 import { getLogger, createLogger } from 'c/logger';
 // Legacy markup-based approach

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
@@ -10,7 +10,7 @@ import LoggerServiceTaskQueue from './loggerServiceTaskQueue';
 import getSettings from '@salesforce/apex/ComponentLogger.getSettings';
 import saveComponentLogEntries from '@salesforce/apex/ComponentLogger.saveComponentLogEntries';
 
-const CURRENT_VERSION_NUMBER = 'v4.16.3';
+const CURRENT_VERSION_NUMBER = 'v4.16.4';
 
 const CONSOLE_OUTPUT_CONFIG = {
   messagePrefix: `%c  Nebula Logger ${CURRENT_VERSION_NUMBER}  `,

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
@@ -26,16 +26,6 @@ const LOGGING_LEVEL_EMOJIS = {
   FINEST: '🌟'
 };
 
-let areSystemMessagesEnabled = true;
-
-export function enableSystemMessages() {
-  areSystemMessagesEnabled = true;
-}
-
-export function disableSystemMessages() {
-  areSystemMessagesEnabled = false;
-}
-
 export class BrowserContext {
   address = window.location.href;
   formFactor = FORM_FACTOR;
@@ -47,6 +37,7 @@ export class BrowserContext {
 
 /* eslint-disable @lwc/lwc/no-dupe-class-members */
 export default class LoggerService {
+  static areSystemMessagesEnabled = true;
   static hasInitialized = false;
 
   #componentFieldToValue = {};
@@ -165,13 +156,10 @@ export default class LoggerService {
           userLoggingLevel: Object.freeze(retrievedSettings.userLoggingLevel)
         });
 
-        if (areSystemMessagesEnabled && !LoggerService.hasInitialized) {
-          LoggerService.hasInitialized = true;
-
-          if (this.#settings.isConsoleLoggingEnabled) {
-            this._logToConsole('INFO', 'logger component initialized\n' + JSON.stringify(new BrowserContext(), null, 2));
-          }
+        if (!LoggerService.hasInitialized && LoggerService.areSystemMessagesEnabled && this.#settings.isConsoleLoggingEnabled) {
+          this._logToConsole('INFO', 'logger component initialized\n' + JSON.stringify(new BrowserContext(), null, 2));
         }
+        LoggerService.hasInitialized = true;
       } catch (error) {
         /* eslint-disable-next-line no-console */
         console.error(error);

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
@@ -57,12 +57,6 @@ export default class LoggerService {
 
   constructor() {
     this._loadSettingsFromServer();
-
-    if (areSystemMessagesEnabled && !LoggerService.hasInitialized) {
-      this._logToConsole('INFO', 'logger component initialized\n' + JSON.stringify(new BrowserContext(), null, 2));
-
-      LoggerService.hasInitialized = true;
-    }
   }
 
   // TODO deprecate? Or make it async?
@@ -170,6 +164,14 @@ export default class LoggerService {
           supportedLoggingLevels: Object.freeze(retrievedSettings.supportedLoggingLevels),
           userLoggingLevel: Object.freeze(retrievedSettings.userLoggingLevel)
         });
+
+        if (areSystemMessagesEnabled && !LoggerService.hasInitialized) {
+          LoggerService.hasInitialized = true;
+
+          if (this.#settings.isConsoleLoggingEnabled) {
+            this._logToConsole('INFO', 'logger component initialized\n' + JSON.stringify(new BrowserContext(), null, 2));
+          }
+        }
       } catch (error) {
         /* eslint-disable-next-line no-console */
         console.error(error);
@@ -183,10 +185,12 @@ export default class LoggerService {
 
   _newEntry(loggingLevel, message, originStackTraceError) {
     originStackTraceError = originStackTraceError ?? new Error();
+
     const logEntryBuilder = new LogEntryEventBuilder(loggingLevel, new BrowserContext())
       .parseStackTrace(originStackTraceError)
       .setMessage(message)
       .setScenario(this.#scenario);
+
     const logEntry = logEntryBuilder.getComponentLogEntry();
     Object.assign(logEntry.fieldToValue, this.#componentFieldToValue);
 

--- a/nebula-logger/plugins/big-object-archiving/plugin/lwc/logEntryArchives/__tests__/logEntryArchives.test.js
+++ b/nebula-logger/plugins/big-object-archiving/plugin/lwc/logEntryArchives/__tests__/logEntryArchives.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import LogEntryArchives from 'c/logEntryArchives';
 import getLogEntryArchives from '@salesforce/apex/LogEntryArchiveController.getLogEntryArchives';
 import getSchemaForName from '@salesforce/apex/LoggerSObjectMetadata.getSchemaForName';

--- a/nebula-logger/recipes/lwc/loggerLWCCreateLoggerImportDemo/__tests__/loggerLWCCreateLoggerImportDemo.test.js
+++ b/nebula-logger/recipes/lwc/loggerLWCCreateLoggerImportDemo/__tests__/loggerLWCCreateLoggerImportDemo.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import { getLogger } from 'c/logger';
 import loggerLWCCreateLoggerImportDemo from 'c/loggerLWCCreateLoggerImportDemo';
 

--- a/nebula-logger/recipes/lwc/loggerLWCGetLoggerImportDemo/__tests__/loggerLWCGetLoggerImportDemo.test.js
+++ b/nebula-logger/recipes/lwc/loggerLWCGetLoggerImportDemo/__tests__/loggerLWCGetLoggerImportDemo.test.js
@@ -1,4 +1,4 @@
-import { createElement } from 'lwc';
+import { createElement } from '@lwc/engine-dom';
 import loggerLWCGetLoggerImportDemo from 'c/loggerLWCGetLoggerImportDemo';
 
 import getSettings from '@salesforce/apex/ComponentLogger.getSettings';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebula-logger",
-  "version": "4.16.3",
+  "version": "4.16.4",
   "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
   "author": "Jonathan Gillespie",
   "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
       "path": "./nebula-logger/core",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "scopeProfiles": true,
-      "versionNumber": "4.16.3.NEXT",
-      "versionName": "Configurable Batch Size for LogBatchPurger",
-      "versionDescription": "Added new LoggerParameter__mdt record LogBatchPurgerDefaultBatchSize to control the default batch size used by the batchable Apex class LogBatchPurger",
+      "versionNumber": "4.16.4.NEXT",
+      "versionName": "Bugfix: Logger LWC Initialization Message",
+      "versionDescription": "Fixed issue where the logger LWC initialization message was always being logged, even when JavaScript console logging was disabled via LoggerSettings__c.IsConsoleLoggingEnabled__c",
       "postInstallUrl": "https://github.com/jongpie/NebulaLogger/wiki",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -219,6 +219,7 @@
     "Nebula Logger - Core@4.16.1-data-masking-&-string-truncation-improvements": "04tKe0000011MXEIA2",
     "Nebula Logger - Core@4.16.2-origin-location-parsing-improvements": "04tKe0000011Mi9IAE",
     "Nebula Logger - Core@4.16.3-configurable-batch-size-for-logbatchpurger": "04tKe0000011Mr1IAE",
+    "Nebula Logger - Core@4.16.4-bugfix:-logger-lwc-initialization-message": "04tKe0000011MyWIAU",
     "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
Fixed #870 by updating the `logger` LWC initialization message to only print when JavaScript console logging is enabled via `LoggerSettings__c`. Also resolved some test isolation issues in `logger.test.js` + test improvements + code cleanup

- Updated `loggerService.js` to only call `console.info()` with an init message ('logger component initialized') when console logging is enabled via `LoggerSettings__c.IsJavaScriptConsoleLoggingEnabled__c`
- Replaced `enableSystemMessages()` and `disableSystemMessages()` in `loggerService.js` with a new static variable `LoggerService.areSystemMessagesEnabled` (intended for internal-use only)
- Updated `logger.test.js` to reset `LoggerService.hasInitialized` and `LoggerService.areSystemMessagesEnabled` static variables in `beforeEach()` (instead of `afterAll()`)
- Switched to using `jest.resetAllMocks()` instead of `jest.clearAllMocks()` in `logger.test.js` for better test isolation
- Updated all test functions to consistently use all 3 logger creation methods (`createLogger`, `getLogger`, and `getMarkupLogger`)

Also include a 🤏 liiiiiiitle bit of scope creep:
- Updated all Jest tests to import createElement from '@lwc/engine-dom' (instead of 'lwc')
- Updated the project's threshold for code coverage in `codecov.yml` to compensate for the lower code coverage in LWC tests for now (currently around ~86%). Eventually, tests & code coverage for LWC will be improved - but for now, the constant pipeline alerts from codecov.io aren't particularly helpful 😅 
- Cleaned up a small code block in `LogBatchPurger` using the null coalescing operator (??) to reduce the lines of code needed
- Corrected the label on field `LoggerScenarioRule__mdt.IsLogAssignmentEnabled__c` to use the term `Logger Scenario`, instead of the deprecated term `Log Scenario`