### PR TITLE
Bugfix: handle dumb breaking platform change for verified email domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The most robust observability solution for Salesforce experts. Built 100% native
 
 ## Unlocked Package - v4.17.4
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tg70000001IMHAA2)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tg70000001IMHAA2)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tg70000004jmXAAQ)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tg70000004jmXAAQ)
 [![View Documentation](./images/btn-view-documentation.png)](https://github.com/jongpie/NebulaLogger/wiki)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04tg70000001IMHAA2`
+`sf package install --wait 20 --security-type AdminsOnly --package 04tg70000004jmXAAQ`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust observability solution for Salesforce experts. Built 100% natively on the platform, and designed to work seamlessly with Apex, Lightning Components, Flow, OmniStudio, and integrations.
 
-## Unlocked Package - v4.17.3
+## Unlocked Package - v4.17.4
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tg70000001IMHAA2)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tg70000001IMHAA2)

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
   // There's no reliable way to get the version number dynamically in Apex
   @TestVisible
-  private static final String CURRENT_VERSION_NUMBER = 'v4.17.3';
+  private static final String CURRENT_VERSION_NUMBER = 'v4.17.4';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
   private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
@@ -10,7 +10,7 @@ import LoggerServiceTaskQueue from './loggerServiceTaskQueue';
 import getSettings from '@salesforce/apex/ComponentLogger.getSettings';
 import saveComponentLogEntries from '@salesforce/apex/ComponentLogger.saveComponentLogEntries';
 
-const CURRENT_VERSION_NUMBER = 'v4.17.3';
+const CURRENT_VERSION_NUMBER = 'v4.17.4';
 
 const CONSOLE_OUTPUT_CONFIG = {
   messagePrefix: `%c  Nebula Logger ${CURRENT_VERSION_NUMBER}  `,

--- a/nebula-logger/core/tests/log-management/classes/LoggerEmailSender_Tests.cls
+++ b/nebula-logger/core/tests/log-management/classes/LoggerEmailSender_Tests.cls
@@ -4,7 +4,7 @@
 //------------------------------------------------------------------------------------------------//
 
 @SuppressWarnings('PMD.MethodNamingConventions, PMD.PropertyNamingConventions')
-@IsTest(IsParallel=true)
+@IsTest(IsParallel=false)
 private class LoggerEmailSender_Tests {
   private static final Boolean IS_EMAIL_DELIVERABILITY_ENABLED {
     get {
@@ -24,6 +24,12 @@ private class LoggerEmailSender_Tests {
   static {
     // Don't use the org's actual custom metadata records when running tests
     LoggerConfigurationSelector.useMocks();
+
+    // Salesforce now sends email only from verified domains, with a few exceptions for domains like gmail.com & hotmail.com
+    // To avoid the error "INSUFFICIENT_ACCESS_OR_READONLY, We can't send your email because your email address domain isn't verified.",
+    // a fake gmail.com address is used on the current user.
+    // Docs: https://help.salesforce.com/s/articleView?id=xcloud.security_user_email_verification_substitute_domain.htm&type=5
+    update new Schema.User(Id = System.UserInfo.getUserId(), Email = 'nebula.logger.testing.fake@gmail.com');
   }
 
   @IsTest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebula-logger",
-  "version": "4.17.3",
+  "version": "4.17.4",
   "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
   "author": "Jonathan Gillespie",
   "license": "MIT",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
       "path": "./nebula-logger/core",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "scopeProfiles": true,
-      "versionNumber": "4.17.3.NEXT",
-      "versionName": "relatedLogEntries LWC Improvements",
-      "versionDescription": "Improved relatedLogEntries LWC so it queries & finds even more LogEntry__c records, added support for picklist labels, improved layout so it visually better aligns with the appearance of standard related lists",
+      "versionNumber": "4.17.4.NEXT",
+      "versionName": "LoggerEmailSender_Tests Fix for New Platform Requirement of Verified Email Domains",
+      "versionDescription": "Updated LoggerEmailSender_Tests to first update the current user's email address to be a (fake) gmail.com address to avoid issues with the new & breaking-change that requires most email domains to be verified (even in tests)",
       "postInstallUrl": "https://github.com/jongpie/NebulaLogger/wiki",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -225,6 +225,7 @@
     "Nebula Logger - Core@4.17.1-bugfix:-allowing-to-log-sobject-without-id-field": "04tg7000000157JAAQ",
     "Nebula Logger - Core@4.17.2-bugfix:-modal-close-buttons-not-rendered-correctly": "04tg700000015gnAAA",
     "Nebula Logger - Core@4.17.3-relatedlogentries-lwc-improvements": "04tg70000001IMHAA2",
+    "Nebula Logger - Core@4.17.4-loggeremailsender_tests-fix-for-new-platform-requirement-of-verified-email-domains": "04tg70000004jmXAAQ",
     "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
Fixed #972 by updating the current user's email address to a (fake) `gmail.com` address in `LoggerEmailSender_Tests` - `gmail.com` is one of a few domains that don't have to be verified