### PR TITLE
Skip System.debug() in LogEntryEventBuilder when running in managed package

### DIFF
--- a/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
+++ b/nebula-logger/core/main/logger-engine/classes/LogEntryEventBuilder.cls
@@ -32,6 +32,9 @@ global with sharing class LogEntryEventBuilder {
 
   @TestVisible
   private String debugMessage = '';
+
+  @TestVisible
+  private static Boolean isApexSystemDebugSupportedOverride;
   private Boolean detailsAreSet = false;
   private Boolean shouldSave;
   private Set<String> tags = new Set<String>();
@@ -775,7 +778,9 @@ global with sharing class LogEntryEventBuilder {
         this.logEntryEvent.put(field, value);
       } catch (System.Exception ex) {
         LogMessage logMessage = new LogMessage('Could not set field {0} with value {1}', field, value);
-        System.debug(System.LoggingLevel.WARN, logMessage.getMessage());
+        if (isApexSystemDebugSupported()) {
+          System.debug(System.LoggingLevel.WARN, logMessage.getMessage());
+        }
       }
     }
 
@@ -922,7 +927,7 @@ global with sharing class LogEntryEventBuilder {
 
   @SuppressWarnings('PMD.AvoidDebugStatements')
   private void logToApexDebug(String message) {
-    if (this.userSettings.IsApexSystemDebugLoggingEnabled__c == false) {
+    if (this.userSettings.IsApexSystemDebugLoggingEnabled__c == false || isApexSystemDebugSupported() == false) {
       return;
     }
 
@@ -1139,6 +1144,13 @@ global with sharing class LogEntryEventBuilder {
   }
 
   // Private static helper methods
+  private static Boolean isApexSystemDebugSupported() {
+    if (System.Test.isRunningTest() && isApexSystemDebugSupportedOverride != null) {
+      return isApexSystemDebugSupportedOverride;
+    }
+    return String.isBlank(NAMESPACE_PREFIX);
+  }
+
   @TestVisible
   private static void setMockDataMaskRule(LogEntryDataMaskRule__mdt dataMaskRule) {
     CACHED_DATA_MASK_RULES.put(dataMaskRule.DeveloperName, dataMaskRule);

--- a/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/LogEntryEventBuilder_Tests.cls
@@ -2497,6 +2497,44 @@ private class LogEntryEventBuilder_Tests {
   }
 
   @IsTest
+  static void it_should_skip_apex_system_debug_when_not_supported() {
+    LogEntryEventBuilder.isApexSystemDebugSupportedOverride = false;
+    try {
+      DebugStringExample example = new DebugStringExample();
+      LoggerSettings__c userSettings = getUserSettings();
+      userSettings.IsApexSystemDebugLoggingEnabled__c = true;
+      LogEntryEventBuilder builder = example.myMethod(userSettings);
+
+      System.Assert.areEqual('', builder.debugMessage);
+      System.Assert.areEqual(example.loggingString, builder.getLogEntryEvent().Message__c);
+    } finally {
+      LogEntryEventBuilder.isApexSystemDebugSupportedOverride = null;
+    }
+  }
+
+  @IsTest
+  static void it_should_use_apex_system_debug_when_supported() {
+    LogEntryEventBuilder.isApexSystemDebugSupportedOverride = true;
+    try {
+      LoggerParameter.setMock(
+        new LoggerParameter__mdt(DeveloperName = 'SystemDebugMessageFormat', Value__c = '{OriginLocation__c}\n{Message__c}: {LoggingLevel__c}')
+      );
+
+      DebugStringExample example = new DebugStringExample();
+      LoggerSettings__c userSettings = getUserSettings();
+      userSettings.IsApexSystemDebugLoggingEnabled__c = true;
+      LogEntryEventBuilder builder = example.myMethod(userSettings);
+
+      System.Assert.areEqual(
+        DebugStringExample.class.getName() + '.myMethod' + '\n' + example.loggingString + ': ' + System.LoggingLevel.DEBUG.name(),
+        builder.debugMessage
+      );
+    } finally {
+      LogEntryEventBuilder.isApexSystemDebugSupportedOverride = null;
+    }
+  }
+
+  @IsTest
   static void it_should_use_configured_log_entry_event_fields_for_debug_string() {
     // Don't bother testing stack trace logic when using a namespace prefix - there are
     // some platform limitations that prevent these tests from behaving as expected


### PR DESCRIPTION
## Summary
- Skip `System.debug()` in `LogEntryEventBuilder` when Nebula Logger runs in a managed-package namespace
- Avoids per-log-entry template processing and debug calls that subscribers cannot see (Fixes #889)



