### PR TITLE
Bugfix: do not load Session Id in a JWT session (#761, #964)

### DIFF
--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -86,13 +86,44 @@ global with sharing class Logger {
     set;
   }
 
+  private static Boolean IS_JWT_SESSION {
+    get {
+      if (IS_JWT_SESSION == null) {
+        Boolean hasCurrentSession = false;
+        Boolean hasJwtSession = false;
+        
+        for (AuthSession session : [
+          SELECT IsCurrent, IsAssociatedWithJwtAccessToken
+          FROM AuthSession
+          WHERE UsersId = :System.UserInfo.getUserId()
+        ]) {
+          if (session.IsAssociatedWithJwtAccessToken) {
+            hasJwtSession = true;
+          }
+          else if (session.IsCurrent) {
+            hasCurrentSession = true;
+          }
+        }
+        
+        IS_JWT_SESSION = !hasCurrentSession && hasJwtSession;
+      }
+      
+      return IS_JWT_SESSION ;
+    }
+    set;
+  }
+
   private static final String USER_SESSION_ID {
     get {
       if (USER_SESSION_ID == null) {
         // TODO Spring '24 release - simplify this (and other lazy-loaded values)
         // by switching to the fancy, new ?? null coalescing operator
         try {
-          USER_SESSION_ID = System.UserInfo.getSessionId();
+          // If we're in a JWT session, System.UserInfo.getSessionId() will throw an 
+          // uncatchable exception
+          USER_SESSION_ID = IS_JWT_SESSION
+            ? ''
+            : System.UserInfo.getSessionId();
         } catch (Exception ex) {
           USER_SESSION_ID = '';
         }

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -86,50 +86,12 @@ global with sharing class Logger {
     set;
   }
 
-  private static Boolean IS_JWT_SESSION {
-    get {
-      if (IS_JWT_SESSION == null) {
-        Boolean hasCurrentSession = false;
-        Boolean hasJwtSession = false;
-        
-        for (AuthSession session : [
-          SELECT IsCurrent, IsAssociatedWithJwtAccessToken
-          FROM AuthSession
-          WHERE UsersId = :System.UserInfo.getUserId()
-        ]) {
-          if (session.IsAssociatedWithJwtAccessToken) {
-            hasJwtSession = true;
-          }
-          else if (session.IsCurrent) {
-            hasCurrentSession = true;
-          }
-        }
-        
-        IS_JWT_SESSION = !hasCurrentSession && hasJwtSession;
-      }
-      
-      return IS_JWT_SESSION ;
-    }
-    set;
-  }
-
   private static final String USER_SESSION_ID {
     get {
       if (USER_SESSION_ID == null) {
-        // TODO Spring '24 release - simplify this (and other lazy-loaded values)
-        // by switching to the fancy, new ?? null coalescing operator
-        try {
-          // If we're in a JWT session, System.UserInfo.getSessionId() will throw an 
-          // uncatchable exception
-          USER_SESSION_ID = IS_JWT_SESSION
-            ? ''
-            : System.UserInfo.getSessionId();
-        } catch (Exception ex) {
-          USER_SESSION_ID = '';
-        }
-        // If System.UserInfo.getSessionId() returns null, set to an empty string to
-        // avoid calling System.UserInfo.getSessionId() again
-        USER_SESSION_ID = USER_SESSION_ID ?? '';
+        // If loadSessionId() returns null, set to an empty string to
+        // avoid calling loadSessionId() again
+        USER_SESSION_ID = loadSessionId() ?? '';
       }
       return USER_SESSION_ID;
     }
@@ -3964,6 +3926,22 @@ global with sharing class Logger {
     if (String.isNotBlank(USER_SESSION_ID)) {
       return System.Request.getCurrent().getQuiddity();
     } else {
+      return null;
+    }
+  }
+
+  private static String loadSessionId() {
+    LoggerSObjectProxy.AuthSession authSessionProxy = LoggerEngineDataSelector.getInstance().getCachedAuthSessionProxy();
+
+    if (authSessionProxy != null && authSessionProxy.IsAssociatedWithJwtAccessToken) {
+      // If the user is authenticated via a JWT access token, 
+      // calling `getSessionId()` will throw an uncatchable exception
+      return null;
+    }
+
+    try {
+      return System.UserInfo.getSessionId();
+    } catch (Exception ex) {
       return null;
     }
   }

--- a/nebula-logger/core/main/logger-engine/classes/LoggerEngineDataSelector.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerEngineDataSelector.cls
@@ -48,6 +48,7 @@ public without sharing virtual class LoggerEngineDataSelector {
     List<SObject> authSessionRecords = [
       SELECT
         Id,
+        IsAssociatedWithJwtAccessToken,
         LoginType,
         LoginHistoryId,
         LoginHistory.Application,
@@ -61,8 +62,12 @@ public without sharing virtual class LoggerEngineDataSelector {
         SourceIp,
         UsersId
       FROM AuthSession
-      WHERE UsersId IN :userIds AND IsCurrent = TRUE
-      ORDER BY ParentId NULLS FIRST
+      WHERE UsersId IN :userIds 
+      AND (
+        IsCurrent = TRUE
+        OR IsAssociatedWithJwtAccessToken = TRUE
+      )
+      ORDER BY ParentId NULLS LAST, IsCurrent DESC
     ];
 
     List<LoggerSObjectProxy.AuthSession> authSessionProxies = (List<LoggerSObjectProxy.AuthSession>) System.JSON.deserialize(
@@ -75,7 +80,9 @@ public without sharing virtual class LoggerEngineDataSelector {
     }
 
     for (LoggerSObjectProxy.AuthSession authSessionProxy : authSessionProxies) {
-      userIdToAuthSessionProxy.put(authSessionProxy.UsersId, authSessionProxy);
+      if (!userIdToAuthSessionProxy.containsKey(authSessionProxy.UsersId)) {
+        userIdToAuthSessionProxy.put(authSessionProxy.UsersId, authSessionProxy);
+      }
     }
     return userIdToAuthSessionProxy;
   }

--- a/nebula-logger/core/main/logger-engine/classes/LoggerSObjectProxy.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LoggerSObjectProxy.cls
@@ -27,6 +27,7 @@ public without sharing class LoggerSObjectProxy {
     public String SessionType;
     public String SourceIp;
     public Id UsersId;
+    public Boolean IsAssociatedWithJwtAccessToken;
   }
 
   /**


### PR DESCRIPTION
Following my comment in #761 I tried some options.

The naive approach of querying the AuthSession directly seems contradictory to the optimizations done with the `LoggerEngineDataSelector`.

Following that I added the filtering to the AuthSession query in `LoggerEngineDataCollector` and also return the field `IsAssociatedWithJwtAccessToken`. When loading the Session Id we can check if the AuthSession is for JWT based on the cached proxy. 

One drawback is that this check does not work if 'QueryAuthSessionData' is set to false. For now I've landed on only skipping the Session Id load if we're definitely in a JWT session. I've also expiremented with always querying the AuthSession, but that would run counter to the intention of the parameter.

Another drawback is that this will invalidate the 'QueryAuthSessionDataSynchronously' parameter, since this will always query the AuthSession through the chain LOGGING_CONTEXT > transactionQuiddity > SESSION_ID.

For now I'll keep this a draft PR with the solution I landed on before working on test. @jongpie what do you think of this approach and/or do you see any other options to handle this issue?