### PR TITLE
New Logger Parameter record 'OrganizationAllowlist' to control logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ The most robust observability solution for Salesforce experts. Built 100% native
 
 ## Unlocked Package - v4.18.4
 
-[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tg70000009GaDAAU)
-[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tg70000009GaDAAU)
+[![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tg7000000BNcPAAW)
+[![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tg7000000BNcPAAW)
 [![View Documentation](./images/btn-view-documentation.png)](https://github.com/jongpie/NebulaLogger/wiki)
 
-`sf package install --wait 20 --security-type AdminsOnly --package 04tg70000009GaDAAU`
+`sf package install --wait 20 --security-type AdminsOnly --package 04tg7000000BNcPAAW`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The most robust observability solution for Salesforce experts. Built 100% natively on the platform, and designed to work seamlessly with Apex, Lightning Components, Flow, OmniStudio, and integrations.
 
-## Unlocked Package - v4.18.3
+## Unlocked Package - v4.18.4
 
 [![Install Unlocked Package in a Sandbox](./images/btn-install-unlocked-package-sandbox.png)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tg70000009GaDAAU)
 [![Install Unlocked Package in Production](./images/btn-install-unlocked-package-production.png)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tg70000009GaDAAU)

--- a/docs/apex/Configuration/LoggerParameter.md
+++ b/docs/apex/Configuration/LoggerParameter.md
@@ -50,6 +50,10 @@ Indicates if Nebula Logger will store scenarios in the custom object `LoggerScen
 
 Indicates if Nebula Logger will store tags in the custom objects `LoggerTag__c` &amp; `LogEntryTag__c`, or in the field `LogEntry__c.Tags__c`. Controlled by the custom metadata record `LoggerParameter.NormalizeTagData`, or `true` as the default
 
+#### `ORGANIZATION_ALLOWLIST` → `Set<String>`
+
+An optional way to only enable logging in specified orgs/environments - this is useful for disabling logging by default in new sandboxes refreshed from a produciton org. When blank, logging will run normally - when org IDs are specified, logging will only run if the current org&apos;s ID is in the configured list.
+
 #### `PLATFORM_CACHE_PARTITION_NAME` → `String`
 
 The name of the Platform Cache partition to use for caching (when platform cache is enabled). Controlled by the custom metadata record `LoggerParameter.PlatformCachePartitionName`, or `LoggerCache` as the default

--- a/docs/apex/Configuration/LoggerParameter.md
+++ b/docs/apex/Configuration/LoggerParameter.md
@@ -52,7 +52,7 @@ Indicates if Nebula Logger will store tags in the custom objects `LoggerTag__c` 
 
 #### `ORGANIZATION_ALLOWLIST` → `Set<String>`
 
-An optional way to only enable logging in specified orgs/environments - this is useful for disabling logging by default in new sandboxes refreshed from a produciton org. When blank, logging will run normally - when org IDs are specified, logging will only run if the current org&apos;s ID is in the configured list.
+An optional way to enable logging in only specified orgs/environments - this is useful for disabling logging by default in new sandboxes refreshed from a produciton org. When blank/empty, logging will run normally - when org IDs are specified, logging will only run if the current org&apos;s ID is in the configured list.
 
 #### `PLATFORM_CACHE_PARTITION_NAME` → `String`
 

--- a/nebula-logger/core.package.xml
+++ b/nebula-logger/core.package.xml
@@ -741,6 +741,7 @@
         <members>LoggerParameter.LogEntryEventStreamDisplayFields</members>
         <members>LoggerParameter.NormalizeScenarioData</members>
         <members>LoggerParameter.NormalizeTagData</members>
+        <members>LoggerParameter.OrganizationAllowlist</members>
         <members>LoggerParameter.PlatformCachePartitionName</members>
         <members>LoggerParameter.QueryApexClassData</members>
         <members>LoggerParameter.QueryApexTriggerData</members>

--- a/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
@@ -163,6 +163,23 @@ public class LoggerParameter {
   }
 
   /**
+   * @description An optional way to only enable logging in specified orgs/environments - this is useful for disabling logging by default in new sandboxes refreshed from a produciton org.
+   *              When blank, logging will run normally - when org IDs are specified, logging will only run if the current org's ID is in the configured list.
+   */
+  public static final Set<String> ORGANIZATION_ALLOWLIST {
+    get {
+      if (ORGANIZATION_ALLOWLIST == null) {
+        ORGANIZATION_ALLOWLIST = new Set<String>(getStringList('OrganizationAllowlist', new List<String>()));
+        if (ORGANIZATION_ALLOWLIST.size() == 0) {
+          ORGANIZATION_ALLOWLIST.add(System.UserInfo.getOrganizationId());
+        }
+      }
+      return ORGANIZATION_ALLOWLIST;
+    }
+    private set;
+  }
+
+  /**
    * @description The name of the Platform Cache partition to use for caching (when platform cache is enabled).
    *              Controlled by the custom metadata record `LoggerParameter.PlatformCachePartitionName`, or `LoggerCache` as the default
    */

--- a/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
+++ b/nebula-logger/core/main/configuration/classes/LoggerParameter.cls
@@ -163,8 +163,8 @@ public class LoggerParameter {
   }
 
   /**
-   * @description An optional way to only enable logging in specified orgs/environments - this is useful for disabling logging by default in new sandboxes refreshed from a produciton org.
-   *              When blank, logging will run normally - when org IDs are specified, logging will only run if the current org's ID is in the configured list.
+   * @description An optional way to enable logging in only specified orgs/environments - this is useful for disabling logging by default in new sandboxes refreshed from a produciton org.
+   *              When blank/empty, logging will run normally - when org IDs are specified, logging will only run if the current org's ID is in the configured list.
    */
   public static final Set<String> ORGANIZATION_ALLOWLIST {
     get {

--- a/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.OrganizationAllowlist.md-meta.xml
+++ b/nebula-logger/core/main/configuration/customMetadata/LoggerParameter.OrganizationAllowlist.md-meta.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Organization Allowlist</label>
+    <protected>false</protected>
+    <values>
+        <field>Comments__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Description__c</field>
+        <value xsi:type="xsd:string">An optional way to only enable logging in specified orgs/environments - this is useful for disabling logging by default in new sandboxes refreshed from a produciton org. When blank, logging will run normally - when org IDs are specified, logging will only run if the current org's ID is in the configured list.</value>
+    </values>
+    <values>
+        <field>Value__c</field>
+        <value xsi:type="xsd:string">[]</value>
+    </values>
+</CustomMetadata>

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -15,7 +15,7 @@
 global with sharing class Logger {
   // There's no reliable way to get the version number dynamically in Apex
   @TestVisible
-  private static final String CURRENT_VERSION_NUMBER = 'v4.18.3';
+  private static final String CURRENT_VERSION_NUMBER = 'v4.18.4';
   private static final System.LoggingLevel FALLBACK_LOGGING_LEVEL = System.LoggingLevel.DEBUG;
   private static final List<LogEntryEventBuilder> LOG_ENTRIES_BUFFER = new List<LogEntryEventBuilder>();
   private static final String MISSING_SCENARIO_ERROR_MESSAGE = 'No logger scenario specified. A scenario is required for logging in this org.';

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -452,7 +452,13 @@ global with sharing class Logger {
       loggingUserSettings.SetupOwnerId = loggingUser.Id;
     }
 
-    if (LoggerParameter.ORGANIZATION_ALLOWLIST.contains(System.UserInfo.getOrganizationId()) == false) {
+    // Since we're dealing with strings stored in CMDT, we check for both the 15 & 18 character
+    // versions of the organization ID.
+    String fullOrganizationId = System.UserInfo.getOrganizationId();
+    if (
+      LoggerParameter.ORGANIZATION_ALLOWLIST.contains(fullOrganizationId) == false &&
+      LoggerParameter.ORGANIZATION_ALLOWLIST.contains(fullOrganizationId.left(15)) == false
+    ) {
       loggingUserSettings.IsEnabled__c = false;
     }
 

--- a/nebula-logger/core/main/logger-engine/classes/Logger.cls
+++ b/nebula-logger/core/main/logger-engine/classes/Logger.cls
@@ -452,6 +452,10 @@ global with sharing class Logger {
       loggingUserSettings.SetupOwnerId = loggingUser.Id;
     }
 
+    if (LoggerParameter.ORGANIZATION_ALLOWLIST.contains(System.UserInfo.getOrganizationId()) == false) {
+      loggingUserSettings.IsEnabled__c = false;
+    }
+
     return loggingUserSettings;
   }
 

--- a/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
+++ b/nebula-logger/core/main/logger-engine/lwc/logger/loggerService.js
@@ -10,7 +10,7 @@ import LoggerServiceTaskQueue from './loggerServiceTaskQueue';
 import getSettings from '@salesforce/apex/ComponentLogger.getSettings';
 import saveComponentLogEntries from '@salesforce/apex/ComponentLogger.saveComponentLogEntries';
 
-const CURRENT_VERSION_NUMBER = 'v4.18.3';
+const CURRENT_VERSION_NUMBER = 'v4.18.4';
 
 const CONSOLE_OUTPUT_CONFIG = {
   messagePrefix: `%c  Nebula Logger ${CURRENT_VERSION_NUMBER}  `,

--- a/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
+++ b/nebula-logger/core/tests/configuration/classes/LoggerParameter_Tests.cls
@@ -139,6 +139,17 @@ private class LoggerParameter_Tests {
   }
 
   @IsTest
+  static void it_should_return_constant_value_for_organization_allowlist() {
+    List<String> mockValue = new List<String>{ 'SomeValue', 'AnotherValue' };
+    LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'OrganizationAllowlist', Value__c = System.JSON.serialize(mockValue));
+    LoggerParameter.setMock(mockParameter);
+
+    Set<String> returnedValue = LoggerParameter.ORGANIZATION_ALLOWLIST;
+
+    System.Assert.areEqual(new Set<String>(mockValue), returnedValue);
+  }
+
+  @IsTest
   static void it_should_return_constant_value_for_platform_cache_partition_name() {
     String mockValue = 'SomeValue';
     LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'PlatformCachePartitionName', Value__c = mockValue);

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -276,6 +276,60 @@ private class Logger_Tests {
   }
 
   @IsTest
+  static void it_should_enable_logging_in_user_settings_when_org_allowlist_is_blank() {
+    LoggerSettings__c configuredSettings = LoggerSettings__c.getOrgDefaults();
+    configuredSettings.IsEnabled__c = true;
+    insert configuredSettings;
+    LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'OrgAllowlist', Value__c = System.JSON.serialize(new List<String>()));
+    LoggerParameter.setMock(mockParameter);
+    System.Assert.isFalse(LoggerParameter.ORGANIZATION_ALLOWLIST.contains(System.UserInfo.getUserId()));
+
+    LoggerSettings__c returnedSettings = Logger.getUserSettings();
+
+    configuredSettings = [SELECT Id, IsEnabled__c FROM LoggerSettings__c];
+    System.Assert.areEqual(true, configuredSettings.IsEnabled__c);
+    System.Assert.areEqual(true, returnedSettings.IsEnabled__c);
+  }
+
+  @IsTest
+  static void it_should_enable_logging_in_user_settings_when_current_org_is_in_allowlist() {
+    LoggerSettings__c configuredSettings = LoggerSettings__c.getOrgDefaults();
+    configuredSettings.IsEnabled__c = true;
+    insert configuredSettings;
+    LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(
+      DeveloperName = 'OrgAllowlist',
+      Value__c = System.JSON.serialize(new List<String>{ System.UserInfo.getOrganizationId() })
+    );
+    LoggerParameter.setMock(mockParameter);
+    System.Assert.isFalse(LoggerParameter.ORGANIZATION_ALLOWLIST.contains(System.UserInfo.getUserId()));
+
+    LoggerSettings__c returnedSettings = Logger.getUserSettings();
+
+    configuredSettings = [SELECT Id, IsEnabled__c FROM LoggerSettings__c];
+    System.Assert.areEqual(true, configuredSettings.IsEnabled__c);
+    System.Assert.areEqual(true, returnedSettings.IsEnabled__c);
+  }
+
+  @IsTest
+  static void it_should_disable_logging_in_user_settings_when_current_org_is_not_in_allowlist() {
+    LoggerSettings__c configuredSettings = LoggerSettings__c.getOrgDefaults();
+    configuredSettings.IsEnabled__c = true;
+    insert configuredSettings;
+    LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(
+      DeveloperName = 'OrgAllowlist',
+      Value__c = System.JSON.serialize(new List<String>{ 'some-org-id-that-is-not-the-current-org-id' })
+    );
+    LoggerParameter.setMock(mockParameter);
+    System.Assert.isFalse(LoggerParameter.ORGANIZATION_ALLOWLIST.contains(System.UserInfo.getUserId()));
+
+    LoggerSettings__c returnedSettings = Logger.getUserSettings();
+
+    configuredSettings = [SELECT Id, IsEnabled__c FROM LoggerSettings__c];
+    System.Assert.areEqual(true, configuredSettings.IsEnabled__c);
+    System.Assert.areEqual(false, returnedSettings.IsEnabled__c);
+  }
+
+  @IsTest
   static void it_should_return_system_request_id() {
     String expectedRequestId = System.Request.getCurrent().getRequestId();
 

--- a/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
+++ b/nebula-logger/core/tests/logger-engine/classes/Logger_Tests.cls
@@ -280,9 +280,12 @@ private class Logger_Tests {
     LoggerSettings__c configuredSettings = LoggerSettings__c.getOrgDefaults();
     configuredSettings.IsEnabled__c = true;
     insert configuredSettings;
-    LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(DeveloperName = 'OrgAllowlist', Value__c = System.JSON.serialize(new List<String>()));
+    LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(
+      DeveloperName = 'OrganizationAllowlist',
+      Value__c = System.JSON.serialize(new List<String>())
+    );
     LoggerParameter.setMock(mockParameter);
-    System.Assert.isFalse(LoggerParameter.ORGANIZATION_ALLOWLIST.contains(System.UserInfo.getUserId()));
+    System.Assert.isTrue(LoggerParameter.ORGANIZATION_ALLOWLIST.contains(System.UserInfo.getOrganizationId()));
 
     LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
@@ -292,16 +295,39 @@ private class Logger_Tests {
   }
 
   @IsTest
-  static void it_should_enable_logging_in_user_settings_when_current_org_is_in_allowlist() {
+  static void it_should_enable_logging_in_user_settings_when_current_org_18_character_id_is_in_allowlist() {
     LoggerSettings__c configuredSettings = LoggerSettings__c.getOrgDefaults();
     configuredSettings.IsEnabled__c = true;
     insert configuredSettings;
+    String organizationId = System.UserInfo.getOrganizationId();
+    System.Assert.areEqual(18, organizationId.length());
     LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(
-      DeveloperName = 'OrgAllowlist',
-      Value__c = System.JSON.serialize(new List<String>{ System.UserInfo.getOrganizationId() })
+      DeveloperName = 'OrganizationAllowlist',
+      Value__c = System.JSON.serialize(new List<String>{ organizationId })
     );
     LoggerParameter.setMock(mockParameter);
-    System.Assert.isFalse(LoggerParameter.ORGANIZATION_ALLOWLIST.contains(System.UserInfo.getUserId()));
+    System.Assert.isTrue(LoggerParameter.ORGANIZATION_ALLOWLIST.contains(System.UserInfo.getOrganizationId()));
+
+    LoggerSettings__c returnedSettings = Logger.getUserSettings();
+
+    configuredSettings = [SELECT Id, IsEnabled__c FROM LoggerSettings__c];
+    System.Assert.areEqual(true, configuredSettings.IsEnabled__c);
+    System.Assert.areEqual(true, returnedSettings.IsEnabled__c);
+  }
+
+  @IsTest
+  static void it_should_enable_logging_in_user_settings_when_current_org_15_character_id_is_in_allowlist() {
+    LoggerSettings__c configuredSettings = LoggerSettings__c.getOrgDefaults();
+    configuredSettings.IsEnabled__c = true;
+    insert configuredSettings;
+    String shortenedOrganizationId = System.UserInfo.getOrganizationId().left(15);
+    System.Assert.areEqual(15, shortenedOrganizationId.length());
+    LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(
+      DeveloperName = 'OrganizationAllowlist',
+      Value__c = System.JSON.serialize(new List<String>{ shortenedOrganizationId })
+    );
+    LoggerParameter.setMock(mockParameter);
+    System.Assert.isFalse(LoggerParameter.ORGANIZATION_ALLOWLIST.contains(System.UserInfo.getOrganizationId()));
 
     LoggerSettings__c returnedSettings = Logger.getUserSettings();
 
@@ -316,11 +342,11 @@ private class Logger_Tests {
     configuredSettings.IsEnabled__c = true;
     insert configuredSettings;
     LoggerParameter__mdt mockParameter = new LoggerParameter__mdt(
-      DeveloperName = 'OrgAllowlist',
+      DeveloperName = 'OrganizationAllowlist',
       Value__c = System.JSON.serialize(new List<String>{ 'some-org-id-that-is-not-the-current-org-id' })
     );
     LoggerParameter.setMock(mockParameter);
-    System.Assert.isFalse(LoggerParameter.ORGANIZATION_ALLOWLIST.contains(System.UserInfo.getUserId()));
+    System.Assert.isFalse(LoggerParameter.ORGANIZATION_ALLOWLIST.contains(System.UserInfo.getOrganizationId()));
 
     LoggerSettings__c returnedSettings = Logger.getUserSettings();
 

--- a/nebula-logger/extra-tests/bundled-custom-metadata-type-records/CMDT_LoggerParameter_Tests.cls
+++ b/nebula-logger/extra-tests/bundled-custom-metadata-type-records/CMDT_LoggerParameter_Tests.cls
@@ -113,6 +113,17 @@ private class CMDT_LoggerParameter_Tests {
   }
 
   @IsTest
+  static void it_has_correct_record_for_organization_allowlist() {
+    LoggerParameter__mdt bundledRecord = LoggerParameter__mdt.getInstance('OrganizationAllowlist');
+
+    System.Assert.isNotNull(bundledRecord, 'Record is missing');
+    System.Assert.isNull(bundledRecord.Comments__c, 'Comments should be null/blank');
+    System.Assert.isNotNull(bundledRecord.Description__c, 'Description is missing');
+    System.Assert.areEqual('Organization Allowlist', bundledRecord.Label);
+    System.Assert.areEqual('[]', bundledRecord.Value__c);
+  }
+
+  @IsTest
   static void it_has_correct_record_for_platform_cache_partition_name() {
     LoggerParameter__mdt bundledRecord = LoggerParameter__mdt.getInstance('PlatformCachePartitionName');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@cparra/apexdocs": "1.13.7",
         "@jongpie/sfdx-bummer-plugin": "0.0.20",
         "@salesforce-ux/slds-linter": "1.2.0",
-        "@salesforce/cli": "2.134.1",
+        "@salesforce/cli": "^2.136.8",
         "@salesforce/eslint-config-lwc": "4.1.2",
         "@salesforce/sfdx-lwc-jest": "7.5.0",
         "@types/jest-when": "3.5.5",
@@ -3755,47 +3755,47 @@
       }
     },
     "node_modules/@salesforce/cli": {
-      "version": "2.134.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/cli/-/cli-2.134.1.tgz",
-      "integrity": "sha512-6RB+ENByzDpGzVKTTFj1MDpO08J+wwmhewguRk6gWWhast60MCeLY89nJL45S5m6hMGJY9tzqq0Nnq3hbSMULA==",
+      "version": "2.136.8",
+      "resolved": "https://registry.npmjs.org/@salesforce/cli/-/cli-2.136.8.tgz",
+      "integrity": "sha512-mnsRQ3qd3CCgu4RekTABptOTksXGVYk8TYKnm0fhB9zDdNJdKWVE3lNe9Jf0Qgr9fC7qvq8vfyXoESbi4dN30w==",
       "dev": true,
       "hasInstallScript": true,
       "hasShrinkwrap": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/select": "^2.3.5",
-        "@oclif/core": "4.11.0",
-        "@oclif/plugin-autocomplete": "3.2.46",
-        "@oclif/plugin-commands": "4.1.47",
-        "@oclif/plugin-help": "6.2.45",
-        "@oclif/plugin-not-found": "3.2.81",
-        "@oclif/plugin-plugins": "5.4.62",
-        "@oclif/plugin-search": "1.2.45",
-        "@oclif/plugin-update": "4.7.33",
-        "@oclif/plugin-version": "2.2.42",
-        "@oclif/plugin-warn-if-update-available": "3.1.61",
-        "@oclif/plugin-which": "3.2.50",
+        "@oclif/core": "4.11.3",
+        "@oclif/plugin-autocomplete": "3.2.49",
+        "@oclif/plugin-commands": "4.1.54",
+        "@oclif/plugin-help": "6.2.49",
+        "@oclif/plugin-not-found": "3.2.86",
+        "@oclif/plugin-plugins": "5.4.68",
+        "@oclif/plugin-search": "1.2.49",
+        "@oclif/plugin-update": "4.7.40",
+        "@oclif/plugin-version": "2.2.46",
+        "@oclif/plugin-warn-if-update-available": "3.1.65",
+        "@oclif/plugin-which": "3.2.54",
         "@salesforce/core": "^8.28.0",
         "@salesforce/kit": "^3.1.6",
-        "@salesforce/plugin-agent": "1.34.0",
-        "@salesforce/plugin-apex": "3.9.22",
-        "@salesforce/plugin-api": "1.3.21",
-        "@salesforce/plugin-auth": "4.3.7",
-        "@salesforce/plugin-data": "4.0.92",
-        "@salesforce/plugin-deploy-retrieve": "3.24.37",
-        "@salesforce/plugin-info": "3.4.124",
-        "@salesforce/plugin-limits": "3.3.84",
-        "@salesforce/plugin-marketplace": "1.3.18",
-        "@salesforce/plugin-org": "5.10.3",
-        "@salesforce/plugin-packaging": "2.27.7",
-        "@salesforce/plugin-schema": "3.3.106",
-        "@salesforce/plugin-settings": "2.4.71",
-        "@salesforce/plugin-sobject": "1.4.100",
-        "@salesforce/plugin-telemetry": "3.8.15",
-        "@salesforce/plugin-templates": "56.16.4",
-        "@salesforce/plugin-trust": "3.8.0",
-        "@salesforce/plugin-user": "3.9.0",
-        "@salesforce/sf-plugins-core": "12.2.10",
+        "@salesforce/plugin-agent": "1.40.3",
+        "@salesforce/plugin-apex": "3.9.29",
+        "@salesforce/plugin-api": "1.3.33",
+        "@salesforce/plugin-auth": "4.4.0",
+        "@salesforce/plugin-data": "4.0.101",
+        "@salesforce/plugin-deploy-retrieve": "3.24.48",
+        "@salesforce/plugin-info": "3.4.133",
+        "@salesforce/plugin-limits": "3.3.89",
+        "@salesforce/plugin-marketplace": "1.3.26",
+        "@salesforce/plugin-org": "5.11.1",
+        "@salesforce/plugin-packaging": "2.28.2",
+        "@salesforce/plugin-schema": "3.3.114",
+        "@salesforce/plugin-settings": "2.4.80",
+        "@salesforce/plugin-sobject": "1.4.108",
+        "@salesforce/plugin-telemetry": "3.8.21",
+        "@salesforce/plugin-templates": "56.17.2",
+        "@salesforce/plugin-trust": "3.8.9",
+        "@salesforce/plugin-user": "3.10.0",
+        "@salesforce/sf-plugins-core": "12.2.17",
         "ansis": "^3.12.0"
       },
       "bin": {
@@ -3899,47 +3899,6 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -3954,47 +3913,6 @@
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-crypto/sha256-js": {
@@ -4034,94 +3952,30 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/client-cloudfront": {
-      "version": "3.1009.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.1009.0.tgz",
-      "integrity": "sha512-KRac+gkuj3u49IyWkrudHRlP/q/faTto+1xRS7Aj6cDGewMIzgdQArrdZEJoVntbaVZHLM5s/NVmWORzBWNcSw==",
+      "version": "3.1046.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudfront/-/client-cloudfront-3.1046.0.tgz",
+      "integrity": "sha512-OkWCMU19+dT+lbXCxZZQjzcM3bSopbDebGkLbIr5XpRwNCrvbj190vxjakifBqHT1h5e2XKeR+DVhLK0VVz7XQ==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.20",
-        "@aws-sdk/credential-provider-node": "^3.972.21",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.21",
-        "@aws-sdk/region-config-resolver": "^3.972.8",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.11",
-        "@smithy/core": "^3.23.11",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.25",
-        "@smithy/middleware-retry": "^4.4.42",
-        "@smithy/middleware-serde": "^4.2.14",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.4.16",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.5",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.41",
-        "@smithy/util-defaults-mode-node": "^4.2.44",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-stream": "^4.5.19",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.13",
+        "@aws-sdk/core": "^3.974.9",
+        "@aws-sdk/credential-provider-node": "^3.972.40",
+        "@aws-sdk/middleware-host-header": "^3.972.11",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.12",
+        "@aws-sdk/middleware-user-agent": "^3.972.39",
+        "@aws-sdk/region-config-resolver": "^3.972.14",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.9",
+        "@aws-sdk/util-user-agent-browser": "^3.972.11",
+        "@aws-sdk/util-user-agent-node": "^3.973.25",
+        "@smithy/core": "^3.24.1",
+        "@smithy/fetch-http-handler": "^5.4.1",
+        "@smithy/node-http-handler": "^4.7.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4129,66 +3983,29 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/client-s3": {
-      "version": "3.1014.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1014.0.tgz",
-      "integrity": "sha512-0XLrOT4Cm3NEhhiME7l/8LbTXS4KdsbR4dSrY207KNKTcHLLTZ9EXt4ZpgnTfLvWQF3pGP2us4Zi1fYLo0N+Ow==",
+      "version": "3.1049.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1049.0.tgz",
+      "integrity": "sha512-e5ToFwYeHSfkKDPs/G0yhO7vxvfVOF6DhmlvI2xFi4m12NvjxPhaA2Y35QMaYLrw/oGPXmu9McfKnBm/oXYXbg==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.23",
-        "@aws-sdk/credential-provider-node": "^3.972.24",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.8",
-        "@aws-sdk/middleware-expect-continue": "^3.972.8",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.3",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-location-constraint": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.23",
-        "@aws-sdk/middleware-ssec": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.24",
-        "@aws-sdk/region-config-resolver": "^3.972.9",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.11",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.10",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.12",
-        "@smithy/eventstream-serde-browser": "^4.2.12",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
-        "@smithy/eventstream-serde-node": "^4.2.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-blob-browser": "^4.2.13",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/hash-stream-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/md5-js": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.27",
-        "@smithy/middleware-retry": "^4.4.44",
-        "@smithy/middleware-serde": "^4.2.15",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.0",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.43",
-        "@smithy/util-defaults-mode-node": "^4.2.47",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-stream": "^4.5.20",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.13",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-node": "^3.972.43",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.14",
+        "@aws-sdk/middleware-expect-continue": "^3.972.12",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.20",
+        "@aws-sdk/middleware-location-constraint": "^3.972.10",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.41",
+        "@aws-sdk/middleware-ssec": "^3.972.10",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4196,24 +4013,19 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/core": {
-      "version": "3.973.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
-      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
+      "version": "3.974.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
+      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/xml-builder": "^3.972.17",
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4221,13 +4033,13 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.6.tgz",
-      "integrity": "sha512-NMbiqKdruhwwgI6nzBVe2jWMkXjaoQz2YOs3rFX+2F3gGyrJDkDPwMpV/RsTFeq2vAQ055wZNtOXFK4NYSkM8g==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.8.tgz",
+      "integrity": "sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4235,16 +4047,16 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
-      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.38.tgz",
+      "integrity": "sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4252,21 +4064,18 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
-      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.40.tgz",
+      "integrity": "sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4274,25 +4083,24 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
-      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.42.tgz",
+      "integrity": "sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-login": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-login": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4300,19 +4108,17 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
-      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.42.tgz",
+      "integrity": "sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4320,23 +4126,22 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
-      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.43.tgz",
+      "integrity": "sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-ini": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-ini": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4344,17 +4149,16 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
-      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.38.tgz",
+      "integrity": "sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4362,19 +4166,18 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
-      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.42.tgz",
+      "integrity": "sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/token-providers": "3.1026.0",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/token-providers": "3.1049.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4382,18 +4185,17 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
-      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.42.tgz",
+      "integrity": "sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4401,18 +4203,16 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.9.tgz",
-      "integrity": "sha512-COToYKgquDyligbcAep7ygs48RK+mwe/IYprq4+TSrVFzNOYmzWvHf6werpnKV5VYpRiwdn+Wa5ZXkPqLVwcTg==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.14.tgz",
+      "integrity": "sha512-Aaj0d+xbo1jJquBWJP0/9V/XZRYukO3LWIRp3dOLHmoFrYKb4YZ0aLefgVHfGcNOVBS2ZTq7L/n5JcrE7DaC+Q==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-config-provider": "^4.2.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4420,15 +4220,15 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.9.tgz",
-      "integrity": "sha512-V/FNCjFxnh4VGu+HdSiW4Yg5GELihA1MIDSAdsEPvuayXBVmr0Jaa6jdLAZLH38KYXl/vVjri9DQJWnTAujHEA==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.12.tgz",
+      "integrity": "sha512-dA5pKTom/Ls9mgeyeaRBNQrRIVOLVjv4AmKOB0/e4yaiXEUy0gSz2d3liP8JHtYoCAEWySU1jWnyzwLOREN+4g==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4436,25 +4236,20 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.7.tgz",
-      "integrity": "sha512-uU4/ch2CLHB8Phu1oTKnnQ4e8Ujqi49zEnQYBhWYT53zfFvtJCdGsaOoypBr8Fm/pmCBssRmGoIQ4sixgdLP9w==",
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.20.tgz",
+      "integrity": "sha512-NdnMVQCR1YjIcqFAiNLdBiOwr2DyQDB2IiXQrBhzolKOv32ae4d4Ll7IzLMi04eMHiq/o/Y/GjFuVjF9HuG0QA==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/crc64-nvme": "^3.972.6",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-stream": "^4.5.22",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/crc64-nvme": "^3.972.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4462,15 +4257,15 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
-      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.11.tgz",
+      "integrity": "sha512-CBC6+tVYaOJo7QXgN1zJ4Ba2f3/Cpy4eRViYFimXW/O5Mn8hBmgXXzHu4vy4ubT80YWnp8aCFygr7dTOa14yQg==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4478,14 +4273,14 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.9.tgz",
-      "integrity": "sha512-TyfOi2XNdOZpNKeTJwRUsVAGa+14nkyMb2VVGG+eDgcWG/ed6+NUo72N3hT6QJioxym80NSinErD+LBRF0Ir1w==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
+      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4493,14 +4288,14 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
-      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4508,16 +4303,16 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
-      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.12.tgz",
+      "integrity": "sha512-5eltYxKB4MfdQv7/VhWxRbAVQKow5dz9votRFigTYrWJHMQXwLMltlbk7KFWSZh5NDBySfmjT7Jv/DWfYCmDng==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/types": "^3.973.8",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4525,25 +4320,18 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.28.tgz",
-      "integrity": "sha512-qJHcJQH9UNPUrnPlRtCozKjtqAaypQ5IgQxTNoPsVYIQeuwNIA8Rwt3NvGij1vCDYDfCmZaPLpnJEHlZXeFqmg==",
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.41.tgz",
+      "integrity": "sha512-M4T2I2WPuH5WQpU8Tsp+u2bcO29zGRkU14ATzuqb9I4xh8tzsLqtp4hzaJM5aO2dhMZnHDzyQwSFVgc3XbnoGg==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-stream": "^4.5.22",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4551,14 +4339,14 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.9.tgz",
-      "integrity": "sha512-wSA2BR7L0CyBNDJeSrleIIzC+DzL93YNTdfU0KPGLiocK6YsRv1nPAzPF+BFSdcs0Qa5ku5Kcf4KvQcWwKGenQ==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
+      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4566,19 +4354,17 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
-      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.39.tgz",
+      "integrity": "sha512-MlNSvNsSVlMKKWaCzA0GP1nS4Cuq3WCXUN1vmMvd+Ctztib5kmRcpmTtKx9kikN8szAc+gcdp7uqJJervV2nQg==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-retry": "^4.3.0",
+        "@aws-sdk/core": "^3.974.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.9",
+        "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4586,49 +4372,21 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
-      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
+      "version": "3.997.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.10.tgz",
+      "integrity": "sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4636,16 +4394,15 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
-      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.14.tgz",
+      "integrity": "sha512-VuLXVmm7+lKVxqFcOItPkXhjbJ02iUfxkxheRu41SfWf6/xrZup2A2SwHZos/LeQGu3SBHeqTQht80Uo3ienPA==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4653,17 +4410,16 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.16.tgz",
-      "integrity": "sha512-EMdXYB4r/k5RWq86fugjRhid5JA+Z6MpS7n4sij4u5/C+STrkvuf9aFu41rJA9MjUzxCLzv8U2XL8cH2GSRYpQ==",
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.28",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4671,18 +4427,17 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1026.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
-      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
+      "version": "3.1049.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1049.0.tgz",
+      "integrity": "sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4690,26 +4445,13 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/types": {
-      "version": "3.973.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
-      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
-      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4717,16 +4459,15 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
-      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
+      "version": "3.996.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.9.tgz",
+      "integrity": "sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-endpoints": "^3.3.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4747,30 +4488,29 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
-      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.11.tgz",
+      "integrity": "sha512-kq3RS6XQtHMrLFShbkem6h+8fxazB3jEIsbMC6aaSInOciRGE+eGAqTgJ+obO7Euo/pjM8thVqLiLISEH9X9DA==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
-      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
+      "version": "3.973.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.25.tgz",
+      "integrity": "sha512-066hKH/0nvV7x4ofV/iK9kz8r/qNfcR6rzuEOFqI2vQL/fcTTsDAbTw0jmXkyMzANK8ltQdALj19ns3zuOJiUw==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-config-provider": "^4.2.2",
+        "@aws-sdk/middleware-user-agent": "^3.972.39",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4786,14 +4526,15 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
-      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "fast-xml-parser": "5.5.8",
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4801,9 +4542,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "extraneous": true,
       "funding": [
         {
@@ -4813,9 +4554,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -5867,16 +5609,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/@gar/promise-retry": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
-      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -6784,9 +6516,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6822,13 +6554,13 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -6867,13 +6599,6 @@
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/@salesforce/cli/node_modules/@isaacs/string-locale-compare": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
-      "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
-      "extraneous": true,
-      "license": "ISC"
     },
     "node_modules/@salesforce/cli/node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -6987,9 +6712,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@jsforce/jsforce-node": {
-      "version": "3.10.14",
-      "resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.10.14.tgz",
-      "integrity": "sha512-p8Ug1SypcAT7Q0zZA0+7fyBmgUpB/aXkde4Bxmu0S/O4p28CVwgYvKyFd9vswmHIhFabd/QqUCrlYuVhYdr2Ew==",
+      "version": "3.10.15",
+      "resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.10.15.tgz",
+      "integrity": "sha512-rtl4MCmy5EzUQ8ehJfjcQCVW2EPCBfopxpZjmXzJrKdtwH6ptjeC5VdyfjS40XNjD7k7heXRZr1jRVU3Ej6kcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7162,6 +6887,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@salesforce/cli/node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@salesforce/cli/node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -7213,291 +6956,10 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
-      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^11.2.1",
-        "socks-proxy-agent": "^8.0.3"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/arborist": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-9.4.3.tgz",
-      "integrity": "sha512-YhkR7XFdO7OBr8U1qs7DA7PmhSJXg59rLqd53jmeJ4pYe8WTCAsUZsKqxX7KKPEgAO5K7D/SjbyPUrBes9aP6Q==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promise-retry": "^1.0.0",
-        "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/fs": "^5.0.0",
-        "@npmcli/installed-package-contents": "^4.0.0",
-        "@npmcli/map-workspaces": "^5.0.0",
-        "@npmcli/metavuln-calculator": "^9.0.2",
-        "@npmcli/name-from-folder": "^4.0.0",
-        "@npmcli/node-gyp": "^5.0.0",
-        "@npmcli/package-json": "^7.0.0",
-        "@npmcli/query": "^5.0.0",
-        "@npmcli/redact": "^4.0.0",
-        "@npmcli/run-script": "^10.0.0",
-        "bin-links": "^6.0.0",
-        "cacache": "^20.0.1",
-        "common-ancestor-path": "^2.0.0",
-        "hosted-git-info": "^9.0.0",
-        "json-stringify-nice": "^1.1.4",
-        "lru-cache": "^11.2.1",
-        "minimatch": "^10.0.3",
-        "nopt": "^9.0.0",
-        "npm-install-checks": "^8.0.0",
-        "npm-package-arg": "^13.0.0",
-        "npm-pick-manifest": "^11.0.1",
-        "npm-registry-fetch": "^19.0.0",
-        "pacote": "^21.0.2",
-        "parse-conflict-json": "^5.0.1",
-        "proc-log": "^6.0.0",
-        "proggy": "^4.0.0",
-        "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^3.0.1",
-        "semver": "^7.3.7",
-        "ssri": "^13.0.0",
-        "treeverse": "^3.0.0",
-        "walk-up-path": "^4.0.0"
-      },
-      "bin": {
-        "arborist": "bin/index.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/config": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-10.8.1.tgz",
-      "integrity": "sha512-MAYk9IlIGiyC0c9fnjdBSQfIFPZT0g1MfeSiD1UXTq2zJOLX55jS9/sETJHqw/7LN18JjITrhYfgCfapbmZHiQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/map-workspaces": "^5.0.0",
-        "@npmcli/package-json": "^7.0.0",
-        "ci-info": "^4.0.0",
-        "ini": "^6.0.0",
-        "nopt": "^9.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.5",
-        "walk-up-path": "^4.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/config/node_modules/ini": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/fs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
-      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/git": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
-      "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promise-retry": "^1.0.0",
-        "@npmcli/promise-spawn": "^9.0.0",
-        "ini": "^6.0.0",
-        "lru-cache": "^11.2.1",
-        "npm-pick-manifest": "^11.0.1",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.5",
-        "which": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/git/node_modules/ini": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
-      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/installed-package-contents": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-4.0.0.tgz",
-      "integrity": "sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-bundled": "^5.0.0",
-        "npm-normalize-package-bin": "^5.0.0"
-      },
-      "bin": {
-        "installed-package-contents": "bin/index.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/map-workspaces": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.3.tgz",
-      "integrity": "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/name-from-folder": "^4.0.0",
-        "@npmcli/package-json": "^7.0.0",
-        "glob": "^13.0.0",
-        "minimatch": "^10.0.3"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/metavuln-calculator": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@npmcli/metavuln-calculator/-/metavuln-calculator-9.0.3.tgz",
-      "integrity": "sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "cacache": "^20.0.0",
-        "json-parse-even-better-errors": "^5.0.0",
-        "pacote": "^21.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/name-from-folder": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-4.0.0.tgz",
-      "integrity": "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/node-gyp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-5.0.0.tgz",
-      "integrity": "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/package-json": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
-      "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^7.0.0",
-        "glob": "^13.0.0",
-        "hosted-git-info": "^9.0.0",
-        "json-parse-even-better-errors": "^5.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.5.3",
-        "spdx-expression-parse": "^4.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/promise-spawn": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
-      "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "which": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/query": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/query/-/query-5.0.0.tgz",
-      "integrity": "sha512-8TZWfTQOsODpLqo9SVhVjHovmKXNpevHU0gO9e+y4V4fRIOneiXy0u0sMP9LmS71XivrEWfZWg50ReH4WRT4aQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "postcss-selector-parser": "^7.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/redact": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
-      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@npmcli/run-script": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-10.0.4.tgz",
-      "integrity": "sha512-mGUWr1uMnf0le2TwfOZY4SFxZGXGfm4Jtay/nwAa2FLNAKXUoUwaGwBMNH36UHPtinWfTSJ3nqFQr0091CxVGg==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/node-gyp": "^5.0.0",
-        "@npmcli/package-json": "^7.0.0",
-        "@npmcli/promise-spawn": "^9.0.0",
-        "node-gyp": "^12.1.0",
-        "proc-log": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/@oclif/core": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.0.tgz",
-      "integrity": "sha512-nTkRMgxFlIKQIIYGvhO2JMsLSQ1aHPHblHfFgxgoBrGK8Ao/8wxc4eNOIv/+t8dMXliZd7mREVr6la4aXXXg5A==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.3.tgz",
+      "integrity": "sha512-gQCSYAtUhJilGKaSaZhqejH9X1dDu+jWQjLmtGOgN/XcKaAEPPSeT2mu1UvlvtPox1/NNRdlBcUa8KRKo2HnJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7512,10 +6974,10 @@
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
         "minimatch": "^10.2.5",
-        "semver": "^7.7.3",
+        "semver": "^7.8.0",
         "string-width": "^4.2.3",
         "supports-color": "^8",
-        "tinyglobby": "^0.2.14",
+        "tinyglobby": "^0.2.16",
         "widest-line": "^3.1.0",
         "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
@@ -7538,6 +7000,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@salesforce/cli/node_modules/@oclif/core/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/core/node_modules/supports-color": {
@@ -7575,9 +7050,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/multi-stage-output": {
-      "version": "0.8.36",
-      "resolved": "https://registry.npmjs.org/@oclif/multi-stage-output/-/multi-stage-output-0.8.36.tgz",
-      "integrity": "sha512-3BEpG5CDUJYtyJQZbMPU+o3C0XSC7MgupTb75KjLE6RoG5r9q+BRYkyDyGMspWkqcPtbMqZjs0sMFKmYMiDrEA==",
+      "version": "0.8.42",
+      "resolved": "https://registry.npmjs.org/@oclif/multi-stage-output/-/multi-stage-output-0.8.42.tgz",
+      "integrity": "sha512-pAgfE5v+xGTp0yIOJwIXCtbCrfc0Rmw1KZwyylmUNao0gV50/x5JhJHD4MUSET0oi5Zx8haLSLH6IJewkFIjnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7594,9 +7069,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/multi-stage-output/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7661,13 +7136,13 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/multi-stage-output/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -7695,9 +7170,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/plugin-autocomplete": {
-      "version": "3.2.46",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.46.tgz",
-      "integrity": "sha512-TFvuD6JlmqEVsEvMqunyj3cyCz/l2Q4MqCjp/XtlSLS9x3xTlam7PGlqWi4WAhxl/K8CtpYqVlMYFEnlLTHspw==",
+      "version": "3.2.49",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-autocomplete/-/plugin-autocomplete-3.2.49.tgz",
+      "integrity": "sha512-+rrAZ468bW/B9uVrn6sEnFYepy3M1N/BWht8mHzhFIFCIduPSoE+8MweROxZLOGBZrXGWt0iavuPQmy0eaXRfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7779,14 +7254,14 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/plugin-commands": {
-      "version": "4.1.47",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-commands/-/plugin-commands-4.1.47.tgz",
-      "integrity": "sha512-rfiRMLzqr4VqIssGIbug14z0N5gLAmhJj45Se7rMtg9yoOEvnbAHtMs81YWTgrtlD+/37kGyPINfHKidmcZkNA==",
+      "version": "4.1.54",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-commands/-/plugin-commands-4.1.54.tgz",
+      "integrity": "sha512-4Km/ejYtqWBcrnFE2Ig7nbc+lyXBQDG+XND+Psy1I8FQZX+Kn54RFG3LbKZcqKKsh61jUpupa4zbcWgY29hlQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4",
-        "@oclif/table": "^0.5.4",
+        "@oclif/table": "^0.5.8",
         "lodash": "^4.18.1",
         "object-treeify": "^4.0.1"
       },
@@ -7795,9 +7270,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/plugin-help": {
-      "version": "6.2.45",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.45.tgz",
-      "integrity": "sha512-avWOKYmjANtyu8ipju/kopIIrSrbS/scJjiZTpBp/HKEHNm46v5riOo5LQj6MZ4bYJVQEoyHPg/2Seig5Ilkjw==",
+      "version": "6.2.49",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.49.tgz",
+      "integrity": "sha512-fEsO0YU7ThtzHE1RGuoHxFu/OGlqxm7PCfFp+U1PS8sde4E0cDqjVDuv78+VKrr45LpC5lWOApj7pm3FNfHrVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7808,14 +7283,14 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/plugin-not-found": {
-      "version": "3.2.81",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.81.tgz",
-      "integrity": "sha512-M88tLONBH36hLAbkFbmCo1hoZPSdU5l8Px1xEIlIgSmGMam+CoAzx4kGqpLbokgfpaHeP8/Jx3QJ18u9ef/2Qw==",
+      "version": "3.2.86",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.86.tgz",
+      "integrity": "sha512-BJhJSahwsYayZpo18f0fPTg8tKb9dIvydaz03NCK3eMfmcsT1MmXhXqh1KEV8J7mz0sQ6f0qFEb6BXy490/iUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",
-        "@oclif/core": "^4.10.6",
+        "@oclif/core": "^4.11.3",
         "ansis": "^3.17.0",
         "fast-levenshtein": "^3.0.0"
       },
@@ -7824,16 +7299,16 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/plugin-plugins": {
-      "version": "5.4.62",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-5.4.62.tgz",
-      "integrity": "sha512-AFFKQpn/SHJE5ETiyQYBJjg7895WmvrBjEKvLWnJX+fNuOVSf6WLbiRqJI7kEaLUmmL8O1EtMcc18COxTOSgIw==",
+      "version": "5.4.68",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-5.4.68.tgz",
+      "integrity": "sha512-+YZ5Afv9OiTsOIS3ODGJH2T8+CymruYQxRPXOCDQBZC0sjLb02S5yQ4OGKSCLBFpbbeBjo05C3IOBdxKzwF+wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oclif/core": "^4.8.0",
+        "@oclif/core": "^4.11.1",
         "ansis": "^3.17.0",
         "debug": "^4.4.0",
-        "npm": "^11.13.0",
+        "npm": "^11.14.1",
         "npm-package-arg": "^11.0.3",
         "npm-run-path": "^5.3.0",
         "object-treeify": "^4.0.1",
@@ -7951,9 +7426,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/plugin-search": {
-      "version": "1.2.45",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-search/-/plugin-search-1.2.45.tgz",
-      "integrity": "sha512-UNy8lvLdl8aacGZbFoo9qNKr45EVxF8qt2FHOkATdEE/rXPPVT5v3+whgdw0bDXocsypyIyvuvarysZWhQRyHg==",
+      "version": "1.2.49",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-search/-/plugin-search-1.2.49.tgz",
+      "integrity": "sha512-gvcTYRgFljVwFEJ4ajdBDJTC1T99hAmtVUaZ+LZFhyk+iRdRXmWW75xuFU7QxbFatLgZXnQMxVcD9Ju7qsU8TA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7982,15 +7457,15 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/plugin-update": {
-      "version": "4.7.33",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-update/-/plugin-update-4.7.33.tgz",
-      "integrity": "sha512-ygTzGkqF+EPOMx30RGs9R2Kyyn3pFXpacihX0NCzkZDfljOdbESfEd5usc9iod9gxasouqwoSIFm9Tdb4zMHNA==",
+      "version": "4.7.40",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-update/-/plugin-update-4.7.40.tgz",
+      "integrity": "sha512-c9gojJ6+T27Q8tQf/p4M5qitQlpshqGaSdR9/Lau2DYPheNiicRLhQkr0yknXH2AE/vIdf2nyl8albfZ1D5itw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/select": "^2.5.0",
         "@oclif/core": "^4",
-        "@oclif/table": "^0.5.4",
+        "@oclif/table": "^0.5.8",
         "ansis": "^3.17.0",
         "debug": "^4.4.1",
         "filesize": "^6.1.0",
@@ -8004,9 +7479,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/plugin-version": {
-      "version": "2.2.42",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-version/-/plugin-version-2.2.42.tgz",
-      "integrity": "sha512-EsHlMwhwPBYYzs2YFbdGODqiLb5B3Ami1CncD4OHYzM2xwUJ6fHyHxMG5FVPaXia/Z/qjZnFdOnl1bGqm49MzQ==",
+      "version": "2.2.46",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-version/-/plugin-version-2.2.46.tgz",
+      "integrity": "sha512-6eq2CgmJH6gyyJqh2ATcxaZGFduE9bGKN+KlBjNS+n+BVJW4MMbR3lhcv1EoNuY1C6hRnTc6/hPOAzlASusSXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8018,9 +7493,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/plugin-warn-if-update-available": {
-      "version": "3.1.61",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-3.1.61.tgz",
-      "integrity": "sha512-4XcrTxcCs+brR/eZ0BPeuiREiH3USlJiaHbUqPhnIBuyxhhUSYVd8ZO6s5MQN7AXJq4SMQ+B5zLaHq+ep/afIw==",
+      "version": "3.1.65",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-warn-if-update-available/-/plugin-warn-if-update-available-3.1.65.tgz",
+      "integrity": "sha512-HcSJc8SeCVUBHwc063xDL0LcpdjcamAISlisSX14VDDYQayMantvtVNOo9PmciwYpXRXfAykeH1z066YkA9JvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8036,9 +7511,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/plugin-which": {
-      "version": "3.2.50",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-which/-/plugin-which-3.2.50.tgz",
-      "integrity": "sha512-Yglue51/sQfnhsVE7jWm6Fsya4sLmXw9ldKx7e3VUT+OmJIys4pQirEHRsbVaA4fK1ms3jzwdDqG15Btd/x3Mw==",
+      "version": "3.2.54",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-which/-/plugin-which-3.2.54.tgz",
+      "integrity": "sha512-fV4J2GRklwRVnWdIGf/oc4YGfLbpOkfS6xe/Mg1hNhDYM+DfDXaNlJ/nNuz56nuscuhaOnZVVxI1ng6EAvwP/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8050,9 +7525,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/table": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@oclif/table/-/table-0.5.5.tgz",
-      "integrity": "sha512-ppjPNFf5bL28KiiMIxyDwXhGJ3ke7MFg532k8bkaInavv84zRgoLhc+5ocZMX1EPToqgSsZAn8bQhaZz07enww==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@oclif/table/-/table-0.5.8.tgz",
+      "integrity": "sha512-yIWar+oDCoN1ji3gUB1QSQAewBiWevwLI7Stg9a+0MX7dtmLXcYucqyR6L5BvJ1b+ekG8C/JY+GJc+ytnzrR9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8063,8 +7538,8 @@
         "natural-orderby": "^3.0.2",
         "object-hash": "^3.0.0",
         "react": "^18.3.1",
-        "string-width": "^8.2.0",
-        "strip-ansi": "^7.1.2",
+        "string-width": "^8.2.1",
+        "strip-ansi": "^7.2.0",
         "wrap-ansi": "^9.0.2"
       },
       "engines": {
@@ -8072,9 +7547,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/table/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8109,13 +7584,13 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@oclif/table/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -8349,6 +7824,31 @@
         "@octokit/openapi-types": "^25.1.0"
       }
     },
+    "node_modules/@salesforce/cli/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@salesforce/cli/node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@salesforce/cli/node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@salesforce/cli/node_modules/@opentelemetry/api": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
@@ -8563,39 +8063,39 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@salesforce/cli/node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/agents": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/agents/-/agents-1.2.0.tgz",
-      "integrity": "sha512-gyF1xzJcEp3MuS8Apf1eUGUvy41zq7HQqKPEhDIU6aUiowoewW/RI9LcPB0K7LPrGCIiARq4TYKlxf452HASqA==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@salesforce/agents/-/agents-1.6.6.tgz",
+      "integrity": "sha512-YMYOPv45aSLjIARu+9vkHz5GWXGh0EMhiQw+oCBEwlxD55/O4Gm6Zb/HzLuOPKhXt5xn9TogG87vvHvCNgiUyA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/core": "^8.28.3",
+        "@salesforce/core": "^8.29.1",
         "@salesforce/kit": "^3.2.6",
-        "@salesforce/source-deploy-retrieve": "^12.32.7",
+        "@salesforce/source-deploy-retrieve": "^12.35.8",
         "@salesforce/types": "^1.7.1",
-        "fast-xml-parser": "^5.6.0",
-        "nock": "^13.5.6",
-        "yaml": "^2.8.3"
+        "fast-xml-parser": "^5.7.3",
+        "nock": "^14.0.15",
+        "yaml": "^2.8.4"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/apex-node": {
-      "version": "8.4.22",
-      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-8.4.22.tgz",
-      "integrity": "sha512-/pleLG4HD/F5li4eQUXIqLCFCYh/UnXHZNgoeHSkG89WDLITxjTp2lzbdE7QkkRzCFKGcjECW6DmHR67+TYqrQ==",
+      "version": "8.4.26",
+      "resolved": "https://registry.npmjs.org/@salesforce/apex-node/-/apex-node-8.4.26.tgz",
+      "integrity": "sha512-wPMzZrbWaJmPcJub/Q6m89D3+Oq2QvMwXTOTbjwXRZlsJTidZvPuaPcYjsrZWKQjk0npUxQ1/jDlP5eH3Mn4hQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@salesforce/core": "^8.28.3",
+        "@salesforce/core": "^8.30.3",
         "@salesforce/kit": "^3.2.6",
         "@types/istanbul-reports": "^3.0.4",
         "fast-glob": "^3.3.2",
@@ -8610,13 +8110,13 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/cli-plugins-testkit": {
-      "version": "5.3.52",
-      "resolved": "https://registry.npmjs.org/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-5.3.52.tgz",
-      "integrity": "sha512-je/iynPTb5VcDhzPfr+jN+ydapFox0A+0CdE2fkg1ZXws3tZZnyMd+y0i79CchpdtrMUD/Jzkcx0KjvxWF7oTw==",
+      "version": "5.3.57",
+      "resolved": "https://registry.npmjs.org/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-5.3.57.tgz",
+      "integrity": "sha512-997GulQmQvaPCyCHCxxOQHZNJlemyBlvRDn9pkQSXTGLRi6SiI4UwJ5RgbUBW4N1v8z0RrfVObQYxrU1W/zasw==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/core": "^8.28.1",
+        "@salesforce/core": "^8.29.1",
         "@salesforce/kit": "^3.2.6",
         "@salesforce/ts-types": "^2.0.11",
         "@types/shelljs": "^0.10.0",
@@ -8721,9 +8221,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/core": {
-      "version": "8.28.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.28.4.tgz",
-      "integrity": "sha512-XQ0BBSetdW9cu36pu8ig5ZBX3oAbDSSH4djHkSU3iAzjLdTygEPIBVtKNeyj1++GmCy0rRiLr/yqoFYr21+GuQ==",
+      "version": "8.30.3",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.30.3.tgz",
+      "integrity": "sha512-E3WPXxAEqvpZXp6nnkkoNRFGQ2c/5Mhnbl9s0ajQiLTpqQ1Una5PlPu0s2rRvu8qGKnT1AI7xT3RDy3pd/dULg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8743,7 +8243,7 @@
         "pino-abstract-transport": "^1.2.0",
         "pino-pretty": "^11.3.0",
         "proper-lockfile": "^4.1.2",
-        "semver": "^7.7.3",
+        "semver": "^7.8.0",
         "ts-retry-promise": "^0.8.1",
         "zod": "^4.1.12"
       },
@@ -8991,38 +8491,31 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/o11y-reporter": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/o11y-reporter/-/o11y-reporter-1.8.3.tgz",
-      "integrity": "sha512-m9LY3gQ8WFeB38NHmQRie9WtiaeUr+Lvy45RthbSSFwe6PDzfiD8jknpsSNTce0GRPZLly46wqrOXyyMSb8yxg==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@salesforce/o11y-reporter/-/o11y-reporter-1.8.4.tgz",
+      "integrity": "sha512-lI2QKKs1idr5aZW6caeSnd+jO1+/JFT/k1BTJ1jbK9P0Juo+FaSu8E7Wuz64Zd2mUIEasT55bC9q+pX3JSbSpw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "o11y": "^258.7.0",
-        "o11y_schema": "256.154.0"
+        "o11y": "^264.5.0",
+        "o11y_schema": "260.5.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/o11y-reporter/node_modules/o11y_schema": {
-      "version": "256.154.0",
-      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-256.154.0.tgz",
-      "integrity": "sha512-czvU/9cibyZptbr0gLJSM70U7zLlhWC2D2L5e9nOG84Wnqmn4F5YzVjrH1ZQzAzDbBbtbeU6WTS3F/SHqtMQ5g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@salesforce/cli/node_modules/@salesforce/packaging": {
-      "version": "4.22.12",
-      "resolved": "https://registry.npmjs.org/@salesforce/packaging/-/packaging-4.22.12.tgz",
-      "integrity": "sha512-3Y6dhzpmwGIdW0iADL549E0Rb1L9DZl/c/cjzCbeC2FNgRm7s7biB07SZlDxSJKNGoxZgPDGLbWvyG5V/mIOBg==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/packaging/-/packaging-4.23.0.tgz",
+      "integrity": "sha512-fPQD8hUUuk2rLUf0Hry6x6qeDeA53IpRTO50NpvMOpHY6NuydescW1C6jYSY6+qhFTgDXOx/zKN6isVgK1SKNg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jsforce/jsforce-node": "^3.10.14",
-        "@salesforce/core": "^8.28.4",
+        "@salesforce/core": "^8.29.0",
         "@salesforce/kit": "^3.2.6",
         "@salesforce/schemas": "^1.10.3",
-        "@salesforce/source-deploy-retrieve": "^12.34.2",
+        "@salesforce/source-deploy-retrieve": "^12.35.0",
         "@salesforce/ts-types": "^2.0.12",
         "@salesforce/types": "^1.7.1",
         "fast-xml-parser": "^5.7.2",
@@ -9048,9 +8541,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-agent": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-agent/-/plugin-agent-1.34.0.tgz",
-      "integrity": "sha512-SEoqoInZyprCUvlE1j+hmV6YVrFF+SJX1Dpxk4pl+uPDkcASxRDglSQm63R2ExzpIDnb6SdiivFJjID1qvNmLQ==",
+      "version": "1.40.3",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-agent/-/plugin-agent-1.40.3.tgz",
+      "integrity": "sha512-cYoiP+5tT1klOn5Wxw8IghbSTICK2RQzf96vxaQgbUw2PEVhEcMiDI7E7Uu/qXVILlwd73/JgcWszKl7+lvI2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9058,11 +8551,11 @@
         "@inquirer/prompts": "^7.10.1",
         "@oclif/core": "^4",
         "@oclif/multi-stage-output": "^0.8.36",
-        "@salesforce/agents": "^1.2.0",
+        "@salesforce/agents": "^1.6.6",
         "@salesforce/core": "^8.28.3",
         "@salesforce/kit": "^3.2.6",
         "@salesforce/sf-plugins-core": "^12.2.6",
-        "@salesforce/source-deploy-retrieve": "^12.32.8",
+        "@salesforce/source-deploy-retrieve": "^12.35.3",
         "@salesforce/types": "^1.7.1",
         "ansis": "^3.3.2",
         "fast-xml-parser": "^5.7.1",
@@ -9071,7 +8564,7 @@
         "ink-text-input": "^6.0.0",
         "inquirer-autocomplete-standalone": "^0.8.1",
         "react": "^18.3.1",
-        "yaml": "^2.8.3"
+        "yaml": "^2.8.4"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -9102,16 +8595,16 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-apex": {
-      "version": "3.9.22",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-apex/-/plugin-apex-3.9.22.tgz",
-      "integrity": "sha512-1WkxPe6vzW5zBwz8mljuG7HlNeT7kvHj83QWWMvbF/hEiewMc1vvaeCvnPUf/K/nOfs+GM40xpQCMZGhs844fQ==",
+      "version": "3.9.29",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-apex/-/plugin-apex-3.9.29.tgz",
+      "integrity": "sha512-Bzf1iwd9ZyDMxXMUYaKeMivBIa1TVfs+HCk3E+cACJdozquY51yCsG+DHg62cY20D9KpPhRdy1RNpxLlBdBvBw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/apex-node": "^8.4.22",
-        "@salesforce/core": "^8.28.1",
+        "@salesforce/apex-node": "^8.4.26",
+        "@salesforce/core": "^8.29.0",
         "@salesforce/kit": "^3.2.3",
-        "@salesforce/sf-plugins-core": "^12.2.6",
+        "@salesforce/sf-plugins-core": "^12.2.17",
         "ansis": "^3.3.1"
       },
       "engines": {
@@ -9119,16 +8612,16 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-api": {
-      "version": "1.3.21",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-api/-/plugin-api-1.3.21.tgz",
-      "integrity": "sha512-M9thrFMnq5D7OP9pXPZFWrlwzt7VZqiIjZC/5nV9WcG7OLqYVhPnBO/TQGqy4jS2kKfTk/zZ58CrT8anZx5ZUQ==",
+      "version": "1.3.33",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-api/-/plugin-api-1.3.33.tgz",
+      "integrity": "sha512-qjEU6IKuh9JKpsQ6SzdTsIXhdvR1hlzz7Cv4riVRoz5TRJVAc1wn41wj8eM80b4uy+ZTsNGRrimkwdEo0dSfbg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "^4",
-        "@salesforce/core": "^8.28.3",
+        "@salesforce/core": "^8.30.3",
         "@salesforce/kit": "^3.2.4",
-        "@salesforce/sf-plugins-core": "^12.2.6",
+        "@salesforce/sf-plugins-core": "^12.2.17",
         "@salesforce/ts-types": "^2.0.12",
         "ansis": "^3.3.2",
         "form-data": "^4.0.5",
@@ -9140,9 +8633,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-auth": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-auth/-/plugin-auth-4.3.7.tgz",
-      "integrity": "sha512-4XIuTC9IPThKHob7wdPNWeIu1a98TIwoaB/dybjqOnxC0AxaT/qh/D02QH4AwJPLJv9J0BPgA/i81i0mIsVVHw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-auth/-/plugin-auth-4.4.0.tgz",
+      "integrity": "sha512-ucsKDkr3hcTlaBi8tW409sHgjOn1JIY2TqK1v3iyN/OMyM4F1XGzZhQDvWaCIFAfG1q252vDwZzDfkurU+UKzw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9151,7 +8644,7 @@
         "@oclif/core": "^4",
         "@salesforce/core": "^8.25.1",
         "@salesforce/kit": "^3.2.4",
-        "@salesforce/plugin-info": "^3.4.100",
+        "@salesforce/plugin-info": "^3.4.131",
         "@salesforce/sf-plugins-core": "^12.2.6",
         "@salesforce/ts-types": "^2.0.11",
         "open": "^10.2.0"
@@ -9161,16 +8654,16 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference": {
-      "version": "3.1.90",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-command-reference/-/plugin-command-reference-3.1.90.tgz",
-      "integrity": "sha512-LyrcL1iJcmH7oFGQO1VfbCFqwLPxIBA6RpB6qQH7Rqkl38IZq5AZd+xR6X4CFOR5bBtMMBJUed+G3p8wQ9QTqQ==",
+      "version": "3.1.101",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-command-reference/-/plugin-command-reference-3.1.101.tgz",
+      "integrity": "sha512-jZZO216dGbxB6tKMOSKs0lEj4Yn3YJAts6gaG/DC8caUrbfxeSu/H1/3IPb4fhMFjIsV2A7phAwseSe3LCyKDg==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "^4",
-        "@salesforce/core": "^8.28.1",
+        "@salesforce/core": "^8.29.1",
         "@salesforce/kit": "^3.2.6",
-        "@salesforce/sf-plugins-core": "^11.3.12",
+        "@salesforce/sf-plugins-core": "^12.2.16",
         "@salesforce/ts-types": "^2.0.11",
         "chalk": "^5.6.2",
         "debug": "^4.4.3",
@@ -9178,129 +8671,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@inquirer/core": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.1.0.tgz",
-      "integrity": "sha512-RZVfH//2ytTjmaBIzeKT1zefcQZzuruwkpTwwbe/i2jTl4o9M+iML5ChULzz6iw1Ok8iUBBsRCjY2IEbD8Ft4w==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.3",
-        "@types/mute-stream": "^0.0.4",
-        "@types/node": "^22.5.2",
-        "@types/wrap-ansi": "^3.0.0",
-        "ansi-escapes": "^4.3.2",
-        "cli-spinners": "^2.9.2",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^1.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@inquirer/core/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@inquirer/core/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@inquirer/password": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.2.0.tgz",
-      "integrity": "sha512-5otqIpgsPYIshqhgtEwSspBQE40etouR8VIxzpJkv9i0dVHIpyhiivbkH9/dGiMLdyamT54YRdGJLfl8TFnLHg==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "ansi-escapes": "^4.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@inquirer/type": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.3.tgz",
-      "integrity": "sha512-xUQ14WQGR/HK5ei+2CvgcwoH9fQ4PgPGmVFSN0pc1+fVyDL3MREhyAY7nxEErSu6CkllBM3D7e3e+kOvtu+eIg==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@salesforce/sf-plugins-core": {
-      "version": "11.3.12",
-      "resolved": "https://registry.npmjs.org/@salesforce/sf-plugins-core/-/sf-plugins-core-11.3.12.tgz",
-      "integrity": "sha512-hi8EcSoRHRxj4sm/V5YDtzq9bPr/cKpM4fC6abo/jRzpXygwizinc2gVQkXfVdhjK7NGMskVRQB1N+0TThG7bA==",
-      "extraneous": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@inquirer/confirm": "^3.1.22",
-        "@inquirer/password": "^2.2.0",
-        "@oclif/core": "^4.0.27",
-        "@salesforce/core": "^8.5.1",
-        "@salesforce/kit": "^3.2.3",
-        "@salesforce/ts-types": "^2.0.12",
-        "ansis": "^3.3.2",
-        "cli-progress": "^3.12.0",
-        "natural-orderby": "^3.0.2",
-        "slice-ansi": "^7.1.0",
-        "string-width": "^7.2.0",
-        "terminal-link": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/@types/node": {
-      "version": "22.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/chalk": {
@@ -9316,79 +8686,18 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/emoji-regex": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-command-reference/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "extraneous": true,
-      "license": "MIT"
-    },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-data": {
-      "version": "4.0.92",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-data/-/plugin-data-4.0.92.tgz",
-      "integrity": "sha512-NQtedJyvfqjv1irhGJgAD8UecR0pxpcZw8jsZfDDGzFD24Pa81T9yAIktzUj6xIh+pe206mXb90dm58oPutjrA==",
+      "version": "4.0.101",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-data/-/plugin-data-4.0.101.tgz",
+      "integrity": "sha512-q1qcfW/VsnL450e4jqF0mQhmv6WkYcbQAkJvIJ9a+MRkY38lIDRHFUrVAYXvab68aPr5VFCcphi/AgW2TlAAxw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsforce/jsforce-node": "^3.10.14",
-        "@oclif/multi-stage-output": "^0.8.36",
-        "@salesforce/core": "^8.28.1",
+        "@jsforce/jsforce-node": "^3.10.15",
+        "@oclif/multi-stage-output": "^0.8.41",
+        "@salesforce/core": "^8.29.1",
         "@salesforce/kit": "^3.2.6",
-        "@salesforce/sf-plugins-core": "^12.2.6",
+        "@salesforce/sf-plugins-core": "^12.2.14",
         "@salesforce/ts-types": "^2.0.11",
         "ansis": "^3.16.0",
         "change-case": "^5.4.4",
@@ -9397,29 +8706,29 @@
         "form-data": "^4.0.5",
         "terminal-link": "^3.0.0",
         "undici": "^7.25.0",
-        "zod": "^4.3.6"
+        "zod": "^4.4.3"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-deploy-retrieve": {
-      "version": "3.24.37",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-deploy-retrieve/-/plugin-deploy-retrieve-3.24.37.tgz",
-      "integrity": "sha512-p6NENTffrUfQS4dEbCJ61n1cyQFR7Z++TYLP+SH2rAnEI29h7ibfqeboTY9MLi0vuG0M3nLZZWyt48U3rJ2s9g==",
+      "version": "3.24.48",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-deploy-retrieve/-/plugin-deploy-retrieve-3.24.48.tgz",
+      "integrity": "sha512-2OEFsS1JlNG12BjYArjnzaLElXaaA+xFgZixnsiRzDudNUNO9Hg/0z8fRxLHAKM/idHrXvHfm2w5UKR1vyPCRA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.8.3",
-        "@oclif/core": "^4.10.5",
-        "@oclif/multi-stage-output": "^0.8.34",
+        "@oclif/core": "^4.11.3",
+        "@oclif/multi-stage-output": "^0.8.37",
         "@salesforce/apex-node": "^8.4.22",
-        "@salesforce/core": "^8.28.3",
+        "@salesforce/core": "^8.30.0",
         "@salesforce/kit": "^3.2.4",
-        "@salesforce/plugin-info": "^3.4.123",
+        "@salesforce/plugin-info": "^3.4.131",
         "@salesforce/sf-plugins-core": "^12.2.6",
-        "@salesforce/source-deploy-retrieve": "^12.34.2",
-        "@salesforce/source-tracking": "^7.8.14",
+        "@salesforce/source-deploy-retrieve": "^12.35.9",
+        "@salesforce/source-tracking": "^7.8.16",
         "@salesforce/ts-types": "^2.0.12",
         "ansis": "^3.17.0",
         "terminal-link": "^3.0.0"
@@ -9429,16 +8738,16 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-info": {
-      "version": "3.4.124",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-info/-/plugin-info-3.4.124.tgz",
-      "integrity": "sha512-U27FegsFc0jGDfCOfDCm6MBml8WdLPfDShVEtg1X3tEub67eUyi+yyHq4Q/yiAQltB23KMn92HpyedGhWmYPJg==",
+      "version": "3.4.133",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-info/-/plugin-info-3.4.133.tgz",
+      "integrity": "sha512-NBejGfST5NxQNHQifl9NM6r831Cjh7VHtweHXLom5GWp1XEL95X3rrYrZsZ6uHmmmhWjD76swcT1Xlcsei3zRg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/input": "^2.3.0",
         "@jsforce/jsforce-node": "^3.10.14",
         "@oclif/core": "^4",
-        "@salesforce/core": "^8.28.4",
+        "@salesforce/core": "^8.30.3",
         "@salesforce/kit": "^3.2.6",
         "@salesforce/sf-plugins-core": "^12",
         "got": "^13.0.0",
@@ -9446,36 +8755,36 @@
         "marked-terminal": "^4.2.0",
         "open": "^10.2.0",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.3"
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-limits": {
-      "version": "3.3.84",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-limits/-/plugin-limits-3.3.84.tgz",
-      "integrity": "sha512-yu6FV6IW/PdSw4IqMqbNrZAwzEN6NB6mkjrgk87qTcyYFyEdEgvgVsqeK3UQ50HfBECgY1wVcRH2F9lSr6pg7A==",
+      "version": "3.3.89",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-limits/-/plugin-limits-3.3.89.tgz",
+      "integrity": "sha512-ztxez0p4N7RPOxZYgVGWlmHAovj/3ozqhnIv++KMwix5fY0+F4Yre5aFs+MJeeCiVWpznTU23xgicusKopqAmw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/core": "^8.27.1",
-        "@salesforce/sf-plugins-core": "^12.2.6"
+        "@salesforce/core": "^8.29.0",
+        "@salesforce/sf-plugins-core": "^12.2.15"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-marketplace": {
-      "version": "1.3.18",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-marketplace/-/plugin-marketplace-1.3.18.tgz",
-      "integrity": "sha512-/LgPtlK1f+CZPNFJ/YoSeAaPHMqgPaKtkpW4c0dXMnc6d9oighV7FsgfD/ho7aDOKYgdZ3GpywoHSqtKpBpTZA==",
+      "version": "1.3.26",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-marketplace/-/plugin-marketplace-1.3.26.tgz",
+      "integrity": "sha512-P9cFt+QTACV0EyKdzwQ4pQJDGAmsHKNiI2Hfgf5f6SjsuqggD8bOGZu89hfsEdvNznVF5ZUB5Z6VPXPtVJSjaw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/core": "^8.27.1",
+        "@salesforce/core": "^8.29.1",
         "@salesforce/kit": "^3.2.4",
-        "@salesforce/sf-plugins-core": "^12.2.6",
+        "@salesforce/sf-plugins-core": "^12.2.14",
         "got": "^13.0.0",
         "proxy-agent": "^6.5.0"
       },
@@ -9484,18 +8793,18 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-org": {
-      "version": "5.10.3",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-org/-/plugin-org-5.10.3.tgz",
-      "integrity": "sha512-iosc1yccnXOLY/3jSU806V0AJHVcRzvZ/sfxa6Q98rh9DqpzulPi7/5BDk0OQ12oxNp92N9G0JpY6Bw2N+6pWQ==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-org/-/plugin-org-5.11.1.tgz",
+      "integrity": "sha512-k7Grb8GptDfBoIx3/+Gj4lkeXGHqfAgPn0sLTVAadZS/QhIPOZzEHHglEMwAZni6ILCWr+A8jNvHHzn1KeOsMg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@oclif/core": "^4.10.6",
-        "@oclif/multi-stage-output": "^0.8.30",
-        "@salesforce/core": "^8.28.4",
+        "@oclif/core": "^4.11.3",
+        "@oclif/multi-stage-output": "^0.8.40",
+        "@salesforce/core": "^8.29.0",
         "@salesforce/kit": "^3.2.4",
-        "@salesforce/sf-plugins-core": "^12.2.6",
-        "@salesforce/source-deploy-retrieve": "^12.34.2",
+        "@salesforce/sf-plugins-core": "^12.2.16",
+        "@salesforce/source-deploy-retrieve": "^12.35.1",
         "@salesforce/ts-types": "^2.0.12",
         "ansis": "^3.16.0",
         "change-case": "^5.4.4",
@@ -9507,34 +8816,18 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-org/node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-packaging": {
-      "version": "2.27.7",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-packaging/-/plugin-packaging-2.27.7.tgz",
-      "integrity": "sha512-9jDf+q0+rTk1UQLoXjBl3DF+GFQQfZi1Vw/muwt72g6wsi5RNLdv4VWOzepoa5zN9iPHEDO8BYFSIH5Rnz6U/w==",
+      "version": "2.28.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-packaging/-/plugin-packaging-2.28.2.tgz",
+      "integrity": "sha512-wk2D78rWZQyr03YLaba/sDqSPcClXr9sMfaGoGUi5FXzaYjzr4OyRLWVrNB/gG4Xe8yRHp3NdUQtDkdqoHLj8g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "^4",
-        "@salesforce/core": "^8.28.4",
+        "@salesforce/core": "^8.29.0",
         "@salesforce/kit": "^3.2.6",
-        "@salesforce/packaging": "^4.22.9",
-        "@salesforce/sf-plugins-core": "^12.2.6",
+        "@salesforce/packaging": "^4.23.0",
+        "@salesforce/sf-plugins-core": "^12.2.14",
         "chalk": "^5.6.2"
       },
       "engines": {
@@ -9555,9 +8848,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management": {
-      "version": "5.8.7",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-release-management/-/plugin-release-management-5.8.7.tgz",
-      "integrity": "sha512-zzhyz0JQvOBdRChQSJRMsl+RQsWZh5jM78Arp9HcAgrYnK09VXtVAWHl7Zh7xPKIDAPGTsd1vdPX/Wt+zRLQ+Q==",
+      "version": "5.8.21",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-release-management/-/plugin-release-management-5.8.21.tgz",
+      "integrity": "sha512-WGCIinDurX+KJpJoZL/9csn5aD8o+cEmcp2DHmWS/fSxVf/DNmaWTXP2mw4O/VZaBR0yHvpWhVdQAuzO533fdQ==",
       "extraneous": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -9566,14 +8859,14 @@
         "@octokit/core": "^6.1.6",
         "@octokit/plugin-paginate-rest": "^11.6.0",
         "@octokit/plugin-throttling": "^9.6.1",
-        "@salesforce/cli-plugins-testkit": "^5.3.41",
-        "@salesforce/core": "^8.27.1",
-        "@salesforce/kit": "^3.2.4",
-        "@salesforce/plugin-command-reference": "^3.1.81",
+        "@salesforce/cli-plugins-testkit": "^5.3.54",
+        "@salesforce/core": "^8.28.3",
+        "@salesforce/kit": "^3.2.6",
+        "@salesforce/plugin-command-reference": "^3.1.101",
         "@salesforce/plugin-trust": "^3.7.89",
-        "@salesforce/sf-plugins-core": "^12.2.6",
+        "@salesforce/sf-plugins-core": "^12.2.10",
         "@salesforce/ts-types": "^2.0.10",
-        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/node-http-handler": "^4.6.1",
         "@smithy/types": "^4.11.0",
         "chalk": "^5.6.0",
         "commit-and-tag-version": "^12.7.1",
@@ -9593,73 +8886,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/@aws-sdk/client-s3": {
-      "version": "3.1029.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1029.0.tgz",
-      "integrity": "sha512-OuA8RZTxsAaHDcI25j2NGLMaYFI2WpJdDzK3uLmVBmaHwjQKQZOUDVVBcln8pNo3IgkY+HRSJhRR4/xlM//UyQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha1-browser": "5.2.0",
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-node": "^3.972.30",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.9",
-        "@aws-sdk/middleware-expect-continue": "^3.972.9",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.7",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-location-constraint": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.28",
-        "@aws-sdk/middleware-ssec": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.16",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/eventstream-serde-browser": "^4.2.13",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.13",
-        "@smithy/eventstream-serde-node": "^4.2.13",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-blob-browser": "^4.2.14",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/hash-stream-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/md5-js": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
-        "@smithy/util-stream": "^4.5.22",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.15",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-release-management/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -9674,214 +8900,30 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema": {
-      "version": "3.3.106",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-schema/-/plugin-schema-3.3.106.tgz",
-      "integrity": "sha512-yTiwYMlR8H0jpnqMBAGacFCu7CPip+Jrr3UAtwimr8oYUAbKuUGmHLFDbFqo6dBTC8ALQTg42K3bWuZtkU8wig==",
+      "version": "3.3.114",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-schema/-/plugin-schema-3.3.114.tgz",
+      "integrity": "sha512-lauby/hsQvBcAryx+dEufAIBHRr5f+N/Rp2ZSlVwkHuYEPnrFrx3M8B9jqaQHngzJ28eiBeeRno9fyQI0dfBVQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "^4",
-        "@salesforce/core": "^8.28.3",
-        "@salesforce/sf-plugins-core": "^11.3.12"
+        "@salesforce/core": "^8.30.3",
+        "@salesforce/sf-plugins-core": "^12.2.17"
       },
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema/node_modules/@inquirer/core": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.1.0.tgz",
-      "integrity": "sha512-RZVfH//2ytTjmaBIzeKT1zefcQZzuruwkpTwwbe/i2jTl4o9M+iML5ChULzz6iw1Ok8iUBBsRCjY2IEbD8Ft4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.3",
-        "@types/mute-stream": "^0.0.4",
-        "@types/node": "^22.5.2",
-        "@types/wrap-ansi": "^3.0.0",
-        "ansi-escapes": "^4.3.2",
-        "cli-spinners": "^2.9.2",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^1.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema/node_modules/@inquirer/core/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema/node_modules/@inquirer/core/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema/node_modules/@inquirer/password": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.2.0.tgz",
-      "integrity": "sha512-5otqIpgsPYIshqhgtEwSspBQE40etouR8VIxzpJkv9i0dVHIpyhiivbkH9/dGiMLdyamT54YRdGJLfl8TFnLHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "ansi-escapes": "^4.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema/node_modules/@inquirer/type": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.3.tgz",
-      "integrity": "sha512-xUQ14WQGR/HK5ei+2CvgcwoH9fQ4PgPGmVFSN0pc1+fVyDL3MREhyAY7nxEErSu6CkllBM3D7e3e+kOvtu+eIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema/node_modules/@salesforce/sf-plugins-core": {
-      "version": "11.3.12",
-      "resolved": "https://registry.npmjs.org/@salesforce/sf-plugins-core/-/sf-plugins-core-11.3.12.tgz",
-      "integrity": "sha512-hi8EcSoRHRxj4sm/V5YDtzq9bPr/cKpM4fC6abo/jRzpXygwizinc2gVQkXfVdhjK7NGMskVRQB1N+0TThG7bA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@inquirer/confirm": "^3.1.22",
-        "@inquirer/password": "^2.2.0",
-        "@oclif/core": "^4.0.27",
-        "@salesforce/core": "^8.5.1",
-        "@salesforce/kit": "^3.2.3",
-        "@salesforce/ts-types": "^2.0.12",
-        "ansis": "^3.3.2",
-        "cli-progress": "^3.12.0",
-        "natural-orderby": "^3.0.2",
-        "slice-ansi": "^7.1.0",
-        "string-width": "^7.2.0",
-        "terminal-link": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema/node_modules/@types/node": {
-      "version": "22.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema/node_modules/emoji-regex": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-schema/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-settings": {
-      "version": "2.4.71",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-settings/-/plugin-settings-2.4.71.tgz",
-      "integrity": "sha512-Yasa3EbluDxgjStFUZpzX5YCk1LBoIJMwYLuCYdA19OQrBeL3wQcCIwI9hoTwyIohTcTdId055lBL3+zQKjv0Q==",
+      "version": "2.4.80",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-settings/-/plugin-settings-2.4.80.tgz",
+      "integrity": "sha512-BsAZF78Dq30uKNRyIhE2wDfx1HnA87OprLbyF8YZ8/43EwsTRjklWcZdAJ/yrTfitXqbw/1J7jEPS7rDT5/Gkw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "^4",
-        "@salesforce/core": "^8.28.4",
-        "@salesforce/sf-plugins-core": "^12.2.6",
+        "@salesforce/core": "^8.30.3",
+        "@salesforce/sf-plugins-core": "^12.2.17",
         "fast-levenshtein": "^3.0.0"
       },
       "engines": {
@@ -9889,215 +8931,31 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject": {
-      "version": "1.4.100",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-sobject/-/plugin-sobject-1.4.100.tgz",
-      "integrity": "sha512-nfZmnqF65yNZ2fghgH+aZQhUAS/lCC/YffaiBUHsN87SSITMEKrtGTrHC9NDc3wjLT0G8GlmtmIM/YFkEUhtWQ==",
+      "version": "1.4.108",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-sobject/-/plugin-sobject-1.4.108.tgz",
+      "integrity": "sha512-mhsWGepX9wuA2845+xq2LPQWhLTatmDFkCiOWFUB+OOiB98HSPzwwiX2lJMBRlQe40i0RDAZ5mmvTPNPhjQv6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/confirm": "^3.2.0",
         "@inquirer/input": "^2.3.0",
         "@inquirer/select": "^2.5.0",
-        "@oclif/core": "^4",
-        "@salesforce/core": "^8.28.4",
+        "@oclif/core": "^4.11.0",
+        "@salesforce/core": "^8.29.0",
         "@salesforce/kit": "^3.2.6",
-        "@salesforce/sf-plugins-core": "^11.3.12",
+        "@salesforce/sf-plugins-core": "^12.2.17",
         "fast-glob": "^3.3.3",
-        "fast-xml-parser": "^5.7.2",
+        "fast-xml-parser": "^5.8.0",
         "js2xmlparser": "^4.0.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject/node_modules/@inquirer/core": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.1.0.tgz",
-      "integrity": "sha512-RZVfH//2ytTjmaBIzeKT1zefcQZzuruwkpTwwbe/i2jTl4o9M+iML5ChULzz6iw1Ok8iUBBsRCjY2IEbD8Ft4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.3",
-        "@types/mute-stream": "^0.0.4",
-        "@types/node": "^22.5.2",
-        "@types/wrap-ansi": "^3.0.0",
-        "ansi-escapes": "^4.3.2",
-        "cli-spinners": "^2.9.2",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^1.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject/node_modules/@inquirer/core/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject/node_modules/@inquirer/core/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject/node_modules/@inquirer/password": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.2.0.tgz",
-      "integrity": "sha512-5otqIpgsPYIshqhgtEwSspBQE40etouR8VIxzpJkv9i0dVHIpyhiivbkH9/dGiMLdyamT54YRdGJLfl8TFnLHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/type": "^1.5.3",
-        "ansi-escapes": "^4.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject/node_modules/@inquirer/type": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.3.tgz",
-      "integrity": "sha512-xUQ14WQGR/HK5ei+2CvgcwoH9fQ4PgPGmVFSN0pc1+fVyDL3MREhyAY7nxEErSu6CkllBM3D7e3e+kOvtu+eIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject/node_modules/@salesforce/sf-plugins-core": {
-      "version": "11.3.12",
-      "resolved": "https://registry.npmjs.org/@salesforce/sf-plugins-core/-/sf-plugins-core-11.3.12.tgz",
-      "integrity": "sha512-hi8EcSoRHRxj4sm/V5YDtzq9bPr/cKpM4fC6abo/jRzpXygwizinc2gVQkXfVdhjK7NGMskVRQB1N+0TThG7bA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@inquirer/confirm": "^3.1.22",
-        "@inquirer/password": "^2.2.0",
-        "@oclif/core": "^4.0.27",
-        "@salesforce/core": "^8.5.1",
-        "@salesforce/kit": "^3.2.3",
-        "@salesforce/ts-types": "^2.0.12",
-        "ansis": "^3.3.2",
-        "cli-progress": "^3.12.0",
-        "natural-orderby": "^3.0.2",
-        "slice-ansi": "^7.1.0",
-        "string-width": "^7.2.0",
-        "terminal-link": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject/node_modules/@types/node": {
-      "version": "22.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject/node_modules/emoji-regex": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-sobject/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-telemetry": {
-      "version": "3.8.15",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-telemetry/-/plugin-telemetry-3.8.15.tgz",
-      "integrity": "sha512-/2ezpJ8lGm2YMuexkAjPyPgzSPCSOmJZGfmj9ZDEQpUv5RFXtWQAp+zCrL7O+5zXFwTiVdVj9xQ3LXzALo6tng==",
+      "version": "3.8.21",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-telemetry/-/plugin-telemetry-3.8.21.tgz",
+      "integrity": "sha512-VtSFAxy8yH/RdDCf0OCKGqd4I2Bgs9c29bqcjHSPi+x7DDWVbIBZ7NkD7GxljU4X9dWvAqC0jI6nNIlq8ypm6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -10105,7 +8963,7 @@
         "@salesforce/core": "^8.27.1",
         "@salesforce/kit": "^3.2.6",
         "@salesforce/sf-plugins-core": "^12",
-        "@salesforce/telemetry": "^6.8.17",
+        "@salesforce/telemetry": "^6.8.19",
         "@salesforce/ts-types": "^2.0.12",
         "debug": "^4.4.3"
       },
@@ -10114,34 +8972,34 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-templates": {
-      "version": "56.16.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-templates/-/plugin-templates-56.16.4.tgz",
-      "integrity": "sha512-uetB+fNMJZgenksXfWNnPub7dy2lzQRPwQY4jeMhTwrmOJjlQFbH1ekgBGnJ8l8405qAAeuCxhfsVnBs2P2mAQ==",
+      "version": "56.17.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-templates/-/plugin-templates-56.17.2.tgz",
+      "integrity": "sha512-9v3QMiJ38oIxZ2b1fhpNfM8KHGaIz7ez5k+149aCJdc0F3AHzczR0ztMN775LWr+I/+lRqUsUEygODdaltME4A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/core": "^8.28.4",
+        "@salesforce/core": "^8.30.3",
         "@salesforce/sf-plugins-core": "^12",
-        "@salesforce/templates": "^66.7.12"
+        "@salesforce/templates": "^66.7.13"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-trust": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-trust/-/plugin-trust-3.8.0.tgz",
-      "integrity": "sha512-SkG1HhfWMfo3hpKooukPW4wlVadk4lQlP3R2De8D6CElxNlr0zkQhWirQrt67nCkSZZKjXdyPOeJzqY2/9jMpA==",
+      "version": "3.8.9",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-trust/-/plugin-trust-3.8.9.tgz",
+      "integrity": "sha512-/ocgwyuFCfA/eboauUrzQOk1UV107fTl/bJe3LIEkB3CxfAQMOqVYcBsdQ7awJyTB71a0omv/Deg9W5MUqM98Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/core": "^4",
-        "@salesforce/core": "^8.28.1",
+        "@salesforce/core": "^8.29.1",
         "@salesforce/kit": "^3.2.6",
-        "@salesforce/plugin-info": "^3.4.123",
+        "@salesforce/plugin-info": "^3.4.131",
         "@salesforce/sf-plugins-core": "^12",
         "got": "^13.0.0",
-        "npm": "^11.13.0",
+        "npm": "^11.14.1",
         "npm-run-path": "^4.0.1",
         "proxy-agent": "^6.5.0",
         "semver": "^7.7.4",
@@ -10155,15 +9013,15 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/plugin-user": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/plugin-user/-/plugin-user-3.9.0.tgz",
-      "integrity": "sha512-T6tK51gVFkOKfoaRptO6YGhuHsh9YD11JYa9MPpbZcv2aq1la02BilN4Xc5jnkBLNY9VaZhIq4UC1sfYJPHq9A==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/plugin-user/-/plugin-user-3.10.0.tgz",
+      "integrity": "sha512-s2khmxS1OqcwmO1lThxS/A9Mxth19YQDVDm0CkjNrqmMqrPeVuC2SlZizRgKirtDidwTf3b2BGLtrbLpDfe9CQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/core": "^8.28.4",
+        "@salesforce/core": "^8.30.3",
         "@salesforce/kit": "^3.2.4",
-        "@salesforce/sf-plugins-core": "^12.2.6",
+        "@salesforce/sf-plugins-core": "^12.2.17",
         "@salesforce/ts-types": "^2.0.11"
       },
       "engines": {
@@ -10185,17 +9043,17 @@
       "license": "ISC"
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/sf-plugins-core": {
-      "version": "12.2.10",
-      "resolved": "https://registry.npmjs.org/@salesforce/sf-plugins-core/-/sf-plugins-core-12.2.10.tgz",
-      "integrity": "sha512-Rx6dbyKb1u08Fjcan8ZDhUkb073CBLRVEPH2KllZWclQRMa5gzcvmuB3uXhUXK5l0paH5o4g0CojgbNqEKhS9g==",
+      "version": "12.2.17",
+      "resolved": "https://registry.npmjs.org/@salesforce/sf-plugins-core/-/sf-plugins-core-12.2.17.tgz",
+      "integrity": "sha512-a8wHzT4IPUxvqUcguTd6wXp4C7R2i+HTjjiCBNNEqL5/OFXmROlttalgxFceRsnfoi2Sq9jYuVIVWHOs43uEWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/confirm": "^6.0.12",
         "@inquirer/password": "^5.0.12",
-        "@oclif/core": "^4.10.6",
-        "@oclif/table": "^0.5.5",
-        "@salesforce/core": "^8.28.4",
+        "@oclif/core": "^4.11.2",
+        "@oclif/table": "^0.5.7",
+        "@salesforce/core": "^8.30.0",
         "@salesforce/kit": "^3.2.3",
         "@salesforce/ts-types": "^2.0.12",
         "ansis": "^3.3.2",
@@ -10317,18 +9175,18 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "12.34.5",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.34.5.tgz",
-      "integrity": "sha512-iL+656HXNGFMv0DTPF4MKCaJ3de9qGyIzOrOyZ/CL1l0CYcgp2YHrLJuSaCKujul0ymceUGcAptSsZcSVWhjqw==",
+      "version": "12.35.10",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.35.10.tgz",
+      "integrity": "sha512-njg3pt0aqwUF5xCleO6wMN45+AIbhpG9xOExWz3io+Qy2uWW75WoHdcj3ZTZFLKqyHBc2NNSfDJc+QYEnJccGg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/core": "^8.28.4",
+        "@salesforce/core": "^8.30.3",
         "@salesforce/kit": "^3.2.4",
         "@salesforce/ts-types": "^2.0.12",
         "@salesforce/types": "^1.6.0",
         "fast-levenshtein": "^3.0.0",
-        "fast-xml-parser": "^5.7.2",
+        "fast-xml-parser": "^5.7.3",
         "got": "^11.8.6",
         "graceful-fs": "^4.2.11",
         "ignore": "^5.3.2",
@@ -10480,15 +9338,15 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/source-tracking": {
-      "version": "7.8.14",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking/-/source-tracking-7.8.14.tgz",
-      "integrity": "sha512-qebz8KFH2plLJzQNs6r+/DG16UmnoUqK3Z3HvIjaIsTuoQUd0d/XP96C1nNEfnnhkqLc6Pu0sd1C0Et59y3CxA==",
+      "version": "7.8.16",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-tracking/-/source-tracking-7.8.16.tgz",
+      "integrity": "sha512-l6nUZpueLqApzIlwQWS72oU+NOnLRGOvhMjPxGUdII+vFBdFxniHOXd0vFEx3LZFJ3ksk95x5pQgV0nEKW9TRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/core": "^8.28.3",
+        "@salesforce/core": "^8.30.0",
         "@salesforce/kit": "^3.2.6",
-        "@salesforce/source-deploy-retrieve": "^12.32.7",
+        "@salesforce/source-deploy-retrieve": "^12.35.9",
         "@salesforce/ts-types": "^2.0.12",
         "fast-xml-parser": "^5.5.7",
         "graceful-fs": "^4.2.11",
@@ -10500,18 +9358,18 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/telemetry": {
-      "version": "6.8.18",
-      "resolved": "https://registry.npmjs.org/@salesforce/telemetry/-/telemetry-6.8.18.tgz",
-      "integrity": "sha512-YHXOdGB6wrS7aekS+F7DNGgohlKv25MXioYrCnn7D/g6u47s7lT5Q2NGmSiMA3wspz4aSNEmIf20FGtKhhZDmQ==",
+      "version": "6.8.21",
+      "resolved": "https://registry.npmjs.org/@salesforce/telemetry/-/telemetry-6.8.21.tgz",
+      "integrity": "sha512-gGx4hDQ7gMxg4CbmEntrEiZrz0b7111fO/LEtXYZUJOWemoQP+3eCjeoR7v2JUto9kBP6onwZ0BKo7J3lTGNDQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/core": "^8.28.4",
+        "@salesforce/core": "^8.29.0",
         "@salesforce/kit": "^3.2.6",
-        "@salesforce/o11y-reporter": "1.8.3",
+        "@salesforce/o11y-reporter": "1.8.4",
         "applicationinsights": "^2.9.8",
         "got": "^11",
-        "o11y_schema": "^260.63.0",
+        "o11y_schema": "^260.65.0",
         "proxy-agent": "^6.5.0"
       },
       "engines": {
@@ -10629,6 +9487,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@salesforce/cli/node_modules/@salesforce/telemetry/node_modules/o11y_schema": {
+      "version": "260.65.0",
+      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-260.65.0.tgz",
+      "integrity": "sha512-F3VWPhiDHH+L170X4Tt2cfqzlpXGbtowWPz+Npam3yB3KGBUIHA9paRG7FWZKv9wNcxrtQXgIZemmffVQTm3jg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@salesforce/cli/node_modules/@salesforce/telemetry/node_modules/p-cancelable": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -10640,9 +9505,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@salesforce/templates": {
-      "version": "66.7.12",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.7.12.tgz",
-      "integrity": "sha512-yfJrJBpanECeFvZ7E+/PA9Xz0GxtO6BxfQ3Vp3PKJiA7yTGpdHMv6EdCDwy7utHxdmA06kq0m5GMD3YGW/qM7A==",
+      "version": "66.7.13",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.7.13.tgz",
+      "integrity": "sha512-xR0reatO1Z0wKieUeMudM8nyFA7v1dJxAD3BO+Zsqrt1iNtMDRUlnYoFrG+R82Jmtek69rLqhyMaRor2WZ8qpg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10652,7 +9517,7 @@
         "hpagent": "^1.2.0",
         "mime-types": "^3.0.2",
         "proxy-from-env": "^1.1.0",
-        "tar": "^7.5.13",
+        "tar": "^7.5.15",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -10964,86 +9829,6 @@
       "extraneous": true,
       "license": "MIT"
     },
-    "node_modules/@salesforce/cli/node_modules/@sigstore/bundle": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
-      "integrity": "sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.5.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@sigstore/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-kxHrDQ9YgfrWUSXU0cjsQGv8JykOFZQ9ErNKbFPWzk3Hgpwu8x2hHrQ9IdA8yl+j9RTLTC3sAF3Tdq1IQCP4oA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.5.1.tgz",
-      "integrity": "sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@sigstore/sign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
-      "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@gar/promise-retry": "^1.0.2",
-        "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.2.0",
-        "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.4",
-        "proc-log": "^6.1.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@sigstore/tuf": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
-      "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.5.0",
-        "tuf-js": "^4.1.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@sigstore/verify": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-3.1.0.tgz",
-      "integrity": "sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
-        "@sigstore/protobuf-specs": "^0.5.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -11129,67 +9914,15 @@
       "extraneous": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
-    "node_modules/@salesforce/cli/node_modules/@smithy/chunked-blob-reader": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
-      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/chunked-blob-reader-native": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
-      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-base64": "^4.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/config-resolver": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.14.tgz",
-      "integrity": "sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/@smithy/core": {
-      "version": "3.23.14",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz",
-      "integrity": "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-stream": "^4.5.22",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11197,91 +9930,14 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.13.tgz",
-      "integrity": "sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.13.tgz",
-      "integrity": "sha512-vYahwBAtRaAcFbOmE9aLr12z7RiHYDSLcnogSdxfm7kKfsNa3wH+NU5r7vTeB5rKvLsWyPjVX8iH94brP7umiQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.13.tgz",
-      "integrity": "sha512-wwybfcOX0tLqCcBP378TIU9IqrDuZq/tDV48LlZNydMpCnqnYr+hWBAYbRE+rFFf/p7IkDJySM3bgiMKP2ihPg==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.13.tgz",
-      "integrity": "sha512-ied1lO559PtAsMJzg2TKRlctLnEi1PfkNeMMpdwXDImk1zV9uvS/Oxoy/vcy9uv1GKZAjDAB5xT6ziE9fzm5wA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.13.tgz",
-      "integrity": "sha512-hFyK+ORJrxAN3RYoaD6+gsGDQjeix8HOEkosoajvXYZ4VeqonM3G4jd9IIRm/sWGXUKmudkY9KdYjzosUqdM8A==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.13.tgz",
-      "integrity": "sha512-kRrq4EKLGeOxhC2CBEhRNcu1KSzNJzYY7RK3S7CxMPgB5dRrv55WqQOtRwQxQLC04xqORFLUgnDlc6xrNUULaA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11289,77 +9945,14 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.16.tgz",
-      "integrity": "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/querystring-builder": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-base64": "^4.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/hash-blob-browser": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.14.tgz",
-      "integrity": "sha512-rtQ5es8r/5v4rav7q5QTsfx9CtCyzrz/g7ZZZBH2xtMmd6G/KQrLOWfSHTvFOUPlVy59RQvxeBYJaLRoybMEyA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/chunked-blob-reader": "^5.2.2",
-        "@smithy/chunked-blob-reader-native": "^4.2.3",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/hash-node": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.13.tgz",
-      "integrity": "sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/hash-stream-node": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.13.tgz",
-      "integrity": "sha512-WdQ7HwUjINXETeh6dqUeob1UHIYx8kAn9PSp1HhM2WWegiZBYVy2WXIs1lB07SZLan/udys9SBnQGt9MQbDpdg==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.13.tgz",
-      "integrity": "sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11367,230 +9960,27 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
-      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/md5-js": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.13.tgz",
-      "integrity": "sha512-cNm7I9NXolFxtS20ojROddOEpSAeI1Obq6pd1Kj5HtHws3s9Fkk8DdHDfQSs5KuxCewZuVK6UqrJnfJmiMzDuQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.13.tgz",
-      "integrity": "sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.29",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
-      "integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-middleware": "^4.2.13",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/middleware-retry": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.1.tgz",
-      "integrity": "sha512-/zY+Gp7Qj2D2hVm3irkCyONER7E9MiX3cUUm/k2ZmhkzZkrPgwVS4aJ5NriZUEN/M0D1hhjrgjUmX04HhRwdWA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/service-error-classification": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.1",
-        "@smithy/uuid": "^1.1.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/middleware-serde": {
-      "version": "4.2.17",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.17.tgz",
-      "integrity": "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/middleware-stack": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.13.tgz",
-      "integrity": "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/node-config-provider": {
-      "version": "4.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
-      "integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/@smithy/node-http-handler": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz",
-      "integrity": "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/querystring-builder": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/property-provider": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
-      "integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
-      "integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/querystring-parser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.13.tgz",
-      "integrity": "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/service-error-classification": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.13.tgz",
-      "integrity": "sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.8.tgz",
-      "integrity": "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11598,38 +9988,14 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@smithy/signature-v4": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
-      "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/smithy-client": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
-      "integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11637,65 +10003,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@smithy/types": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
-      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/url-parser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.13.tgz",
-      "integrity": "sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/util-base64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
-      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
-      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11706,196 +10016,31 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
-      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/util-config-provider": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
-      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.45",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.45.tgz",
-      "integrity": "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.49",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.49.tgz",
-      "integrity": "sha512-jlN6vHwE8gY5AfiFBavtD3QtCX2f7lM3BKkz7nFKSNfFR5nXLXLg6sqXTJEEyDwtxbztIDBQCfjsGVXlIru2lQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/util-endpoints": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.4.tgz",
-      "integrity": "sha512-BKoR/ubPp9KNKFxPpg1J28N1+bgu8NGAtJblBP7yHy8yQPBWhIAv9+l92SlQLpolGm71CVO+btB60gTgzT0wog==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
-      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/util-middleware": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
-      "integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/util-retry": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.1.tgz",
-      "integrity": "sha512-FwmicpgWOkP5kZUjN3y+3JIom8NLGqSAJBeoIgK0rIToI817TEBHCrd0A2qGeKQlgDeP+Jzn4i0H/NLAXGy9uQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/util-stream": {
-      "version": "4.5.22",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.22.tgz",
-      "integrity": "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-buffer-from": "^4.2.2",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/@smithy/util-utf8": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/util-waiter": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.15.tgz",
-      "integrity": "sha512-oUt9o7n8hBv3BL56sLSneL0XeigZSuem0Hr78JaoK33D9oKieyCvVP8eTSe3j7g2mm/S1DvzxKieG7JEWNJUNg==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@smithy/uuid": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
-      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/@szmarczak/http-timer": {
@@ -11945,30 +10090,6 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "extraneous": true,
       "license": "MIT"
-    },
-    "node_modules/@salesforce/cli/node_modules/@tufjs/canonical-json": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
-      "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/@tufjs/models": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-4.1.0.tgz",
-      "integrity": "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^10.1.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
     },
     "node_modules/@salesforce/cli/node_modules/@types/cacheable-request": {
       "version": "6.0.3",
@@ -12428,16 +10549,6 @@
       "extraneous": true,
       "license": "BSD-2-Clause"
     },
-    "node_modules/@salesforce/cli/node_modules/abbrev": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
-      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -12515,8 +10626,10 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -12529,8 +10642,10 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -12690,19 +10805,14 @@
         }
       }
     },
-    "node_modules/@salesforce/cli/node_modules/aproba": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "extraneous": true,
-      "license": "ISC"
-    },
     "node_modules/@salesforce/cli/node_modules/archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
-      "extraneous": true,
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@salesforce/cli/node_modules/are-docs-informative": {
       "version": "0.0.2",
@@ -13098,9 +11208,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13113,62 +11223,6 @@
       "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
       "extraneous": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@salesforce/cli/node_modules/bin-links": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
-      "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "cmd-shim": "^8.0.0",
-        "npm-normalize-package-bin": "^5.0.0",
-        "proc-log": "^6.0.0",
-        "read-cmd-shim": "^6.0.0",
-        "write-file-atomic": "^7.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/bin-links/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/bin-links/node_modules/write-file-atomic": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
-      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/binary-extensions": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-3.1.0.tgz",
-      "integrity": "sha512-Jvvd9hy1w+xUad8+ckQsWA/V1AoyubOvqn0aygjMOVM4BfIaRav1NFS3LsTSDaV4n4FtcCtQXvzep1E6MboqwQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/@salesforce/cli/node_modules/bl": {
       "version": "4.1.0",
@@ -13332,41 +11386,6 @@
       "dependencies": {
         "run-applescript": "^7.0.0"
       },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/cacache": {
-      "version": "20.0.4",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
-      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^5.0.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^13.0.0",
-        "lru-cache": "^11.1.0",
-        "minipass": "^7.0.3",
-        "minipass-collect": "^2.0.1",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "p-map": "^7.0.2",
-        "ssri": "^13.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/cacache/node_modules/p-map": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
-      "extraneous": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -13778,7 +11797,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
       "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-      "extraneous": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13786,18 +11805,10 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/cidr-regex": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-5.0.5.tgz",
-      "integrity": "sha512-59tdLZcC+BJXa4C5rOmVSuJTy/UneqfJJtCraqwdx5BDHTkGrBtKCUl3u2uiCFvXu+wk0kVuX8axX7yHCZOI9w==",
-      "extraneous": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/@salesforce/cli/node_modules/cjs-module-lexer": {
@@ -13942,9 +11953,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/cli-truncate/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14010,13 +12021,13 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/cli-truncate/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -14127,16 +12138,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/cmd-shim": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
-      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/code-excerpt": {
@@ -14502,16 +12503,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/common-ancestor-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
-      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
-      "extraneous": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/@salesforce/cli/node_modules/commondir": {
@@ -15119,19 +13110,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "extraneous": true,
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -15526,8 +13504,10 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "extraneous": true,
+      "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -15826,16 +13806,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@salesforce/cli/node_modules/environment": {
@@ -16631,13 +14601,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/exponential-backoff": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
-      "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
-      "extraneous": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/@salesforce/cli/node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -16745,11 +14708,21 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/fast-uri": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
-      "license": "MIT"
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/@salesforce/cli/node_modules/fast-wrap-ansi": {
       "version": "0.2.0",
@@ -16762,9 +14735,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "dev": true,
       "funding": [
         {
@@ -16774,13 +14747,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/fast-xml-parser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "dev": true,
       "funding": [
         {
@@ -16791,9 +14765,10 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.2.0",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -17133,19 +15108,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/fs-minipass": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
-      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/fs.realpath": {
@@ -17551,24 +15513,6 @@
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "extraneous": true,
       "license": "ISC"
-    },
-    "node_modules/@salesforce/cli/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "extraneous": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/@salesforce/cli/node_modules/glob-parent": {
       "version": "5.1.2",
@@ -18035,19 +15979,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@salesforce/cli/node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^11.1.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/hpagent": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
@@ -18254,19 +16185,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/ignore-walk": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
-      "integrity": "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^10.0.3"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -18318,8 +16236,10 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -18358,34 +16278,6 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@salesforce/cli/node_modules/init-package-json": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-8.2.5.tgz",
-      "integrity": "sha512-IknQ+upLuJU6t3p0uo9wS3GjFD/1GtxIwcIGYOWR8zL2HxQeJwvxYTgZr9brJ8pyZ4kvpkebM8ZKcyqOeLOHSg==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/package-json": "^7.0.0",
-        "npm-package-arg": "^13.0.0",
-        "promzard": "^3.0.1",
-        "read": "^5.0.1",
-        "semver": "^7.7.2",
-        "validate-npm-package-name": "^7.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/init-package-json/node_modules/validate-npm-package-name": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
-      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
     },
     "node_modules/@salesforce/cli/node_modules/ink": {
       "version": "5.0.1",
@@ -18497,9 +16389,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/ink/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -18561,13 +16453,13 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/ink/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -18948,19 +16840,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/is-cidr": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-6.0.4.tgz",
-      "integrity": "sha512-tOIBU3QiXy0W4LvHbcKWAWSuQfGwDiEILphFCAZtDqj7C57uv3ClO6K8aNEGV4VTA7bWJlpQ0suKQkUe6Rd6ag==",
-      "extraneous": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "cidr-regex": "^5.0.4"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/is-core-module": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
@@ -19145,6 +17024,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@salesforce/cli/node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@salesforce/cli/node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -19322,8 +17208,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "extraneous": true,
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@salesforce/cli/node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -19362,16 +17250,19 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-docker": "^2.0.0"
+        "is-inside-container": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@salesforce/cli/node_modules/isarray": {
@@ -19380,16 +17271,6 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@salesforce/cli/node_modules/isexe": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
-      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
-      "extraneous": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=20"
-      }
     },
     "node_modules/@salesforce/cli/node_modules/isomorphic-git": {
       "version": "1.34.2",
@@ -19710,16 +17591,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@salesforce/cli/node_modules/json-parse-even-better-errors": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
-      "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -19742,16 +17613,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=7.10.1"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/json-stringify-nice": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz",
-      "integrity": "sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==",
-      "extraneous": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@salesforce/cli/node_modules/json-stringify-safe": {
@@ -19798,11 +17659,13 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
-      "extraneous": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@salesforce/cli/node_modules/JSONStream": {
       "version": "1.3.5",
@@ -19894,15 +17757,10 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-5.2.0.tgz",
       "integrity": "sha512-6ufhP9SHjb7jibNFrNxyFZ6od3g+An6Ai9mhGRvcYe8UJlH0prseN64M+6ZBBUoKYHZsitDP42gAJ8+eVWr3lw==",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "node_modules/@salesforce/cli/node_modules/just-diff-apply": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
-      "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
-      "extraneous": true,
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@salesforce/cli/node_modules/just-extend": {
       "version": "4.2.1",
@@ -19966,194 +17824,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/libnpmaccess": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-10.0.3.tgz",
-      "integrity": "sha512-JPHTfWJxIK+NVPdNMNGnkz4XGX56iijPbe0qFWbdt68HL+kIvSzh+euBL8npLZvl2fpaxo+1eZSdoG15f5YdIQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-package-arg": "^13.0.0",
-        "npm-registry-fetch": "^19.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/libnpmdiff": {
-      "version": "8.1.6",
-      "resolved": "https://registry.npmjs.org/libnpmdiff/-/libnpmdiff-8.1.6.tgz",
-      "integrity": "sha512-nr6/MrxRnqMUoB9t0aHImBKArkJCU3YeaTyu817XYQXAQq9iWgX+ZVLgd+5wZVfoyemPdJj2LasXhFNyVk5GAA==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^9.4.3",
-        "@npmcli/installed-package-contents": "^4.0.0",
-        "binary-extensions": "^3.0.0",
-        "diff": "^8.0.2",
-        "minimatch": "^10.0.3",
-        "npm-package-arg": "^13.0.0",
-        "pacote": "^21.0.2",
-        "tar": "^7.5.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/libnpmdiff/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "extraneous": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/libnpmexec": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/libnpmexec/-/libnpmexec-10.2.6.tgz",
-      "integrity": "sha512-aUHRHUhoi98CW9x+0+RzOVvKvl4rvGgr6o7wnWfdyuvZtU5WXGStfuArN1wBANxEP50bLTocMJrEsBktEuiVqw==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.3",
-        "@npmcli/package-json": "^7.0.0",
-        "@npmcli/run-script": "^10.0.0",
-        "ci-info": "^4.0.0",
-        "npm-package-arg": "^13.0.0",
-        "pacote": "^21.0.2",
-        "proc-log": "^6.0.0",
-        "read": "^5.0.1",
-        "semver": "^7.3.7",
-        "signal-exit": "^4.1.0",
-        "walk-up-path": "^4.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/libnpmexec/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/libnpmfund": {
-      "version": "7.0.20",
-      "resolved": "https://registry.npmjs.org/libnpmfund/-/libnpmfund-7.0.20.tgz",
-      "integrity": "sha512-H1FvUdssvUlAfQJsNotf+DUetF2mS7d2sW8+MByLCMmgsZ+OkKbXgQit0PCjAwg8BD/Z/f8UO0FJT7bOYe73fQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^9.4.3"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/libnpmorg": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-8.0.1.tgz",
-      "integrity": "sha512-/QeyXXg4hqMw0ESM7pERjIT2wbR29qtFOWIOug/xO4fRjS3jJJhoAPQNsnHtdwnCqgBdFpGQ45aIdFFZx2YhTA==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^19.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/libnpmpack": {
-      "version": "9.1.6",
-      "resolved": "https://registry.npmjs.org/libnpmpack/-/libnpmpack-9.1.6.tgz",
-      "integrity": "sha512-Uov/MsMO+1MdJdT4PKdz6MiLNuZb73REKxbxKXKcNUaDkeBGNXxGB1GUxpdsvZlx1sos4MQDTYw34q4yw7hzHw==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^9.4.3",
-        "@npmcli/run-script": "^10.0.0",
-        "npm-package-arg": "^13.0.0",
-        "pacote": "^21.0.2"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/libnpmpublish": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-11.1.3.tgz",
-      "integrity": "sha512-NVPTth/71cfbdYHqypcO9Lt5WFGTzFEcx81lWd7GDJIgZ95ERdYHGUfCtFejHCyqodKsQkNEx2JCkMpreDty/A==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/package-json": "^7.0.0",
-        "ci-info": "^4.0.0",
-        "npm-package-arg": "^13.0.0",
-        "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.7",
-        "sigstore": "^4.0.0",
-        "ssri": "^13.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/libnpmsearch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-9.0.1.tgz",
-      "integrity": "sha512-oKw58X415ERY/BOGV3jQPVMcep8YeMRWMzuuqB0BAIM5VxicOU1tQt19ExCu4SV77SiTOEoziHxGEgJGw3FBYQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^19.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/libnpmteam": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-8.0.2.tgz",
-      "integrity": "sha512-ypLrDUQoi8EhG+gzx5ENMcYq23YjPV17Mfvx4nOnQiHOi8vp47+4GvZBrMsEM4yeHPwxguF/HZoXH4rJfHdH/w==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^19.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/libnpmversion": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/libnpmversion/-/libnpmversion-8.0.3.tgz",
-      "integrity": "sha512-Avj1GG3DT6MGzWOOk3yA7rORcMDUPizkIGbI8glHCO7WoYn3NYNmskLDwxg2NMY1Tyf2vrHAqTuSG58uqd1lJg==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^7.0.0",
-        "@npmcli/run-script": "^10.0.0",
-        "json-parse-even-better-errors": "^5.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/lie": {
@@ -20666,30 +18336,6 @@
       "extraneous": true,
       "license": "ISC"
     },
-    "node_modules/@salesforce/cli/node_modules/make-fetch-happen": {
-      "version": "15.0.5",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
-      "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promise-retry": "^1.0.0",
-        "@npmcli/agent": "^4.0.0",
-        "@npmcli/redact": "^4.0.0",
-        "cacache": "^20.0.1",
-        "http-cache-semantics": "^4.1.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^5.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^1.0.0",
-        "proc-log": "^6.0.0",
-        "ssri": "^13.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -21169,102 +18815,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/minipass-collect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
-      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/minipass-fetch": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
-      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.0.3",
-        "minipass-sized": "^2.0.0",
-        "minizlib": "^3.0.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      },
-      "optionalDependencies": {
-        "iconv-lite": "^0.7.2"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/minipass-pipeline/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/minipass-sized": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
-      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/minizlib": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
@@ -21537,16 +19087,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -21623,18 +19163,18 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/nock": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
-      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "version": "14.0.15",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.15.tgz",
+      "integrity": "sha512-S0a47C9pLvcYx/Ugf0H30BVBEcUgMMBDk9VJIDlJ8XGrfH2QDUD4Tgdp45qDIiHttokBG+IbsOtsvIjGR/j3bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.1.0",
+        "@mswjs/interceptors": "^0.41.0",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       },
       "engines": {
-        "node": ">= 10.13"
+        "node": ">=18.20.0 <20 || >=20.12.1"
       }
     },
     "node_modules/@salesforce/cli/node_modules/node-emoji": {
@@ -21668,41 +19208,6 @@
         }
       }
     },
-    "node_modules/@salesforce/cli/node_modules/node-gyp": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.3.0.tgz",
-      "integrity": "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "exponential-backoff": "^3.1.1",
-        "graceful-fs": "^4.2.6",
-        "nopt": "^9.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.5",
-        "tar": "^7.5.4",
-        "tinyglobby": "^0.2.12",
-        "undici": "^6.25.0",
-        "which": "^6.0.0"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/node-gyp/node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/node-preload": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -21722,22 +19227,6 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "extraneous": true,
       "license": "MIT"
-    },
-    "node_modules/@salesforce/cli/node_modules/nopt": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
-      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "^4.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
     },
     "node_modules/@salesforce/cli/node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -21793,9 +19282,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/npm": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
-      "integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz",
+      "integrity": "sha512-aopNZ0eEl6LbxoFcrXLmTEPzNBNxfiQnVgR9RmJBqzm+5h5pFoOmRljpRJbsXxocBeSl7GLcx3MoDf2UlEOjZw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -21874,8 +19363,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.3",
-        "@npmcli/config": "^10.8.1",
+        "@npmcli/arborist": "^9.5.0",
+        "@npmcli/config": "^10.9.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -21899,11 +19388,11 @@
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.6",
-        "libnpmexec": "^10.2.6",
-        "libnpmfund": "^7.0.20",
+        "libnpmdiff": "^8.1.7",
+        "libnpmexec": "^10.2.7",
+        "libnpmfund": "^7.0.21",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.6",
+        "libnpmpack": "^9.1.7",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -21947,142 +19436,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/npm-audit-report": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-7.0.0.tgz",
-      "integrity": "sha512-bluLL4xwGr/3PERYz50h2Upco0TJMDcLcymuFnfDWeGO99NqH724MNzhWi5sXXuXf2jbytFF0LyR8W+w1jTI6A==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/npm-bundled": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-5.0.0.tgz",
-      "integrity": "sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-normalize-package-bin": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/npm-install-checks": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
-      "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
-      "extraneous": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "semver": "^7.1.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/npm-normalize-package-bin": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
-      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/npm-package-arg": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
-      "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "hosted-git-info": "^9.0.0",
-        "proc-log": "^6.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^7.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
-      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/npm-packlist": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-10.0.4.tgz",
-      "integrity": "sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "ignore-walk": "^8.0.0",
-        "proc-log": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/npm-pick-manifest": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
-      "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-install-checks": "^8.0.0",
-        "npm-normalize-package-bin": "^5.0.0",
-        "npm-package-arg": "^13.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/npm-profile": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-12.0.1.tgz",
-      "integrity": "sha512-Xs1mejJ1/9IKucCxdFMkiBJUre0xaxfCpbsO7DB7CadITuT4k68eI05HBlw4kj+Em1rsFMgeFNljFPYvPETbVQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/npm-registry-fetch": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
-      "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/redact": "^4.0.0",
-        "jsonparse": "^1.3.1",
-        "make-fetch-happen": "^15.0.0",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^5.0.0",
-        "minizlib": "^3.0.1",
-        "npm-package-arg": "^13.0.0",
-        "proc-log": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -22094,16 +19447,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/npm-user-validate": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-4.0.0.tgz",
-      "integrity": "sha512-TP+Ziq/qPi/JRdhaEhnaiMkqfMGjhDLoh/oRfW+t5aCuIfJxIUxvwk6Sg/6ZJ069N/Be6gs00r+aZeJTfS9uHQ==",
-      "extraneous": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/npm/node_modules/@gar/promise-retry": {
@@ -22150,7 +19493,7 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.3",
+      "version": "9.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -22198,7 +19541,7 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.8.1",
+      "version": "10.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -22612,7 +19955,7 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.4",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -22835,7 +20178,7 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -22917,12 +20260,12 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.6",
+      "version": "8.1.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/arborist": "^9.5.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -22936,13 +20279,13 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.6",
+      "version": "10.2.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/arborist": "^9.5.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -22959,12 +20302,12 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.20",
+      "version": "7.0.21",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.3"
+        "@npmcli/arborist": "^9.5.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -22984,12 +20327,12 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.6",
+      "version": "9.1.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.3",
+        "@npmcli/arborist": "^9.5.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -23620,12 +20963,12 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.8",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -24002,28 +21345,21 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/o11y": {
-      "version": "258.7.0",
-      "resolved": "https://registry.npmjs.org/o11y/-/o11y-258.7.0.tgz",
-      "integrity": "sha512-tcE4H3ytUKQXP5Y0Ta3rfPgYokYGSLVQpJW9KZGYGmcD/jRITWOa7siw3Uo/WcMXzEmwwi/fW3uft8Aon7ef2w==",
+      "version": "264.5.0",
+      "resolved": "https://registry.npmjs.org/o11y/-/o11y-264.5.0.tgz",
+      "integrity": "sha512-3eTE13TMBi8b4E9bK0yz1P4RIaGlR9asNhwBjSxCLiuPK8Z6daee/9PnWXDXW40agy72sIT9dWNn4prk87kdxg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "o11y_schema": "254.44.0",
-        "protobufjs": "7.2.6",
-        "web-vitals": "^4.2.4"
+        "o11y_schema": "260.5.0",
+        "protobufjs": "7.5.5",
+        "web-vitals": "^5.1.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/o11y_schema": {
-      "version": "260.63.0",
-      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-260.63.0.tgz",
-      "integrity": "sha512-hRLP3mysaQ6Qi/NO+ceHLOz5DYvgpxKk2mVrTeCtMngsnU4/T3+vsBCOX73rS6YM469tDmBYYHcnXQseXyxqcg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@salesforce/cli/node_modules/o11y/node_modules/o11y_schema": {
-      "version": "254.44.0",
-      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-254.44.0.tgz",
-      "integrity": "sha512-qcwaZsTyl/NFRoyjXk5ZObfjb773wYM5wxDbHSJNkQDBxX96RjUS/Df0M1rSbsmJWPOuYiV4EkvIOEPMm8V86g==",
+      "version": "260.5.0",
+      "resolved": "https://registry.npmjs.org/o11y_schema/-/o11y_schema-260.5.0.tgz",
+      "integrity": "sha512-0qrtqE394CODoPovUBdQQ2efHls6Z2xP6jvLitEGKSEj1KcCyeBLx2dHwTUtv66zwZTKjSp27QLFF4PZhengEQ==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -24146,20 +21482,20 @@
       "license": "MIT"
     },
     "node_modules/@salesforce/cli/node_modules/oclif": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/oclif/-/oclif-4.23.0.tgz",
-      "integrity": "sha512-0Rz8YsJx6NQORMgyDeDr6i0OlJa6h4oLXBht9iRZhn/YI/by/ONKgcJIPXyTgeLK21JmhbFqJn6Y1AME0EH1Dw==",
+      "version": "4.23.7",
+      "resolved": "https://registry.npmjs.org/oclif/-/oclif-4.23.7.tgz",
+      "integrity": "sha512-rog7/P6l6PXe7O3zWMcKB4prQm35z6NyDfpED6B3UwnPr1Fy+KWdcBHSr6Er3AjmvYsP5wsJwwPEsxUfvMNsyg==",
       "extraneous": true,
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-cloudfront": "3.1009.0",
-        "@aws-sdk/client-s3": "3.1014.0",
+        "@aws-sdk/client-cloudfront": "^3.1009.0",
+        "@aws-sdk/client-s3": "^3.1048.0",
         "@inquirer/confirm": "^3.1.22",
         "@inquirer/input": "^2.2.4",
         "@inquirer/select": "^2.5.0",
-        "@oclif/core": "4.9.0",
-        "@oclif/plugin-help": "^6.2.38",
-        "@oclif/plugin-not-found": "^3.2.76",
+        "@oclif/core": "^4.11.2",
+        "@oclif/plugin-help": "^6.2.49",
+        "@oclif/plugin-not-found": "^3.2.85",
         "@oclif/plugin-warn-if-update-available": "^3.1.57",
         "ansis": "^3.16.0",
         "async-retry": "^1.3.3",
@@ -24182,52 +21518,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/oclif/node_modules/@oclif/core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.9.0.tgz",
-      "integrity": "sha512-k/ntRgDcUprTT+aaNoF+whk3cY3f9fRD2lkF6ul7JeCUg2MaMXVXZXfbRhJCfsiX51X8/5Pqo0LGdO9SLYXNHg==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.3.2",
-        "ansis": "^3.17.0",
-        "clean-stack": "^3.0.1",
-        "cli-spinners": "^2.9.2",
-        "debug": "^4.4.3",
-        "ejs": "^3.1.10",
-        "get-package-type": "^0.1.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "lilconfig": "^3.1.3",
-        "minimatch": "^10.2.4",
-        "semver": "^7.7.3",
-        "string-width": "^4.2.3",
-        "supports-color": "^8",
-        "tinyglobby": "^0.2.14",
-        "widest-line": "^3.1.0",
-        "wordwrap": "^1.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/oclif/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@salesforce/cli/node_modules/oclif/node_modules/change-case": {
@@ -24314,22 +21604,6 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/oclif/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/oclif/node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -24338,24 +21612,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/oclif/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@salesforce/cli/node_modules/on-exit-leak-free": {
@@ -24450,6 +21706,13 @@
       "extraneous": true,
       "license": "MIT"
     },
+    "node_modules/@salesforce/cli/node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@salesforce/cli/node_modules/p-cancelable": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
@@ -24493,8 +21756,10 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
       "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -24569,38 +21834,6 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
-    "node_modules/@salesforce/cli/node_modules/pacote": {
-      "version": "21.5.0",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.0.tgz",
-      "integrity": "sha512-VtZ0SB8mb5Tzw3dXDfVAIjhyVKUHZkS/ZH9/5mpKenwC9sFOXNI0JI7kEF7IMkwOnsWMFrvAZHzx1T5fmrp9FQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promise-retry": "^1.0.0",
-        "@npmcli/git": "^7.0.0",
-        "@npmcli/installed-package-contents": "^4.0.0",
-        "@npmcli/package-json": "^7.0.0",
-        "@npmcli/promise-spawn": "^9.0.0",
-        "@npmcli/run-script": "^10.0.0",
-        "cacache": "^20.0.0",
-        "fs-minipass": "^3.0.0",
-        "minipass": "^7.0.2",
-        "npm-package-arg": "^13.0.0",
-        "npm-packlist": "^10.0.1",
-        "npm-pick-manifest": "^11.0.1",
-        "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0",
-        "sigstore": "^4.0.0",
-        "ssri": "^13.0.0",
-        "tar": "^7.4.3"
-      },
-      "bin": {
-        "pacote": "bin/index.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -24631,28 +21864,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/@salesforce/cli/node_modules/parse-conflict-json": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/parse-conflict-json/-/parse-conflict-json-5.0.1.tgz",
-      "integrity": "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^5.0.0",
-        "just-diff": "^6.0.0",
-        "just-diff-apply": "^5.2.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/parse-conflict-json/node_modules/just-diff": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/just-diff/-/just-diff-6.0.2.tgz",
-      "integrity": "sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==",
-      "extraneous": true,
-      "license": "MIT"
     },
     "node_modules/@salesforce/cli/node_modules/parse-json": {
       "version": "4.0.0",
@@ -25005,20 +22216,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -25133,16 +22330,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/proc-log": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
-      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -25189,49 +22376,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/@salesforce/cli/node_modules/proggy": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/proggy/-/proggy-4.0.0.tgz",
-      "integrity": "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/promise-all-reject-late": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
-      "integrity": "sha512-vuf0Lf0lOxyQREH7GDIOUMLS7kz+gs8i6B+Yi8dC68a2sychGrHTJYghMBD6k7eUcH0H5P73EckCA48xijWqXw==",
-      "extraneous": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/promise-call-limit": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/promise-call-limit/-/promise-call-limit-3.0.1.tgz",
-      "integrity": "sha512-utl+0x8gIDasV5X+PI5qWEPqH6fJS0pFtQ/4gZ95xfEFb/89dmh+/b895TbFDBLiafBvxD/PGTKfvxl4kH/pQg==",
-      "extraneous": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/promzard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/promzard/-/promzard-3.0.1.tgz",
-      "integrity": "sha512-M5mHhWh+Adz0BIxgSrqcc6GTCSconR7zWQV9vnOSptNtr6cSFlApLc28GbQhuN6oOWBQeV2C0bNE47JCY/zu3Q==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "read": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
     },
     "node_modules/@salesforce/cli/node_modules/propagate": {
       "version": "2.0.1",
@@ -25284,9 +22428,9 @@
       "license": "ISC"
     },
     "node_modules/@salesforce/cli/node_modules/protobufjs": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -25381,15 +22525,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/qrcode-terminal": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
-      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
-      "extraneous": true,
-      "bin": {
-        "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
     "node_modules/@salesforce/cli/node_modules/querystring": {
@@ -25489,29 +22624,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/read": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/read/-/read-5.0.1.tgz",
-      "integrity": "sha512-+nsqpqYkkpet2UVPG8ZiuE8d113DK4vHYEoEhcrXBAlPiq6di7QRTuNiKQAbaRYegobuX2BpZ6QjanKOXnJdTA==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "mute-stream": "^3.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/read-cmd-shim": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
-      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -25608,16 +22720,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/read/node_modules/mute-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
-      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/readable-stream": {
@@ -26169,9 +23271,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@salesforce/cli/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -26375,24 +23477,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@salesforce/cli/node_modules/sigstore": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-4.1.0.tgz",
-      "integrity": "sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
-        "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.1.0",
-        "@sigstore/tuf": "^4.0.1",
-        "@sigstore/verify": "^3.1.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
     },
     "node_modules/@salesforce/cli/node_modules/simple-concat": {
       "version": "1.0.1",
@@ -26766,15 +23850,19 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-      "extraneous": true,
-      "license": "CC-BY-3.0"
+      "dev": true,
+      "license": "CC-BY-3.0",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@salesforce/cli/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
       "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -26784,8 +23872,10 @@
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
       "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
-      "extraneous": true,
-      "license": "CC0-1.0"
+      "dev": true,
+      "license": "CC0-1.0",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@salesforce/cli/node_modules/split": {
       "version": "1.0.1",
@@ -26830,19 +23920,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/ssri": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
-      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/stack-chain": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
@@ -26872,6 +23949,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@salesforce/cli/node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@salesforce/cli/node_modules/string_decoder": {
       "version": "1.3.0",
@@ -27055,9 +24139,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "dev": true,
       "funding": [
         {
@@ -27108,9 +24192,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -27294,8 +24378,10 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "extraneous": true,
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@salesforce/cli/node_modules/thingies": {
       "version": "2.5.0",
@@ -27348,22 +24434,15 @@
       "extraneous": true,
       "license": "MIT"
     },
-    "node_modules/@salesforce/cli/node_modules/tiny-relative-date": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-2.0.2.tgz",
-      "integrity": "sha512-rGxAbeL9z3J4pI2GtBEoFaavHdO4RKAU54hEuOef5kfx5aPqiQtbhYktMOTL5OA33db8BjsDcLXuNp+/v19PHw==",
-      "extraneous": true,
-      "license": "MIT"
-    },
     "node_modules/@salesforce/cli/node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -27373,11 +24452,14 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
-      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -27388,9 +24470,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -27483,16 +24565,6 @@
       },
       "peerDependencies": {
         "tslib": "2"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/treeverse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
-      "integrity": "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/trim-lines": {
@@ -27695,21 +24767,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/@salesforce/cli/node_modules/tuf-js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-4.1.0.tgz",
-      "integrity": "sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tufjs/models": "4.1.0",
-        "debug": "^4.4.3",
-        "make-fetch-happen": "^15.0.1"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -27844,8 +24901,10 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
@@ -28259,20 +25318,10 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/walk-up-path": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
-      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
-      "extraneous": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@salesforce/cli/node_modules/web-vitals": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -28317,22 +25366,6 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/@salesforce/cli/node_modules/which": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
-      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
-      "extraneous": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^4.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/which-boxed-primitive": {
@@ -28532,8 +25565,10 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "extraneous": true,
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "is-typedarray": "^1.0.0",
@@ -28542,9 +25577,9 @@
       }
     },
     "node_modules/@salesforce/cli/node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -28579,20 +25614,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@salesforce/cli/node_modules/wsl-utils/node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+    "node_modules/@salesforce/cli/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
       "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@salesforce/cli/node_modules/xml2js": {
@@ -28657,13 +25692,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "extraneous": true,
-      "license": "ISC"
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@salesforce/cli/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -28836,9 +25873,9 @@
       "license": "MIT"
     },
     "node_modules/@salesforce/cli/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nebula-logger",
-  "version": "4.18.3",
+  "version": "4.18.4",
   "description": "The most robust logger for Salesforce. Works with Apex, Lightning Components, Flow, Process Builder & Integrations. Designed for Salesforce admins, developers & architects.",
   "author": "Jonathan Gillespie",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@cparra/apexdocs": "1.13.7",
     "@jongpie/sfdx-bummer-plugin": "0.0.20",
     "@salesforce-ux/slds-linter": "1.2.0",
-    "@salesforce/cli": "2.134.1",
+    "@salesforce/cli": "2.136.8",
     "@salesforce/eslint-config-lwc": "4.1.2",
     "@salesforce/sfdx-lwc-jest": "7.5.0",
     "@types/jest-when": "3.5.5",
@@ -92,8 +92,8 @@
     "jest-when": "3.7.0",
     "jsdoc-to-markdown": "9.1.3",
     "lint-staged": "16.2.7",
-    "prettier-plugin-apex": "2.2.6",
     "prettier": "3.8.1",
+    "prettier-plugin-apex": "2.2.6",
     "pwsh": "0.3.0"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,9 +9,9 @@
       "path": "./nebula-logger/core",
       "definitionFile": "./config/scratch-orgs/base-scratch-def.json",
       "scopeProfiles": true,
-      "versionNumber": "4.18.3.NEXT",
-      "versionName": "PrismJS Loading Improvements & Error Handling",
-      "versionDescription": "Fixed some issues with loading PrismJS from LoggerStaticResoures by switching to minified versions + added error handling with fallback display when PrismJS cannot be properly loaded",
+      "versionNumber": "4.18.4.NEXT",
+      "versionName": "New Logger Parameter Record OrganizationAllowlist",
+      "versionDescription": "Added a new LoggerParameter__mdt record, OrganizationAllowlist, to provide an optional way to control via CMDT if logging should be enabled in the current org",
       "postInstallUrl": "https://github.com/jongpie/NebulaLogger/wiki",
       "releaseNotesUrl": "https://github.com/jongpie/NebulaLogger/releases",
       "unpackagedMetadata": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -231,6 +231,7 @@
     "Nebula Logger - Core@4.18.1-new-declarative-configuration-for-ignoring-apex-classes-in-stack-traces": "04tg70000008GVpAAM",
     "Nebula Logger - Core@4.18.2-new-field-logentry__c.wasloggedbycurrentuser__c": "04tg70000008YZBAA2",
     "Nebula Logger - Core@4.18.3-prismjs-loading-improvements-&-error-handling": "04tg70000009GaDAAU",
+    "Nebula Logger - Core@4.18.4-new-logger-parameter-record-organizationallowlist": "04tg7000000BNcPAAW",
     "Nebula Logger - Core Plugin - Async Failure Additions": "0Ho5Y000000blO4SAI",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.0": "04t5Y0000015lhiQAA",
     "Nebula Logger - Core Plugin - Async Failure Additions@1.0.1": "04t5Y0000015lhsQAA",


### PR DESCRIPTION
Added a new `LoggerParameter__mdt` record, `OrganizationAllowlist`, to provide an optional way to control via custom metadata (CMDT) if logging should be enabled in the current org. This is useful in situations where sandboxes are created from a prod org (which clones prod's CMDT records), and orgs don't want logging to be enabled by default in new sandboxes.

There are 3 ways this record can be configured:

1.  **Out of the box (when `OrganizationAllowlist` is blank/empty)**: the `OrganizationAllowlist` record has no impact on logging / logging is fully controlled by `LoggerSettings__c` records.
2. **When the current org's 15 or 18 character ID is present**: logging is enabled based on `LoggerSettings__c.IsEnabled__c`.
3. **When the current org's ID is _NOT_ present**: logging is disabled for the whole org, regardless of what's been configured in `LoggerSettings__c.IsEnabled__c`.

> [!IMPORTANT]  
> TODO: right now, this means that if the `OrganizationAllowlist` has org IDs populated & the CMDT records are deployed to a scratch org, then logging will be disabled in the scratch org... and since scratch orgs are temporary environments, it's not feasible to add their org IDs. There may need to be slightly different behavior for scratch orgs - but determining that the current environment is a scratch org requires using a SOQL query on `Organization` 🤔 